### PR TITLE
Rogue Trader - V1.0.1 - Turf/Decl/RND Code

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/legacy_parts.dm
+++ b/code/game/machinery/_machines_base/stock_parts/legacy_parts.dm
@@ -189,3 +189,199 @@
 	desc = "A large piece of equipment used to open a window into the subspace dimension."
 	origin_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 5, TECH_BLUESPACE = 3)
 	matter = list(MATERIAL_STEEL = 50)
+
+// ARCHEOTECH LOOT
+// ARCHEOTECH LOOT
+
+
+// Material + Engineering, works on armor primarily and some unique weapons
+/obj/item/rnd/eng3
+	name = "xenos alloy"
+	desc = "A xenos alloy forged by means unknown to the AdMech. The Mechanicus will want to study it."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "strange"
+	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 4)
+	sales_price = 6
+
+/obj/item/rnd/eng5
+	name = "admech memory chip"
+	desc = "Contains the partially corrupted memory banks of a deceased tech priest. The Mechanicus will want to study it."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "romos1"
+	origin_tech = list(TECH_MATERIAL = 6, TECH_ENGINEERING = 6)
+	sales_price = 10
+
+/obj/item/rnd/eng8
+	name = "factorum schematics"
+	desc = "Forgotten schematics produced by the AdMech from a now forgotten world. The Mechanicus will want to study it."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "datadisk0"
+	origin_tech = list(TECH_MATERIAL = 8, TECH_ENGINEERING = 8)
+	sales_price = 40
+
+/obj/item/rnd/eng10
+	name = "STC Fragment"
+	desc = "An STC Fragment with designs for manufactorum machinery... The Mechanicus will want to study it."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "datadisk6"
+	origin_tech = list(TECH_MATERIAL = 10, TECH_ENGINEERING = 10)
+	sales_price = 0
+
+// Power + Phoron Mixture of weaponry, vanilla SS13.
+/obj/item/rnd/power3
+	name = "strange chemical canister"
+	desc = "A xenos forged canister filled with a strange chemical fuel mixture. The Mechanicus will want to study it."
+	icon = 'icons/obj/power.dmi'
+	icon_state = "plasmaflask"
+	origin_tech = list(TECH_POWER = 4, TECH_PHORON = 4)
+	sales_price = 8
+
+/obj/item/rnd/power5
+	name = "ancient plasma coil"
+	desc = "The remains of a dismantled seolite plasma gun, the plasma coil is still functional... The Mechanicus will want to study it."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "unknown1"
+	origin_tech = list(TECH_POWER = 6, TECH_PHORON = 6)
+	sales_price = 25
+
+/obj/item/rnd/power8
+	name = "plasma drive schematics"
+	desc = "Forgotten starship plasma drive schematics produced by the AdMech from a now forgotten world... The Mechanicus will want to study it."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "datadisk2"
+	origin_tech = list(TECH_POWER = 8, TECH_PHORON = 8)
+	sales_price = 45
+
+/obj/item/rnd/power10
+	name = "STC Fragment"
+	desc = "An STC Fragment with designs for an ancient voidship reactor... The Mechanicus will want to study it."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "datadisk6"
+	origin_tech = list(TECH_POWER = 10, TECH_PHORON = 10)
+	sales_price = 0
+// Bio + Bluespace For bags/misc items, mainly vanilla SS13 Content
+
+/obj/item/rnd/biospace3
+	name = "glowing rock"
+	desc = "A warpstone... it hums with vibrant energy. The Mechanicus will want to study it."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "plant1"
+	origin_tech = list(TECH_BIO = 4, TECH_BLUESPACE = 4)
+	sales_price = 10
+
+/obj/item/rnd/biospace5
+	name = "xenos green vial"
+	desc = "A vial of strange liquid used for seolite laboratory equipment... The Mechanicus will want to study it."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "box"
+	origin_tech = list(TECH_BIO = 6, TECH_BLUESPACE = 6)
+	sales_price = 20
+
+/obj/item/rnd/biospace8
+	name = "xenos autodoc schematics"
+	desc = "Schematics to construct a medical autodoc used by the seolite... The Mechanicus will want to study it."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "datadisk4"
+	origin_tech = list(TECH_BIO = 8, TECH_BLUESPACE = 8)
+	sales_price = 50
+
+/obj/item/rnd/biospace10
+	name = "Biologis Data Disk"
+	desc = "An old data disk with designs from the famous Biologis Valentin Drusher... The Mechanicus will want to study it."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "datadisk6"
+	origin_tech = list(TECH_BIO = 10, TECH_BLUESPACE = 10)
+	sales_price = 0
+
+/obj/item/rnd/biospacesample1
+	name = "tissue sample"
+	desc = "A vial of strange liquid storing organic material."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "box"
+	origin_tech = list(TECH_BIO = 4, TECH_PHORON = 2, TECH_ILLEGAL = 2)
+	sales_price = 10
+
+/obj/item/rnd/biospacesample2
+	name = "rare tissue sample"
+	desc = "A vial of strange liquid storing organic material."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "box"
+	origin_tech = list(TECH_BIO = 5, TECH_PHORON = 4, TECH_ILLEGAL = 3)
+	sales_price = 10
+
+/obj/item/rnd/biospacesample3
+	name = "exotic tissue sample"
+	desc = "A vial of strange liquid storing organic material."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "box"
+	origin_tech = list(TECH_BIO = 8, TECH_PHORON = 7, TECH_ILLEGAL = 6)
+	sales_price = 10
+
+
+// Combat + Magnet, Works on Weapons primarily, armor as well. (combat needed for armor)
+
+/obj/item/rnd/combat3
+	name = "seolite firing mechanism"
+	desc = "A seolite firing mechanism used in slug firing projectile weapons. The Mechanicus will want to study it."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "anodev"
+	origin_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 4)
+	sales_price = 6
+
+/obj/item/rnd/combat5
+	name = "archeotech weapon fragment"
+	desc = "The remains of an unknown weapon from the dark age of technology. The Mechanicus will want to study it."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "egun5"
+	origin_tech = list(TECH_COMBAT = 7, TECH_MAGNET = 6)
+	sales_price = 15
+
+/obj/item/rnd/combat8
+	name = "archeotech weapon design"
+	desc = "A weapon design for a forgotten archeotech weapon. The Mechanicus will want to study it."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "datadisk6"
+	origin_tech = list(TECH_COMBAT = 9, TECH_MAGNET = 8)
+	sales_price = 50
+
+/obj/item/rnd/combat10
+	name = "STC Fragment"
+	desc = "An STC Fragment with designs for an exteriminatus weapon platform from the dark age of technology... The Mechanicus will want to study it."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "datadisk5"
+	origin_tech = list(TECH_COMBAT = 10, TECH_MAGNET = 10)
+	sales_price = 0
+
+// Illegal + Data (works on very unique things, they border heretical and should be assumed to be bordering technoheresy.) Data is vanilla content from what I can see.
+
+/obj/item/rnd/illegal3
+	name = "xenos puzzle box"
+	desc = "A silly little puzzle box! The Mechanicus will want to study it."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "ano10"
+	origin_tech = list(TECH_DATA = 4, TECH_ILLEGAL = 4)
+	sales_price = 5
+
+/obj/item/rnd/illegal5
+	name = "xenos research notes"
+	desc = "The remains of an unknown weapon from the dark age of technology. The Mechanicus will want to study it."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "measuring"
+	origin_tech = list(TECH_DATA = 6, TECH_ILLEGAL = 6)
+	sales_price = 10
+
+/obj/item/rnd/illegal8
+	name = "strange object"
+	desc = "An AI core from a destroyed Man Of Iron. The Mechanicus will want to study it."
+	icon = 'icons/obj/xenoarchaeology_finds.dmi'
+	icon_state = "unknown2"
+	origin_tech = list(TECH_DATA = 8, TECH_ILLEGAL = 8)
+	sales_price = 30
+
+/obj/item/rnd/illegal10
+	name = "Glowing STC Fragment"
+	desc = "An STC Fragment with designs for an artifact... The Mechanicus will want to study it."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "datadisk0"
+	origin_tech = list(TECH_DATA = 10, TECH_ILLEGAL = 10)
+	sales_price = 60

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -69,9 +69,466 @@
 		return A
 	A.set_color(pickweight(color_choices()))
 	return A
+/// WARHAMMER 40k SPAWNERS ////
+
+/* // DO NOT ENABLE
+/// LOOT SPAWNERS HERE
+/// BEGINNING OF LOOT SPAWNERS
+/// Be careful. Make sure to search up all items related to what you are spawning and make it possible for it's ammo to spawn as well.
+
+/obj/random/loot/guardgear
+	name = "Armor accessories"
+	desc = "This is a loot spawner that spawns combat accessories."
+	icon_state = "armoraccessory"
+
+/obj/random/loot/guardgear/spawn_choices()
+	return list(/obj/item/clothing/accessory/holster/waist = 6,
+				/obj/item/clothing/accessory/holster/hip = 6,
+				/obj/item/clothing/accessory/storage/torso/armor = 4,
+				/obj/item/clothing/accessory/storage/webbing = 12,
+				/obj/item/clothing/accessory/legguards/ballistic = 6,
+				/obj/item/clothing/accessory/legguards/ablative = 4,
+				/obj/item/clothing/accessory/armguards/ablative = 4,
+				/obj/item/clothing/accessory/armguards/ballistic = 6,
+				/obj/item/clothing/accessory/armguards/riot = 6,
+				/obj/item/clothing/glasses/cadiangoggles/elite = 2,
+				/obj/item/clothing/head/helmet/guardhelmet/carapace = 1,
+				/obj/item/storage/backpack/satchel/heavy = 1,
+				/obj/item/clothing/accessory/legguards/riot = 6)
+
+/obj/random/loot/lightmelee
+	name = "Light Melee"
+	desc = "This is a weapon loot spawner with a high chance of spawning common light melee weapons."
+	icon_state = "lightmelee"
+
+/obj/random/loot/lightmelee/spawn_choices()
+	return list(/obj/item/melee/sword/combat_knife = 2,
+				/obj/item/melee/telebaton = 1,
+				/obj/item/melee/sword/combat_knife/rare = 1,
+				/obj/item/melee/sword/combat_knife/glaive = 1,
+				/obj/item/melee/sword/combat_knife/bowie = 1,
+				/obj/item/melee/sword/machete = 1)
+
+/obj/random/loot/heavymelee
+	name = "Heavy Melee"
+	desc = "This is a weapon loot spawner with a high chance of spawning common heavy melee weapons."
+	icon_state = "heavymelee"
+
+/obj/random/loot/heavymelee/spawn_choices()
+	return list(/obj/item/melee/trench_axe = 13,
+				/obj/item/melee/classic_baton/trench_club = 8,
+				/obj/item/melee/trench_axe/bardiche = 6,
+				/obj/item/melee/sword/broadsword = 6,
+				/obj/item/melee/trench_axe/glaive = 6,
+				/obj/item/melee/trench_axe/bardiche = 6,
+				/obj/item/melee/trench_axe/lance = 4,
+				/obj/item/melee/trench_axe/bspear = 6,
+				/obj/item/shield/riot = 2,
+				/obj/item/shield/riot/metal = 4,
+				/obj/item/melee/sword/sabre = 4)
+
+
+/obj/random/loot/tech1
+	name = "LOW TECH SPAWNER"
+	desc = "spawns low tech"
+	icon_state = "armoraccessory"
+
+/obj/random/loot/tech1/spawn_choices()
+	return list(/obj/item/rnd/eng3 = 12,
+				/obj/item/rnd/eng5 = 8,
+				/obj/item/rnd/eng8 = 4,
+				/obj/item/rnd/combat3 = 14,
+				/obj/item/rnd/combat5 = 10,
+				/obj/item/rnd/combat8 = 5,
+				/obj/item/reagent_containers/food/snacks/poo = 6,
+				/obj/item/rnd/power3 = 10,
+				/obj/item/rnd/power5 = 6,
+				/obj/item/rnd/power8 = 3,
+				/obj/item/reagent_containers/food/snacks/poo = 6,
+				/obj/item/rnd/biospace3 = 10,
+				/obj/item/rnd/biospace5 = 6,
+				/obj/item/rnd/biospace8 = 3,
+				/obj/item/reagent_containers/food/snacks/poo = 6,
+				/obj/item/rnd/eng10 = 1)
+
+/obj/random/loot/tech2
+	name = "HIGH TECH SPAWNER"
+	desc = "spawn high tech"
+	icon_state = "armoraccessory"
+
+/obj/random/loot/tech2/spawn_choices()
+	return list(/obj/item/rnd/eng3 = 12,
+				/obj/item/rnd/eng5 = 8,
+				/obj/item/rnd/eng8 = 5,
+				/obj/item/rnd/combat3 = 14,
+				/obj/item/rnd/combat5 = 10,
+				/obj/item/rnd/combat8 = 7,
+				/obj/item/rnd/combat10 = 2,
+				/obj/item/rnd/power3 = 10,
+				/obj/item/rnd/power5 = 6,
+				/obj/item/rnd/power8 = 3,
+				/obj/item/rnd/power10 = 1,
+				/obj/item/rnd/biospace3 = 10,
+				/obj/item/rnd/biospace5 = 6,
+				/obj/item/rnd/biospace8 = 3,
+				/obj/item/rnd/biospace10 = 1,
+				/obj/item/rnd/illegal3 = 12,
+				/obj/item/rnd/illegal5 = 8,
+				/obj/item/rnd/illegal8 = 4,
+				/obj/item/rnd/illegal10 = 2,
+				/obj/item/rnd/eng10 = 1)
+
+/obj/random/loot/meleespawner
+	name = "Random Melee Spawner"
+	desc = "Spawns light and heavy melee.."
+	icon_state = "heavymelee"
+
+/obj/random/loot/meleespawner/spawn_choices()
+	return list(/obj/item/melee/sword/combat_knife = 1,
+				/obj/item/melee/sword/combat_knife/rare = 2,
+				/obj/item/melee/sword/combat_knife/bowie = 3,
+				/obj/item/melee/sword/combat_knife/glaive = 1,
+				/obj/item/melee/trench_axe = 13,
+				/obj/item/melee/classic_baton/trench_club = 5,
+				/obj/item/melee/telebaton = 3,
+				/obj/item/melee/trench_axe/glaive = 3,
+				/obj/item/melee/trench_axe/glaive/adamantine = 1,
+				/obj/item/melee/sword/machete/chopper/heavy = 2,
+				/obj/item/melee/sword/machete/chopper/heavy/adamantine = 1,
+				/obj/item/melee/trench_axe/bardiche = 3,
+				/obj/item/melee/trench_axe/lance = 2,
+				/obj/item/melee/trench_axe/lance/adamantine = 1,
+				/obj/item/melee/trench_axe/bspear = 6,
+				/obj/item/melee/sword/cutro = 10,
+				/obj/item/melee/sword/cutro/adamantine = 1,
+				/obj/item/melee/sword/broadsword = 6,
+				/obj/item/melee/sword/broadsword/adamantine = 1,
+				/obj/item/melee/sword/machete = 6,
+				/obj/item/melee/sword/machete/chopper = 5,
+				/obj/item/toy/katana = 6,
+				/obj/item/toy/katana/strong = 2,
+				/obj/item/shield/riot = 2,
+				/obj/item/melee/chain/inqcs = 1,
+				/obj/item/melee/chain/pcsword/eviscerator = 1,
+				/obj/item/melee/sword/sabre = 4)
+
+/obj/random/loot/sidearmammo // old no use
+	name = "Sidearm Ammo"
+	desc = "This is an ammo spawner that spawns ammo for sidearms" // sidearms are pistols and pdws (smgs)
+	icon_state = "sidearmammo"
+
+/obj/random/loot/sidearmammo/spawn_choices()
+	return list(/obj/item/ammo_magazine/c50 = 2,
+				/obj/item/ammo_magazine/a357 = 4,
+				/obj/item/ammo_magazine/c38 = 1,
+				/obj/item/ammo_magazine/c44 = 3,
+				/obj/item/cell/lasgun = 4,
+				/obj/item/cell/lasgun/small = 2,
+				/obj/item/ammo_magazine/mc45mm = 6,
+				/obj/item/ammo_box/shotgun = 1,
+				/obj/item/ammo_magazine/bolt_pistol_magazine = 1)
+
+/obj/random/loot/sidearms
+	name = "Sidearms"
+	desc = "This is a weapon loot spawner with a high chance of spawning common sidearms"
+	icon_state = "sidearm"
+
+/obj/random/loot/sidearms/spawn_choices()
+	return list(
+				/obj/item/gun/energy/las/laspistol = 4,
+				/obj/item/gun/energy/las/laspistol/shitty = 5,
+				/obj/item/gun/energy/las/laspistol/accatran = 1,
+				/obj/item/gun/energy/las/laspistol/militarum/lucius = 2,
+				/obj/item/gun/energy/las/laspistol/militarum = 2,
+				/obj/item/gun/projectile/talon/renegade = 1,
+				/obj/item/gun/projectile/revolver/mateba = 1,
+				/obj/item/gun/projectile/revolver/villiers = 1,
+				/obj/item/gun/projectile/necros = 1,
+				/obj/item/gun/projectile/slugrevolver = 1,
+				/obj/item/gun/projectile/pistol/pewter = 3,
+				/obj/item/gun/projectile/pistol/kieji = 3,
+				/obj/item/gun/projectile/pistol/kieji/snub = 3,
+				/obj/item/gun/projectile/pistol/villiers = 3,
+				/obj/item/gun/projectile/bolter_pistol = 1)
+
+/obj/random/loot/randomammo1
+	name = "Random Ammo"
+	desc = "This is a random ammo spawner of projectile weaponry."
+	icon_state = "randomammo"
+
+/obj/random/loot/randomammo1/spawn_choices()
+	return list(
+		/obj/item/ammo_magazine/c556 = 6,
+		/obj/item/ammo_box/shotgun = 4,
+		/obj/item/ammo_magazine/smgmc9mm = 2,
+		/obj/item/ammo_box/shotgun/slug = 3,
+		/obj/item/storage/box/sniperammo = 1,
+		/obj/item/ammo_magazine/handful/brifle_handful = 3,
+		/obj/item/ammo_magazine/handful/brifle_handful/ms = 2,
+		/obj/item/ammo_magazine/handful/brifle_handful/ap = 1,
+		/obj/item/ammo_magazine/a762 = 3,
+		/obj/item/ammo_magazine/box/a556/mg08 = 3
+		)
+
+/obj/random/loot/randomammosidearm
+	name = "Random Sidearm Ammo"
+	desc = "This is a random ammo spawner of projectile weaponry."
+	icon_state = "randomammo"
+
+/obj/random/loot/randomammosidearm/spawn_choices()
+	return list(
+		/obj/item/ammo_magazine/mc45mm = 9,
+		/obj/item/ammo_magazine/a357 = 6,
+		/obj/item/ammo_magazine/handful/a50 = 3,
+		/obj/item/ammo_magazine/bolt_pistol_magazine = 1,
+		/obj/item/cell/lasgun/hotshot = 1,
+		/obj/item/cell/lasgun = 3,
+		/obj/item/ammo_magazine/c44 = 5
+		)
+
+/obj/random/loot/randomlasammo
+	name = "Random Lasgun Ammo"
+	desc = "This is a random ammo spawner for energy weapons."
+	icon_state = "randomammo"
+
+/obj/random/loot/randomlasammo/spawn_choices()
+	return list(
+		/obj/item/cell/lasgun/small = 10,
+		/obj/item/cell/lasgun/hotshot = 3,
+		/obj/item/cell/plasma = 1,
+		/obj/item/cell/lasgun = 20
+		)
+
+
+/obj/effect/landmark/poopie/New() // Difficulty: Medium. Guard level threat.
+	if (prob(20))
+		new /obj/item/reagent_containers/food/snacks/poo(src.loc)
+		new /obj/item/reagent_containers/food/snacks/poo(src.loc)
+		new /obj/item/reagent_containers/food/snacks/poo(src.loc)
+	else
+		new /obj/item/reagent_containers/food/snacks/vegetablesoup(src.loc)
+	delete_me = 1
+
+/obj/random/loot/badweapon
+	name = "Bad Weapon Spawner 1" // This spawner creates projectile weapons
+	desc = "This is a weapon loot spawner that spawns mostly low quality weapons."
+	icon_state = "badranged"
+
+/obj/random/loot/badweapon/spawn_choices()
+	return list(
+		/obj/item/gun/projectile/shotgun/pump/boltaction = 4,
+		/obj/item/gun/projectile/shotgun/pump/boltaction/sharpshooter = 2,
+		/obj/item/gun/projectile/shotgun/pump/boltaction/shitty/tinkered = 2,
+		/obj/item/gun/projectile/shotgun/pump/boltaction/shitty/leverchester = 2,
+		/obj/item/gun/projectile/shotgun/pump/boltaction/shitty/glory = 1,
+		/obj/item/gun/projectile/shotgun/pump/voxlegis = 4,
+		/obj/item/gun/projectile/shotgun/pump/shitty/sawn = 2,
+		/obj/item/gun/projectile/shotgun/pump/shitty/magrave = 2,
+		/obj/item/gun/projectile/automatic/m22/warmonger/m14/battlerifle = 1,
+		/obj/item/gun/projectile/automatic/m22/combatrifle = 2,
+		/obj/item/gun/projectile/automatic/heavystubber = 1,
+		/obj/item/gun/projectile/automatic/heavystubber/villiers = 1,
+		/obj/item/gun/projectile/automatic/machinepistol = 4,
+		/obj/item/gun/projectile/automatic/machinepistol/a80 = 3,
+		/obj/item/gun/projectile/automatic/autogrim = 2,
+		/obj/item/gun/projectile/automatic/autogrim/krieg = 1,
+		/obj/item/gun/projectile/automatic/agripinaaii = 1,
+		/obj/item/gun/projectile/automatic/messina = 1,
+		/obj/item/gun/projectile/thrower = 1,
+		/obj/item/storage/backpack/satchel/heavy = 1
+	)
+
+
+/obj/random/loot/badweaponlas
+	name = "Bad Weapon Spawner Las" // This spawner creates las weapons
+	desc = "This is a weapon loot spawner that spawns mostly low quality weapons."
+	icon_state = "badranged"
+
+/obj/random/loot/badweaponlas/spawn_choices()
+	return list(
+		/obj/item/gun/energy/las/laspistol/shitty = 9,
+		/obj/item/gun/energy/las/lasgun/shitty = 7,
+		/obj/item/gun/energy/las/laspistol = 5,
+		/obj/item/gun/energy/las/laspistol/militarum = 3,
+		/obj/item/gun/energy/las/laspistol/militarum/lucius = 2,
+		/obj/item/gun/energy/las/lasgun/lucius = 3,
+		/obj/item/gun/energy/las/lasgun/catachan = 1,
+		/obj/item/gun/energy/las/lasgun/accatran = 1,
+		/obj/item/gun/energy/las/lasgun = 4
+	)
+
+/obj/random/loot/goodweapon
+	name = "Good Weapon Spawner" // plasma, bolter, fancy lasguns
+	desc = "This is a weapon loot spawner that spawns mostly high quality weapons."
+	icon_state = "goodranged"
+
+/obj/random/loot/goodweapon/spawn_choices()
+	return list(
+				/obj/item/gun/projectile/lockebolter = 1,
+				/obj/item/gun/projectile/bolter_pistol/inquis = 1,
+				/obj/item/gun/energy/pulse/plasma/rifle = 1,
+				/obj/item/gun/energy/pulse/plasma/pistol = 3,
+				/obj/item/gun/energy/las/hotshot = 2,
+				/obj/item/gun/energy/melta/handheld = 1,
+				/obj/item/gun/energy/las/lasgun/longlas = 2,
+				/obj/item/gun/energy/las/lasgun/longlas/krieg = 2,
+				/obj/item/gun/projectile/heavysniper = 2
+				)
+
+/obj/random/loot/randomarmor
+	name = "Random Armor"
+	desc = "This is a loot spawner that spawns pilgrim and pilgrim+ level armor"
+	icon_state = "randomarmor"
+
+/obj/random/loot/randomarmor/spawn_choices()
+	return list(/obj/item/clothing/suit/armor/militia = 1,
+				/obj/item/clothing/suit/cloak = 1,
+				/obj/item/clothing/suit/armor/brigandine = 1,
+//				/obj/item/clothing/suit/armor/slaverobe = 1,
+				/obj/item/clothing/suit/armor/templar = 1,
+				/obj/item/clothing/suit/armor/hauberk = 1,
+				/obj/item/clothing/suit/armor/trinet = 1,
+				/obj/item/clothing/suit/armor/heavyflaksuit = 1,
+				/obj/item/clothing/suit/armor/breastplate = 1,
+				/obj/item/clothing/suit/armor/sniper = 1,
+				/obj/item/clothing/suit/armor/cuirass = 1,
+				/obj/item/clothing/suit/armor/salvage = 1,
+				/obj/item/clothing/suit/armor/guardsman/mercenary = 1,
+				/obj/item/clothing/suit/armor/slanclothing/maleslan = 1,
+//				/obj/item/clothing/suit/armor/necromundaflak1 = 1,
+//				/obj/item/clothing/suit/armor/necromundacarapace1 = 1,
+				/obj/item/clothing/suit/armor/ranger3 = 1,
+				/obj/item/clothing/suit/armor/ranger2 = 1,
+				/obj/item/clothing/head/helmet/salvage = 1,
+				/obj/item/clothing/head/helmet/mining = 1,
+				/obj/item/clothing/suit/armor/heavyflaksuit = 1,
+				/obj/item/clothing/suit/armor/heavyduster = 1,
+//				/obj/item/clothing/suit/armor/goliath2 = 1,
+//				/obj/item/clothing/suit/armor/flak1 = 1,
+//				/obj/item/clothing/suit/armor/flak2 = 1,
+				/obj/item/clothing/suit/armor/scum2 = 1,
+				/obj/item/clothing/suit/armor/leather = 1,
+				/obj/item/clothing/suit/armor/hjacket = 1,
+				/obj/item/clothing/suit/armor/hjacket2 = 1,
+				/obj/item/clothing/suit/armor/slumcoat = 1,
+				/obj/item/clothing/suit/armor/towntrench = 1,
+				/obj/item/clothing/suit/armor/tduster = 1,
+				/obj/item/clothing/suit/armor/bonearmor = 1,
+				/obj/item/clothing/suit/armor/carapaceduster = 1,
+				/obj/item/clothing/suit/armor/armoredtrench = 1)
+
+/obj/random/loot/randomsupply
+	name = "Random Supply"
+	desc = "This is a loot spawner that spawns supplies like medicine, food and materials."
+	icon_state = "randomsupply"
+
+/obj/random/loot/randomsupply/spawn_choices()
+	return list(/obj/item/storage/box/ifak = 4,
+				/obj/item/storage/firstaid/adv = 1,
+				/obj/item/storage/firstaid/surgery = 1,
+				/obj/item/storage/belt/medical/full = 1,
+				/obj/item/reagent_containers/hypospray/autoinjector/revive = 4,
+				/obj/item/stack/barbwire = 3,
+				/obj/random/canned_food = 1,
+				/obj/item/flame/lighter/zippo = 1,
+				/obj/item/device/flashlight/lantern = 1,
+				/obj/item/storage/pill_bottle/happy = 1,
+				/obj/item/stack/material/silver/ten = 1,
+				/obj/item/stack/material/glass/fifty = 1,
+				/obj/item/clothing/under/rank/victorian = 1,
+				/obj/item/stack/material/steel/fifty = 2)
+
+/obj/random/loot/randomitemcaves // make this a grenade spawn?
+	name = "Random Item Caves"
+	desc = "This is a loot spawner that spawns random items."
+	icon_state = "randompilgrim"
+
+/obj/random/loot/randomitemcaves/spawn_choices()
+	return list(/obj/item/shovel = 3,
+				/obj/item/clothing/glasses/night = 3,
+				/obj/item/pickaxe = 3,
+				/obj/item/storage/firstaid/combat = 2,
+				/obj/item/storage/firstaid/surgery = 2,
+				/obj/item/reagent_containers/hypospray/autoinjector/revive = 6,
+				/obj/item/clothing/accessory/holster/waist = 6,
+				/obj/item/clothing/accessory/storage/webbing = 8,
+				/obj/item/stack/thrones3/ten = 4,
+				/obj/item/stack/thrones3/twenty = 2,
+				/obj/item/stack/thrones2/ten = 1,
+				/obj/item/grenade/frag/high_yield/homemade = 1,
+				/obj/item/grenade/frag = 1,
+				/obj/item/storage/backpack/satchel/heavy = 1,
+				/obj/item/clothing/under/rank/victorian = 1,
+				/obj/item/grenade/frag/high_yield/krak = 1)
+
+/obj/random/loot/randomitemtown
+	name = "Random Item Pilgrim"
+	desc = "This is a loot spawner that spawns random items that will be useful for any pilgrim."
+	icon_state = "randompilgrim"
+
+/obj/random/loot/randomitemtown/spawn_choices()
+	return list(/obj/item/device/binoculars = 2,
+				/obj/item/storage/box/ifak = 5,
+				/obj/item/storage/firstaid/adv = 1,
+				/obj/item/stack/thrones3/ten = 1,
+				/obj/item/stack/thrones3/twenty = 1,
+				/obj/item/clothing/suit/armor/militia = 2,
+				/obj/item/melee/sword/combat_knife = 1,
+				/obj/item/stack/thrones2/ten = 2,
+				/obj/item/storage/backpack/satchel/heavy = 1,
+				/obj/item/clothing/accessory/holster/waist = 3,
+				/obj/item/clothing/accessory/storage/webbing = 5,
+				/obj/item/storage/belt/utility/full = 2,
+				/obj/item/clothing/accessory/legguards = 2,
+				/obj/item/clothing/accessory/armguards/ballistic = 2,
+				/obj/item/clothing/under/rank/victorian = 1,
+				/obj/item/grenade/frag/high_yield/homemade = 1)
 
 
 
+/obj/random/exploration
+	name = "random exploration loot"
+	desc = "Low grade loot that is often around 50-100 thrones worth."
+	icon = 'icons/map_project/fluff_items.dmi'
+	icon_state = "giftpaper"
+
+/obj/random/exploration/spawn_choices()
+	return list(/obj/item/exploration_loot = 3,
+				/obj/item/exploration_loot/cloth_roll = 4,
+				/obj/item/exploration_loot/sealed_enve = 2,
+				/obj/item/exploration_loot/chem_package = 2,
+			    /obj/item/exploration_loot/package = 3,
+				/obj/item/exploration_loot/case = 2,
+				/obj/item/exploration_loot/odd_book = 2,
+				/obj/item/exploration_loot/guard_diary = 1,
+				/obj/item/exploration_loot/shiny_gem = 1,
+				/obj/item/exploration_loot/map = 1,
+                /obj/item/exploration_loot/spicecase = 1,
+                /obj/item/exploration_loot/lootbox = 1,
+                /obj/item/exploration_loot/imperial_book = 1)
+
+/obj/random/exploration/high
+	name = "random high quality exploration loot"
+	desc = "High grade loot that is often around 100-250 thrones worth."
+	icon = 'icons/map_project/fluff_items.dmi'
+	icon_state = "zrbite"
+
+/obj/random/exploration/high/spawn_choices()
+	return list(/obj/item/exploration_loot/map = 3,
+			    /obj/item/exploration_loot/drugs = 3,
+				/obj/item/exploration_loot/elerium = 1,
+				/obj/item/exploration_loot/guard_diary = 2,
+				/obj/item/exploration_loot/bm_file = 1,
+				/obj/item/exploration_loot/shiny_gem = 2,
+				/obj/item/exploration_loot/zrbite = 1,
+				/obj/item/exploration_loot/elerium = 1,
+				/obj/item/exploration_loot/elerium_ingot = 0.7,
+				/obj/item/exploration_loot/zrbite_ingot = 0.7,
+                /obj/item/exploration_loot/artiaxe = 0.5,
+                /obj/item/exploration_loot/goldbar = 0.5)
+*/
+
+/////////////////////
 /obj/random/tool
 	name = "random tool"
 	desc = "This is a random tool."

--- a/code/game/turfs/dungeon_code.dm
+++ b/code/game/turfs/dungeon_code.dm
@@ -1,0 +1,900 @@
+
+
+/*
+
+This file contains most of the code for the dungeons to work, structures, some items and mobs possibly - Graf
+
+*/
+
+/obj/structure/hivedecor/xenos
+	name = "xenos debris"
+	desc = "..."
+	icon = 'icons/map_project/port/comm_tower3.dmi'
+	icon_state = "resin_final"
+
+
+
+/obj/structure/hivedecor/vehicle
+	name = "Cargo-8"
+	desc = "An ancient cargo hauler of imperial design."
+	icon = 'icons/map_project/port/van.dmi'
+	icon_state = "van_base"
+
+/obj/structure/closet/crate/xenos/cargo8
+	name = "Cargo-8"
+	desc = "An ancient cargo hauler of imperial design."
+	icon = 'icons/map_project/port/van.dmi'
+	icon_state = "vancrate"
+	icon_opened = "vancrateopen"
+	icon_closed = "vancrate"
+
+/obj/structure/hivedecor/vehicle/tau
+	name = "Destroyed Tau APC"
+	desc = "A destroyed armored personnel carrier of Tau origin."
+	icon = 'icons/map_project/port/apc.dmi'
+	icon_state = "apc"
+
+/obj/structure/hivedecor/xenos/broadcaster
+	name = "xenos broadcaster"
+	desc = "A massive vox communication tower of xenos origin."
+	icon = 'icons/map_project/port/comm_tower3.dmi'
+	icon_state = "static1"
+
+/obj/structure/hivedecor/xenos/broadcasterbroken
+	name = "xenos broadcaster"
+	desc = "A massive vox communication tower of xenos origin."
+	icon = 'icons/map_project/port/comm_tower3.dmi'
+	icon_state = "static1_broken"
+
+/obj/structure/hivedecor/xenos/commtower
+	name = "xenos comms relay"
+	desc = "A massive vox communication tower of xenos origin."
+	icon = 'icons/map_project/port/comm_tower2.dmi'
+	icon_state = "comm_tower_off"
+
+/obj/structure/hivedecor/xenos/commtower/powered
+	icon_state = "comm_tower"
+
+/obj/structure/hivedecor/xenos/commtower/damaged
+	icon_state = "comm_tower_broken"
+
+/obj/structure/hivedecor/xenos/commtower/old
+	icon_state = "construct_9_1"
+
+/obj/structure/hivedecor/xenos/coolanttank
+	name = "coolant tank"
+	desc = "A bubbling container of coolant fluid."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "coolanttank"
+
+// add in crystal crate, crystals -- etc for the cave systems.
+
+/obj/structure/hivedecor/xenos/siphon
+	name = "siphon"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "psiphon:0"
+
+/obj/structure/hivedecor/xenos/scrubber
+	name = "scrubber"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "pscrubber:0"
+
+/obj/structure/hivedecor/xenos/autolathe
+	name = "xenos autolathe"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "autolathe_t"
+
+/obj/structure/hivedecor/xenos/vat
+	name = "xenos machine"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "vat"
+
+/obj/structure/hivedecor/xenos/processor
+	name = "xenos machine"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "processor_off"
+
+/obj/structure/hivedecor/xenos/processor/substrate
+	icon_state = "substrate_off"
+
+/obj/structure/hivedecor/xenos/processor/cpu
+	icon_state = "CPU"
+
+/obj/structure/hivedecor/xenos/processor/int
+	icon_state = "int_processor_off"
+
+/obj/structure/hivedecor/xenos/processor/console
+	icon_state = "console"
+
+/obj/structure/hivedecor/xenos/processor/time
+	icon_state = "time"
+
+/obj/structure/hivedecor/xenos/processor/toggle
+	icon_state = "toggle"
+
+/obj/structure/hivedecor/xenos/processor/cracker
+	icon_state = "cracker"
+
+/obj/structure/hivedecor/floodlight
+	name = "floodlight" // does not create light. use with an invisible light source
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "flood01"
+
+/obj/structure/hivedecor/xenos/terminal
+	name = "xenos terminal"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "frame_med"
+
+/obj/structure/hivedecor/xenos/powergen
+	name = "xenos generator"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "generator"
+
+/obj/structure/hivedecor/xenos/powergen/on
+	name = "xenos generator"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "generator_on"
+
+/obj/structure/hivedecor/xenos/artifact
+	name = "xenos artifact"
+	desc = "Death is not the end."
+	icon = 'icons/map_project/port/marker_giant.dmi'
+	icon_state = "marker_giant_active_anim"
+
+/obj/structure/hivedecor/xenos/artifact/teleporter
+	name = "xenos teleporter"
+	desc = "Death is not the end."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "pad"
+
+/obj/structure/hivedecor/xenos/artifact/teleporter/active
+	icon_state = "pad_active"
+
+/obj/structure/hivedecor/xenos/artifact/node
+	name = "xenos harvester"
+	desc = "..."
+	icon = 'icons/map_project/port/resources_64x64.dmi'
+	icon_state = "node_combined_xeno"
+
+/obj/structure/hivedecor/xenos/artifact/teslatower
+	name = "tesla coil"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "teslatower"
+
+/obj/structure/hivedecor/xenos/artifact/fuelpump
+	name = "rhizomatic pump"
+	desc = "..."
+	icon = 'icons/map_project/port/objective.dmi'
+	icon_state = "fuelpump"
+
+/obj/structure/hivedecor/xenos/artifact/node2
+	name = "xenos harvester"
+	desc = "..."
+	icon = 'icons/map_project/port/resources_64x64.dmi'
+	icon_state = "node_combined_marine"
+
+/obj/structure/hivedecor/xenos/artifact/node3
+	name = "xenos harvester"
+	desc = "..."
+	icon = 'icons/map_project/port/resources_64x64.dmi'
+	icon_state = "node_on"
+
+/obj/structure/hivedecor/xenos/artifact/megaweapon
+	name = "???"
+	desc = "..."
+	icon = 'icons/map_project/port/artillery.dmi'
+	icon_state = "1"
+
+/obj/structure/hivedecor/xenos/artifact/bluespacedrive
+	name = "???"
+	desc = "..."
+	icon = 'icons/map_project/port/bluespacedrive.dmi'
+	icon_state = "bsd_core"
+
+/obj/structure/hivedecor/xenos/artifact/bluespacedrive/broken
+	name = "???"
+	desc = "..."
+	icon_state = "bsd_core_broken"
+
+/obj/structure/hivedecor/xenos/artifact/bluespacedrive/core
+	name = "???"
+	desc = "..."
+	icon_state = "bsd_c_s"
+
+/obj/structure/hivedecor/xenos/artifact/supermatter
+	name = "???"
+	desc = "..."
+	icon = 'icons/map_project/port/supermatter.dmi'
+	icon_state = "supermatter_glow"
+
+/obj/structure/hivedecor/xenos/artifact/gateway // top part of gateway. starts off.
+	name = "???"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "offcenter"
+
+/obj/structure/hivedecor/xenos/artifact/gateway/on
+	name = "???"
+	desc = "..."
+	icon_state = "oncenter"
+
+/obj/structure/hivedecor/xenos/artifact/gateway/base
+	name = "???"
+	desc = "..."
+	icon_state = "on"
+
+/obj/structure/hivedecor/xenos/barrel
+	name = "chemical barrel"
+	desc = "..."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "barrel_blue"
+
+/obj/structure/hivedecor/xenos/barrel/green
+	icon_state = "barrel_green"
+
+/obj/structure/hivedecor/xenos/barrel/red
+	icon_state = "barrel_red"
+
+/obj/structure/hivedecor/xenos/barrel/yellow
+	icon_state = "barrel_yellow"
+
+/obj/structure/hivedecor/xenos/barrel/white
+	icon_state = "barrel_white"
+
+/obj/structure/hivedecor/xenos/barrelmany
+	name = "chemical barrel yard"
+	desc = "..."
+	icon = 'icons/map_project/port/barrel_yard.dmi'
+	icon_state = "pile"
+	density = 0
+
+// Racks, crates and tables
+/obj/structure/table/rack/xenos
+	name = "strange rack"
+	desc ="An organic xenos resin seemss to be growing from the metal."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "rack"
+
+/obj/structure/closet/crate/xenos
+	name = "secure crate"
+	desc = "A xenos secure crate."
+	icon = 'icons/map_project/port/objects.dmi'
+	icon_state = "secure_crate"
+	icon_opened = "secure_crate2"
+	icon_closed = "secure_crate"
+
+/obj/structure/closet/crate/xenos/chest
+	name = "secure chest"
+	desc = "A xenos secure chest."
+	icon_state = "chest"
+	icon_opened = "chest2"
+	icon_closed = "chest"
+
+/obj/structure/closet/crate/xenos/chest2
+	name = "secure chest"
+	desc = "A xenos secure chest."
+	icon_state = "chest_white"
+	icon_opened = "chest_white2"
+	icon_closed = "chest_white"
+
+/obj/structure/closet/crate/xenos/chest3
+	name = "secure chest"
+	desc = "A xenos secure chest."
+	icon_state = "crate_ds_blue1"
+	icon_opened = "crate_ds_blue1_open"
+	icon_closed = "crate_ds_blue1"
+
+/obj/structure/closet/crate/xenos/droppod
+	name = "xenos drop pod"
+	desc = "An ancient xenos drop pod."
+	icon = 'icons/map_project/port/droppod_32x64.dmi'
+	icon_state = "techpod_closed"
+	icon_opened = "techpod_open"
+	icon_closed = "techpod_closed"
+
+/obj/structure/closet/crate/secure/safe
+	name = "secure safe"
+	desc = "A secure safe."
+	icon = 'icons/map_project/port/structures.dmi'
+	icon_state = "safe"
+	icon_opened = "safe-open"
+	icon_closed = "safe"
+	anchored = 1
+
+/obj/structure/closet/crate/secure/floorsafe
+	name = "secure safe"
+	desc = "A secure safe."
+	icon = 'icons/map_project/port/structures.dmi'
+	icon_state = "floorsafe"
+	icon_opened = "floorsafe-open"
+	icon_closed = "floorsafe"
+	anchored = 1
+	density = 0
+
+// NECRON TOMB - An old mechanicus outpost that was manned by penal units and mechanicus priest studying a tomb, they've been out of contact for several months
+
+/turf/unsimulated/floor/necron_floor
+	icon = 'icons/map_project/tombs.dmi'
+	icon_state = "floor"
+
+/mob/living/simple_animal/hostile/necron
+	name = "Necron Warrior"
+	desc = "A souless automaton who's only wish is to see you dead now."
+	icon = 'icons/cadia-sprites/mob/necron.dmi'
+	icon_state = "necron"
+	icon_living = "necron"
+	icon_dead = "necron_dead"
+	icon_gib = "syndicate_gib"
+	speak_chance = 0
+	turns_per_move = 35
+	response_help = "pokes"
+	response_disarm = "shoves"
+	response_harm = "hits"
+	speed = 5 // Slower but deadilier
+	stop_automated_movement_when_pulled = 0
+	maxHealth = 550
+	health = 550
+	harm_intent_damage = 45
+	melee_damage_lower = 55
+	melee_damage_upper = 55
+	wander = 1
+	see_in_dark = 6
+	attacktext = "stabbed"
+	a_intent = I_HURT
+	environment_smash = 1
+	faction = "Necron"
+	status_flags = CANPUSH
+
+	ranged = 1
+	rapid = 0
+	projectilesound = 'sound/effects/meteorimpact.ogg'
+	projectiletype = /obj/item/projectile/necrongauss
+
+
+// I had to make a new projectile since the gauss one instantly kills players so here it is.
+
+/obj/item/projectile/necrongauss
+	name = "Gauss"
+	icon_state = "emitter"
+	fire_sound = 'sound/effects/meteorimpact.ogg' //Bass-y sound of firing
+	damage = 40
+	damage_type = BURN
+	agony = 30
+	check_armour = "energy"
+	animate_movement = 1
+	penetrating = 55
+	armor_penetration = 40 // 85 percent pen vs astartes chest
+
+/obj/machinery/door/unpowered/necron_door1
+	icon = 'icons/obj/doors/necron_door.dmi'
+	name = "necron door"
+	desc = "An old ancient door, cold to the touch and highly resilient to any attack."
+	icon_state = "door1"
+	maxhealth = 8000 // Suffer
+	opacity = 0
+	req_access = list(access_necron1)
+
+/obj/machinery/door/unpowered/necron_door2
+	icon = 'icons/obj/doors/necron_door.dmi'
+	name = "necron door"
+	desc = "An old ancient door, cold to the touch and highly resilient to any attack."
+	color = "blue"
+	icon_state = "door1"
+	maxhealth = 8000 // Suffer
+	opacity = 0
+	req_access = list(access_necron2)
+
+/obj/machinery/door/unpowered/necron_door3
+	icon = 'icons/obj/doors/necron_door.dmi'
+	name = "necron door"
+	color = "red"
+	desc = "An old ancient door, cold to the touch and highly resilient to any attack."
+	icon_state = "door1"
+	maxhealth = 8000 // Suffer
+	opacity = 0
+	req_access = list(access_necron3)
+
+/////
+
+/obj/item/card/id/key/super/necron_site1 // Opens the main gate leading to the necron tomb
+	name = "Archeology Site Keycard"
+	desc = "A keycard used to access the archeological site entrace, restricted to mechanicus and the guest only."
+	icon = 'icons/map_project/fluff_items.dmi'
+	icon_state = "id_ship"
+	access = list(access_necron1)
+
+/var/const/access_necron1 = 7675
+/datum/access/necron1
+	id = access_necron1
+	desc = "Archeology Site Access" // Main Entrace
+
+/////
+
+/obj/item/card/id/key/super/necron_site2 // Opens areas in the tomb
+	name = "Blue Glowing Slab"
+	desc = "An slab with an odd blue color."
+	icon = 'icons/cadia-sprites/migrated2/artifacts.dmi'
+	icon_state = "dev111"
+	color = "blue"
+	access = list(access_necron2)
+
+
+/var/const/access_necron2 = 7676
+/datum/access/necron2
+	id = access_necron2
+	desc = "Necron Tomb Access - Blue" // 2nd Area
+
+/////
+
+/obj/item/card/id/key/super/necron_site3 // Opens the main gate leading to the necron tomb
+	name = "Red Glowing Slab"
+	desc = "An slab with an odd red color."
+	icon = 'icons/cadia-sprites/migrated2/artifacts.dmi'
+	icon_state = "dev111"
+	color = "red"
+	access = list(access_necron3)
+
+/var/const/access_necron3 = 7677
+/datum/access/necron3
+	id = access_necron3
+	desc = "Necron Tomb Access - Red" // Loot Area
+
+/obj/item/fluff_items/necron
+	name = "necron artifact"
+	icon = 'icons/cadia-sprites/migrated2/artifacts.dmi'
+	desc = "A necron artifact, what it does is unknown to you and many, the rouge trader could be interested on this."
+	icon_state = "dev121"
+	w_class = ITEM_SIZE_HUGE
+	sales_price = 40
+
+/obj/item/fluff_items/necron1
+	name = "necron artifact"
+	desc = "A necron artifact, what it does is unknown to you and many, the rouge trader could be interested on this."
+	icon = 'icons/cadia-sprites/migrated2/artifacts.dmi'
+	icon_state = "ndev51"
+	w_class = ITEM_SIZE_HUGE
+	sales_price = 40
+
+/obj/item/fluff_items/necron2
+	name = "necron artifact"
+	desc = "A necron artifact, what it does is unknown to you and many, the rouge trader could be interested on this."
+	icon = 'icons/cadia-sprites/migrated2/artifacts.dmi'
+	icon_state = "dev151"
+	w_class = ITEM_SIZE_HUGE
+	sales_price = 40
+
+/obj/item/fluff_items/necron3
+	name = "necron artifact"
+	desc = "A necron artifact, what it does is unknown to you and many, the rouge trader could be interested on this."
+	icon = 'icons/cadia-sprites/migrated2/artifacts.dmi'
+	icon_state = "dev131"
+	w_class = ITEM_SIZE_HUGE
+	sales_price = 40
+
+/obj/item/fluff_items/necron4
+	name = "necron artifact"
+	desc = "A necron artifact, what it does is unknown to you and many, the rouge trader could be interested on this."
+	icon = 'icons/cadia-sprites/migrated2/artifacts.dmi'
+	icon_state = "dev181"
+	w_class = ITEM_SIZE_HUGE
+	sales_price = 85
+// HORRORS OF THE WARP
+// HORRORS OF THE WARP
+// HORRORS OF THE WARP
+
+
+/obj/structure/hivedecor/flesh
+	name = "flesh"
+	desc = "A very old skull, who knows how long it's been there."
+	icon = 'icons/cadia-sprites/migrated2/things2.dmi'
+	icon_state = "2"
+	density = 0
+
+/obj/structure/hivedecor/kitten
+	name = "kitten"
+	desc = "A very old skull, who knows how long it's been there."
+	icon = 'icons/cadia-sprites/migrated2/things.dmi'
+	icon_state = "kitten"
+	density = 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// CONTESTED FORTRESS - A fortress in the east of the planet, under siege from Chaos and the guard trying to retake it.
+
+/obj/structure/hivedecor/chimera_wreck
+	name = "Chimera Wreck"
+	desc = "The wreck of a chimera, between the fire having burned most electronics possibly and the hull being damaged beyond repair, this wont be fixed nor salvageable."
+	icon = 'icons/cadia-sprites/migrated/alienqueen.dmi'
+	icon_state = "chimera_wreckage"
+
+/obj/structure/hivedecor/gun_rack
+	name = "Equipment Rack"
+	desc = "A rack of weapons used by the Imperial guard, time, lack of care, and corrosion has set on this equipment and is now unusable."
+	icon = 'icons/map_project/gunrack.dmi'
+	icon_state = "gr_4"
+
+/obj/structure/hivedecor/sentinel
+	name = "Imperial Guard Sentinel"
+	desc = "An imperial guard sentinel, often used for recon missions and supporting ground troops, without the proper key authorization its be impossible to enter."
+	icon = 'icons/cadia-sprites/migrated/alienqueen.dmi'
+	icon_state = "sentinel2"
+
+/obj/structure/hivedecor/hydra_gun
+	name = "Hydra Platform"
+	desc = "A large anti-air weapon able to take down most enemies on the sky if manned properly, this one seems to have been used for years and mantained properly."
+	icon = 'icons/map_project/anti_air.dmi'
+	icon_state = "type96"
+
+/obj/item/fluff_items/ammo_crate
+	name = "Ammo Crate"
+	desc = "A large ammo crate that would require heavy duty equipment to be opened, mainly filled with ammunition for many imperial vehicles or guns."
+	icon = 'icons/map_project/ammostuff.dmi'
+	icon_state = "crate_closed"
+	w_class = ITEM_SIZE_HUGE
+
+// CRASHED VALKYRIE - A Valkyrie carrying special equipment and an object has been lost somewhere on a valley near the Hive.
+
+/turf/unsimulated/floor/sand
+	name = "sand"
+	icon = 'icons/turf/desert.dmi'
+	icon_state = "desert"
+
+/turf/unsimulated/floor/valk_floor
+	icon = 'icons/map_project/valkyrie.dmi'
+	icon_state = "3"
+
+/turf/unsimulated/wall/valk_wall
+	icon = 'icons/map_project/valkyrie.dmi'
+	icon_state = "1"
+
+/mob/living/simple_animal/hostile/syndicate/mercenary
+	name = "Mercenary"
+	real_name = "Grey Lance Mercenary Soldier"
+	desc = "A mercenary that appears to be wearing modified guard armor, judging by their looks, they're battle hardened."
+	icon_state = "merc_standart"
+	icon = 'icons/map_project/creatures.dmi'
+	icon_living = "merc_standart"
+	icon_dead = "traitorguard1_dead"
+	icon_gib = "syndicate_gib"
+	speak_chance = 0
+	turns_per_move = 35
+	response_help = "pokes"
+	response_disarm = "shoves"
+	response_harm = "hits"
+	speed = 3 // Their speed is low to prevent them from charging into melee range immediately.
+	stop_automated_movement_when_pulled = 0
+	maxHealth = 250
+	health = 250
+	harm_intent_damage = 15
+	melee_damage_lower = 15
+	melee_damage_upper = 20
+	wander = 1
+	see_in_dark = 6
+	attacktext = "stabbed"
+	a_intent = I_HURT
+	unsuitable_atoms_damage = 15
+	environment_smash = 1
+	faction = "Mercenary"
+	status_flags = CANPUSH
+	ranged = 1
+	rapid = 1
+	projectilesound = 'sound/weapons/gunshot/gunshot3.ogg'
+	projectiletype = /obj/item/projectile/bullet/rifle
+
+/mob/living/simple_animal/hostile/syndicate/mercenary/death()
+	..(null, "body beeps before it explodes!")
+	new /obj/effect/decal/cleanable/blood/gibs/core(src.loc)
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(3, 1, src)
+	s.start()
+	qdel(src)
+	return
+
+/mob/living/simple_animal/hostile/syndicate/mercenary/scout
+	name = "Mercenary Scout"
+	real_name = "Grey Lance Mercenary Scout"
+	desc = "A mercenary that appears to be wearing modified guard armor, judging by their looks, they're battle hardened. This one seems to be an scout"
+	icon_state = "merc_scout"
+	icon_dead = "traitorguard1_dead"
+	icon_gib = "syndicate_gib"
+	maxHealth = 175
+	health = 175
+	speed = 1
+
+	projectilesound = 'sound/weapons/lasgun.ogg'
+	projectiletype = /obj/item/projectile/beam
+
+/mob/living/simple_animal/hostile/syndicate/mercenary/machinegunner
+	name = "Mercenary Machinegunner"
+	real_name = "Grey Lance Mercenary Machinegunner"
+	desc = "A mercenary that appears to be wearing modified guard armor, judging by their looks, they're battle hardened. This one seems to be carrying a light machinegun."
+	icon_state = "merc_machinegunner"
+	icon_dead = "traitorguard1_dead"
+	icon_gib = "syndicate_gib"
+	maxHealth = 200
+	health = 200
+	speed = 1
+
+	projectilesound = 'sound/weapons/gunshot/auto1.ogg'
+	projectiletype = /obj/item/projectile/bullet/pistol/medium
+
+/mob/living/simple_animal/hostile/syndicate/mercenary/leader
+	name = "Mercenary Sergeant"
+	real_name = "Grey Lance Mercenary Squad Leader"
+	desc = "A mercenary that appears to be wearing modified guard armor, judging by their looks, they're battle hardened. This one seems to be an officer."
+	icon_state = "merc_leader"
+	icon_dead = "traitorguard1_dead"
+	icon_gib = "syndicate_gib"
+	maxHealth = 325
+	health = 325
+	speed = 1
+
+	projectilesound = 'sound/weapons/gunshot/auto5.ogg'
+	projectiletype = /obj/item/projectile/bullet/pistol/strong/revolver/ap
+
+/obj/item/clothing/suit/armor/aascout/br
+	name = "Blood Raven Scout's Carapace"
+	desc = "The sturdy armour, issued to Adeptus Astartes Scouts for their service until they prove themselves worthy to become full-fledged Battlebrothers."
+	icon_state = "fharmor"
+	item_state = "fharmor"
+	color = "red"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 12, bullet = 55, laser = 60, energy = 30, bomb = 40, bio = 10, rad = 10)
+	sales_price = 30
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	species_restricted = list(SPECIES_SCOUT)
+
+/decl/hierarchy/outfit/brscout
+	name = OUTFIT_JOB_NAME("Blood Raven Scout")
+	uniform = /obj/item/clothing/under/astartes/bodysuit
+	suit = /obj/item/clothing/suit/armor/aascout/br
+	head = null
+	id_type = null
+	pda_type = null
+	pda_slot = null
+	back = null
+	shoes = /obj/item/clothing/shoes/combat
+	neck = /obj/item/reagent_containers/food/drinks/canteen
+	l_ear = null
+	r_ear = null
+
+/obj/effect/landmark/corpse/brscout
+	name = "Dead Blood Raven Scout"
+	species = list(SPECIES_SCOUT)
+	corpse_outfits = list(/decl/hierarchy/outfit/brscout)
+
+// Evil Sentinel
+
+/mob/living/simple_animal/hostile/syndicate/ranged/sentinel
+	name = "Heretical Sentinel"
+	desc = "A sentinel that was once used in the Imperial guard's arsenal, this one has been painted in red and the pilot hates the Emperor."
+	icon = 'icons/cadia-sprites/migrated/alienqueen.dmi'
+	icon_state = "sentinel2"
+	icon_living = "sentinel2"
+	icon_dead = "sentdestroyed"
+	color = "red"
+	maxHealth = 1500
+	health = 1500
+	speed = 4
+
+	ranged = 1
+	rapid = 1
+	projectilesound = 'sound/weapons/lasgun.ogg'
+	projectiletype = /obj/item/projectile/beam
+
+/*
+
+Civilians, Wounded, and other non combat personnel will be placed here, MOBs's with very little HP that if brought to a landmark (which i gotta ask
+rav to help me code) will reward the player with thrones, aka escort mission with reward - Graf
+
+*/
+
+/mob/living/simple_animal/civilians
+	name = "Civilian"
+	desc = "A civilian that is unarmed and with no way to defend itself, <font color='red'>Very weak and cannot defend itself, bring them to the extraction point ALIVE for rewards.</font>"
+	icon = 'icons/map_project/creatures.dmi'
+	icon_state = "guard_wounded1"
+	icon_living = "guard_wounded1"
+	icon_dead = "traitorguard1_dead"
+	speak_chance = 0
+	maxHealth = 55
+	health = 55
+	turns_per_move = 55
+	speak_emote = list("groans in pain")
+	emote_hear = list("grunts in pain")
+	response_help  = "gnashes"
+	response_disarm = "shoves"
+	response_harm   = "punches"
+	attacktext = "punches"
+	wander = 0 // Not gonna go anywhere unless pulled
+	see_in_dark = 6
+	speed = 1
+
+/mob/living/simple_animal/civilians/civ2
+	icon_state = "guard_wounded2"
+	icon_living = "guard_wounded2"
+	icon_dead = "guard_wounded2d"
+
+/mob/living/simple_animal/civilians/civ3
+	icon_state = "guard_wounded3"
+	icon_living = "guard_wounded3"
+	icon_dead = "guard_wounded3d"
+
+/mob/living/simple_animal/civilians/civ4
+	icon_state = "guard_wounded4"
+	icon_living = "guard_wounded4"
+	icon_dead = "guard_wounded4d"
+
+/mob/living/simple_animal/civilians/civ5
+	icon_state = "guard_wounded5"
+	icon_living = "guard_wounded5"
+	icon_dead = "guard_wounded5d"
+
+/mob/living/simple_animal/civilians/civ6
+	icon_state = "guard_wounded6"
+	icon_living = "guard_wounded6"
+	icon_dead = "guard_wounded6"
+
+/mob/living/simple_animal/civilians/priority
+	name = "Important Civilian"
+	desc = "A civilian that is unarmed and with no way to defend itself, <i>this one seems to be important due their noble status</i><font color='red'>Very weak and cannot defend itself, bring them to the extraction point ALIVE for rewards.</font>"
+	icon = 'icons/map_project/creatures.dmi'
+	icon_state = "civilian_rich"
+	icon_living = "civilian_rich"
+	icon_dead = "civilian_richd"
+	speak_chance = 0
+	maxHealth = 75
+	health = 75
+	turns_per_move = 55
+	speak_emote = list("throws a tantrum")
+	emote_hear = list("complains about tax money going to useless guardsmen", "complains about the lack of attention")
+
+/mob/living/simple_animal/civilians/priority/priority1
+	icon_state = "civilian_rich_f"
+	icon_living = "civilian_rich_f"
+	icon_dead = "civilian_rich_fd"
+
+/mob/living/simple_animal/civilians/priority/pilot
+	name = "Stranded Imperial Guard Pilot"
+	desc = "An Imperial Guard pilot that is unarmed and with no way to defend himself,<i>they should be recovered and brought back to the extraction point</i><font color='red'>Very weak and cannot defend itself, bring them to the extraction point ALIVE for rewards.</font>"
+	icon = 'icons/map_project/creatures.dmi'
+	icon_state = "crashed_pilot"
+	icon_living = "crashed_pilot"
+	icon_dead = "crashed_pilotd"
+	speak_chance = 0
+	maxHealth = 75
+	health = 75
+	turns_per_move = 55
+	speak_emote = list("groans in pain")
+	emote_hear = list("grunts in pain")
+
+/mob/living/simple_animal/hostile/pony
+	name = "magical pony"
+	desc = "Friendship is MAGIC, also deadly."
+	icon = 'icons/map_project/creatures.dmi'
+	icon_state = "friendship_is_magical"
+	icon_living = "friendship_is_magical"
+	pass_flags = PASS_FLAG_TABLE
+	health = 255
+	maxHealth = 255
+	melee_damage_lower = 45
+	melee_damage_upper = 45
+	attacktext = "cut"
+	attack_sound = 'sound/weapons/bladeslice.ogg'
+	faction = "chaos"
+	min_gas = null
+	max_gas = null
+	minbodytemp = 0
+
+
+
+
+/*
+
+All of the content below has been scrapped or going to be unused for a few reasons (not being 'fitting', outright unecessary and tests aswell on
+some stuff - Graf
+
+/mob/living/simple_animal/hostile/syndicate/guard
+	name = "Kriegsman" // Like the Traitor guard basically.
+	desc = "Loves the Imperium of man, will gun down anything heretical."
+	icon_state = "krieger"
+	icon = 'icons/map_project/creatures.dmi'
+	icon_living = "krieger"
+	icon_dead = "traitorguard1_dead"
+	icon_gib = "syndicate_gib"
+	speak_chance = 0
+	turns_per_move = 35
+	response_help = "pokes"
+	response_disarm = "shoves"
+	response_harm = "hits"
+	speed = 3 // Their speed is low to prevent them from charging into melee range immediately.
+	stop_automated_movement_when_pulled = 0
+	maxHealth = 250
+	health = 250
+	harm_intent_damage = 5
+	melee_damage_lower = 10
+	melee_damage_upper = 20
+	wander = 1
+	see_in_dark = 6
+	attacktext = "stabbed"
+	a_intent = I_HURT
+	unsuitable_atoms_damage = 15
+	environment_smash = 1
+	// faction = "Chaos" - Disabled till i can find the right faction.
+	status_flags = CANPUSH
+
+	ranged = 1
+	rapid = 1
+	projectilesound = 'sound/weapons/lasgun.ogg'
+	projectiletype = /obj/item/projectile/beam
+
+/mob/living/simple_animal/hostile/syndicate/word_bearer
+	name = "Word Bearer"
+	desc = "A terrifying, tall, and dangerous chaos space marine, this one is armed with a bolter."
+	icon = 'icons/map_project/marine_pack/chaos_chapters.dmi'
+	icon_state = "word_bearer"
+	icon_living = "word_bearer"
+	icon_dead = "traitorguard1_dead"
+	icon_gib = "syndicate_gib"
+	turns_per_move = 25
+	response_help = "pokes"
+	response_disarm = "shoves"
+	response_harm = "hits"
+	speed = 3 // Their speed is low to prevent them from charging into melee range immediately.
+	stop_automated_movement_when_pulled = 0
+	maxHealth = 950
+	health = 950
+	harm_intent_damage = 45
+	melee_damage_lower = 65
+	melee_damage_upper = 65
+	wander = 1
+	see_in_dark = 6
+	attacktext = "stabbed"
+	a_intent = I_HURT
+	unsuitable_atoms_damage = 15
+	environment_smash = 1
+	faction = "Chaos"
+	status_flags = CANPUSH
+	ranged = 1
+	rapid = 0
+	projectilesound = 'sound/weapons/gunshot/loudbolt.ogg'
+	projectiletype = /obj/item/projectile/bullet/bolterrifle
+
+	speak_chance = 0
+
+/mob/living/simple_animal/hostile/syndicate/word_bearer/specialist
+	name = "Word Bearer Specialist"
+	desc = "A terrifying, tall, and dangerous chaos space marine, this one has a heavy bolter..you're fucked"
+	icon = 'icons/map_project/marine_pack/chaos_chapters.dmi'
+	icon_state = "word_bearer_spec"
+	icon_living = "word_bearer_spec"
+	icon_dead = "traitorguard1_dead"
+
+	ranged = 1
+	rapid = 1
+	projectilesound = 'sound/weapons/gunshot/loudbolt.ogg'
+	projectiletype = /obj/item/projectile/bullet/bolterrifle
+
+*/

--- a/code/game/turfs/dungeon_ship.dm
+++ b/code/game/turfs/dungeon_ship.dm
@@ -1,0 +1,279 @@
+/*
+
+A dm file for the dungeon on the planet, an old colony ship from the M21 that was trapped in the Ocean of the planet for thousands of years.
+
+Here's going to be most of what's necessary, taking a dark approach for the dungeon however. If you got complaints then you can go bother me later.
+
+If i knew the spriters whom did most of the assets, i'd credit them, but lifeweb has many contributors and some have left SS13, Rip Dw4o
+
+NOTE: This dungeon is made to be unforgiving, brutal and merciless, but giving exceptional good loot that cant be found anywhere else, it's expected that lone players die horribly here without any support or allies, bring a party like an MMORPG game you fucking dumbasses.
+
+*/
+
+/turf/simulated/floor/ship_floor
+	name = "old steel floor"
+	icon = 'icons/map_project/ship/shiptiles.dmi'
+	icon_state = "oldsteel"
+
+/turf/simulated/floor/ship_floor/ramp
+	name = "ship ramp"
+	icon_state = "fancy_stairs"
+
+/turf/simulated/floor/ship_floor/steel
+	name = "polished steel floor"
+	icon_state = "oldsteelf"
+
+/turf/simulated/floor/ship_floor/white
+	name = "old white floor"
+	icon_state = "whitel"
+
+/turf/simulated/floor/ship_floor/evil
+	name = "horror"
+	icon_state = "evil"
+
+/turf/simulated/floor/ship_floor/brown
+	name = "old white floor"
+	icon_state = "brownl"
+
+/turf/simulated/floor/ship_floor/engines
+	name = "engine floor"
+	icon_state = "warningf"
+
+/turf/simulated/floor/ship_floor/platform
+	name = "platform"
+	icon_state = "south3"
+
+// Walls
+
+/turf/unsimulated/oldship // As someone who's done dungeons on an stalker server & Fallout, not making a wall like this means peep will take tools and rush into the loot without doing the dungeon, here's the fix
+	name = "Ancient Wall"
+	desc = "The wall of this ship is something you've never seen before in your life."
+	icon = 'icons/map_project/ship/ref_walls.dmi'
+	icon_state = "rwall0"
+	opacity = 1
+	density = 1
+
+// DOORS
+
+/obj/machinery/door/unpowered/shuttle/hatch
+	name = "old hatch"
+	icon_state = "door_closed"
+	icon = 'icons/obj/doors/hatch.dmi'
+	autoclose = 1
+	normalspeed = 0
+
+/obj/machinery/door/unpowered/shuttle/hatch2
+	icon_state = "door_closed"
+	icon = 'icons/obj/doors/escotilha.dmi'
+	autoclose = 1
+	normalspeed = 0
+
+/obj/machinery/door/airlock/ancient_ship
+	name = "Ancient Ship Door"
+	icon_state = "normal"
+	icon = 'icons/obj/doors/individual_1.dmi'
+
+
+/obj/machinery/door/airlock/ancient_ship/maint
+	name = "Old Maintenance Door"
+	icon_state = "maint"
+	icon = 'icons/obj/doors/maintdoor.dmi'
+
+
+/obj/machinery/door/airlock/ancient_ship/med
+	name = "Ancient Ship Door"
+	icon_state = "door_closed"
+	icon = 'icons/obj/doors/met_door.dmi'
+
+
+/obj/machinery/door/airlock/ancient_ship/command
+	name = "Bridge Ship Door"
+	icon_state = "door_closed"
+	desc = "You can feel some kind of evil presence behind that door, is it really wise to open it ?" // Giving them a warning, before they die possibly
+	icon = 'icons/obj/doors/command_door.dmi'
+
+	maxhealth = 1500 // No funny shooting ideas
+	secured_wires = 1 // Find the key to open it, dumbass
+
+/obj/machinery/door/airlock/ancient_ship/command/capitan
+	name = "Capitan's Quarters"
+	icon_state = "door_closed"
+	desc = "The whispers and noises are more and more loud behind it."
+	icon = 'icons/obj/doors/command_door.dmi'
+
+	maxhealth = 5000 // No skipping the dungeon
+	secured_wires = 1 // Not letting you just hack it and open it, dumbass.
+
+// 'Decoration'
+
+/obj/structure/shipdecor
+	name = "Ship Computer"
+	icon = 'icons/map_project/ship/ship_equipment.dmi'
+	icon_state = ""
+	desc = "A computer, it seems it's not recieving power."
+	anchored = 1
+	density = 1
+
+/obj/structure/shipdecor/cryochamber
+	name = "Ship Computer"
+	icon = 'icons/map_project/ship/ship_equipment.dmi'
+	icon_state = "cryochamber1"
+	desc = "A closed cryochamber, it seems to be empty on the inside."
+
+/obj/structure/shipdecor/generator
+	name = "Power Generator"
+	icon = 'icons/map_project/ship/ship_equipment.dmi'
+	icon_state = "cryochamber1"
+	desc = "An old power generator, how it's still almost intact is something to wonder."
+
+/obj/structure/sign/ship
+	name = "\improper screen"
+	icon = 'icons/map_project/ship/ship_equipment.dmi'
+	desc = "An small screen, it's constantly transmitting static."
+	icon_state = "science1"
+
+/obj/structure/sign/ship/hell
+	name = "\improper Capitan's screen"
+	icon = 'icons/map_project/ship/pillars.dmi'
+	desc = "A large screen, the words it's spewing constantly make your eyes and mind hurt the more you try to read them."
+	icon_state = "p"
+
+/obj/structure/sign/ship/blood_signs
+	name = "\improper blood signs"
+	icon = 'icons/map_project/ship/blood_signs.dmi'
+	desc = "Signs drawn in human blood."
+	icon_state = "graffiti"
+
+// Effects
+
+/obj/effect/floor_decal/turf/sigil
+	name = "demonic sigil"
+	icon = 'icons/map_project/ship/sigils.dmi'
+	icon_state = "center"
+
+/obj/effect/floor_decal/turf/sun
+	name = "SUN OF ETERNAL NIGHT"
+	icon = 'icons/map_project/ship/sun_of_eternal_night.dmi'
+	icon_state = "sun"
+
+/obj/structure/shipdecor/warp // Meant to make a mini fight with the player being brought inside of it, but i dont have the time to do this + This 40k nerds dont seem to like PVE content that much
+	name = "Warp Portal"
+	icon = 'icons/obj/warpstorm.dmi'
+	icon_state = "ws2"
+	desc = "<span class='danger'>The more you look at it, the more whispers and voices you hear on your head.</span>"
+
+/obj/structure/shipdecor/warp2 // This is the animated version.
+	name = "Warp Portal"
+	icon = 'icons/obj/warpstorm.dmi'
+	icon_state = "ws22"
+	desc = "<span class='danger'>The more you look at it, the more whispers and voices you hear on your head.</span>"
+
+// Mobs
+
+/mob/living/simple_animal/hostile/cpt_miller // Boss of the 'dungeon', slow but heavy hitter & high HP, you'll need a party for this or cheese it, had an arm removal code (ripping arms off players when in crit) & weapon blocking chance, but it's possibly gonna be nerfed or such (unrobust peep), so might aswell just make it a simple mob of sorts.
+	name = "Unholy Angel"
+	real_name = "Captain Miller" // Event Horizon reference baby
+	desc = "<span class='danger'>This creature was possibly once human, now it's something completely different, his skin seems to have been boiled, scratched, and burned, his eyes missing and oozing some sort of ink-like liquid, and two pair of flesh-like wings are on his back</span>."
+	icon = 'icons/map_project/ship/angel.dmi'
+	icon_state = "angel"
+	icon_living = "angel"
+	icon_dead = "tzantz2"
+	maxHealth = 2200 // Strong enemy, should be taken down by multiple enemies, has High HP to hold the
+	health = 2200
+	speed = 3 // Slow to give players a chance, although they're fucked honestly if they try to attack it without a proper team
+	emote_see = list("whimpers uncontrollably", "peels his own face", "furiously scratches his skin off", "rips his own flesh", "whispers in an unknown language")
+	melee_damage_lower = 60
+	melee_damage_upper = 60
+	attacktext = "cuts"
+	attack_sound = 'sound/weapons/bladeslice.ogg'
+
+// Dungeon armors & Loot - Most of this will be loot and equipment you can obtain from the dungeon basically, these come from lifeweb
+
+/obj/item/card/id/key/super/capitan_quarters // To open the capitan's quarters,
+	name = "???"
+	desc = "It appears to be some sort of key..it does not stop pulsating though."
+	icon = 'icons/map_project/fluff_items.dmi'
+	icon_state = "crystal"
+	access = list(access_daemon)
+
+/obj/item/reagent_containers/glass/bottle/panacea
+	name = "Liquid Panacea"
+	desc = "A suspicious looking bottle which seems to contain the solution to cure all diseases and prolong life indefinitely."
+	icon = 'icons/map_project/fluff_items.dmi'
+	icon_state = "panacea"
+	volume = 5 // 5u can heal a 70-80% dmg, excluding bone fractures.
+	sales_price = 50 // A decent price for ahealing juice
+
+/obj/item/reagent_containers/glass/bottle/panacea/New()
+	..()
+	reagents.add_reagent(/datum/reagent/adminordrazine, 5)
+
+/obj/item/rnd/demonic_grimorie // A big R&D toy, possibly the only thing worth it for most people to try and get, due the sheer knowledge, it's behind a big dangerous dungeon.
+	name = "Demonic Grimorie"
+	desc = "<span class='danger'>An ancient grimorie, it's surface is made out of human skin and the words are written in human blood, the knowledge this book has is from millenia ago, right from the dark age of technology , is it really worth it to study such cursed artifact ?</span>"
+	icon = 'icons/map_project/fluff_items.dmi'
+	icon_state = "grimoire1"
+	origin_tech = list(TECH_MATERIAL = 5, TECH_ILLEGAL = 9, TECH_ARCANE = 9)
+	sales_price = 300 // The price for knowledge
+
+
+/obj/item/clothing/suit/armor/leper
+	name = "leper armor"
+	desc = "An ancient armor from millenia ago, it's state is very much pristine and looks like it was masterfully crafted."
+	icon_state = "leper"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
+	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
+	heat_protection = UPPER_TORSO|LOWER_TORSO|ARMS
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
+	armor = list(melee = 5, bullet = 40, laser = 40, energy = 30, bomb = 40, bio = 90, rad = 90) // For skirmish combat, player is fast and can endure shots, but at CQC he's fucked, hit and run is more fitting for the armor user.
+	sales_price = 0 // Only 1 in the map
+	weight = 10
+
+/obj/item/clothing/head/leper
+	name = "leper's helmet"
+	desc = "To be precise, it's a piece of cloth over your head, but it does seem that it's been reinforced with chainmail beneath the cloth."
+	icon_state = "leper_dungeon"
+	item_state = "leper_dungeon"
+	cold_protection = HEAD
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	flags_inv = BLOCKHAIR
+	armor = list(melee = 5, bullet = 40, laser = 40, energy = 30, bomb = 90, rad = 100) // It's to prevent the user being brutally hit on the head and making the armor worthless.
+	sales_price = 0 // Only 1 in the map
+
+/obj/item/clothing/suit/armor/cerb
+	name = "cerberus armor"
+	desc = "A questionable armor of unknown origin, it does seem familiar though.."
+	icon_state = "TrustworthyCerberus"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
+	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
+	heat_protection = UPPER_TORSO|LOWER_TORSO|ARMS
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
+	armor = list(melee = 10, bullet = 46, laser = 46, energy = 30, bomb = 40, bio = 90, rad = 90)
+	sales_price = 0 // Only 1 in the map
+	weight = 10
+
+/obj/item/clothing/head/cerb
+	name = "cerberus helmet"
+	desc = "A heavy combat helmet that seems almost part of some sort of power armor."
+	icon_state = "cerbhelm"
+	item_state = "cerbhelm"
+	cold_protection = HEAD
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	flags_inv = BLOCKHAIR
+	armor = list(melee = 10, bullet = 46, laser = 46, energy = 30, bomb = 90, rad = 100) // It's to prevent the user being brutally hit on the head and making the armor worthless.
+	sales_price = 0 // Only 1 in the map
+
+/obj/item/paper/cpt_diary // Lore about the ship's demise, obtained only when the boss dies, as i thought it would be more proper.
+	name = "Capitan Miller's Diary"
+	desc = "The diary of what was once the capitan of the ship, it's extremly old and seems most of the cover and pages are covered in an ink-like substance."
+	icon = 'icons/map_project/fluff_items.dmi'
+	icon_state = "old_diary"
+	info = "​<p><strong>11 July M21, 839 <br /></strong> <p><em>My computer seems to have issues currently, so i will write the transcripts of the operation here and later upload them once the computer's fixed. After 4 months of travel from Terra we're almost there to colonize the planet of Messina. It is an ocean world that seems to have more than enough resources to supply Terra and prosper, specially some ores that are in high demand right now. The crew and me are finally happy that we're a few hours away from the planet with the warp drive. The Tynedale and the Agamemnon, there's two other colony ships that have been with us on this journey, however their crew is not as good as ours it seems as they're 4 hours late, apparently the Tynedale had engine problems by the looks of it. We'll wait for them and continue.</p><hr /><p><strong>12 July M21, 839 <br /></strong> <p><em>There's been a huge incident, the Tynedale's Gellar field malfunctioned for a few seconds as we were reaching for the destination, all we could hear on the bridge was static and the screams of their command crew before communications went down 10 minutes ago, we're still on the Aether. I have told the command crew to not tell ANYONE else about this incident, we cannot have the crew panicking right when we're so close. I've heard of things like this happening, but i thought these were tales by old miners and retired capitans, but i did not expect that to even happen, there were around 148 men in that ship..</p><hr /><p><strong>13 July M21, 839 <br /></strong> <p><em>As soon as we got out of the warp, we landed right infront of an asteroid field, the space debris was too big and we suffered severe damage on the ship's rear engines and communications, we could see how the Agamemnon was burning and crashing towards the planet. Our main engine is failing and we've got 4 enginieers dead from the promethium explosion on the enginieering bay, i need to go.</p><hr /><p><strong>14 July M21, 839<br /></strong> <p><em>We crashed into the planet's ocean, no hull breaches have been present on the monitors and the water pressure is nothing to worry about thanks to the alloys of our hull, based on what our specialists on the ship said, we're around.. 3566 feet below from the surface. We had only 12 deaths on the ship and we've got yet 34 people on hibernation and 86 awake. We are going to evaluate the damage once again, then attempt to fix communications and contact the Agamemnon for assistance, the crew is clearly afraid but i've told them to not worry, we've got the finest enginieers and officers from Terra, we're gonna get out of this.</p><hr /><p><strong>23 July M21, 839<br /></strong><p><em> Nothing, we've got nothing, long range communications are busted and we do not have any sort of replacement parts for them to work, last day we decided on bringing 6 of our finest scouts and a pregnant crewmember on the escape pods, we've given them enough food and supplies to reach the surface using the pods, even if the rest of us are trapped down. The volunteers will have to reach what we assume is the location of the Agamemnon, they should be there in a week and we may recieve help, i just hope they can infact reach them in time.</p><hr /><p><strong>26 August M21, 839<br /></strong> <p><em>The team we sent weeks ago has not been heard from again, some of the men have become desperate, we take turns to simply be on the garden. Two men last night tried to escape using the airlocks, but they realized that our space suits do not protect from the pressure of such depths below.. So their bodies exploded, the rest of crewmembers are anxious and saying that we're not gonna ever leave this place. I've been hearing a familiar voice, the doctors have me on antipsychotics when i told them about this..I know it's due the stress, but this voice does not stop talking to me, it does not matter how many drugs i take or how long i sleep, it keeps talking on that strange language.</p><hr /><p><strong>11 November M21, 839<br /></strong> <p><em>I was naive, ignorant and unwilling back then, the words it spoke to me soon made sense. The voice has promised me salvation, it has given me instructions on how we can get out of here.. Most of us. I have ordered security to execute the men and women who are sick as we cannot spare more food and supplies on these useless beings. Some of the crew are taking sides and threatened me of a mutiny once they seen the first executions, but they wont, once they sleep i will bring the security forces and execute them for questioning my command.</p><hr /><p><strong>22<br /></strong> <p><em>Time does not matter anymore, neither is writing this, but i keep going to keep my sanity. Food is running low on the ship, i instructed the chef to begin butchering the bodies of the men and women who are executed. What is taboo is now saving us, it has been months since i ate something so delicious and tasty. Some of the crew has begun to hear the same voice as i do, but theirs is different..we're going to show our gratitude to the voice. As long as i do as it says, i will survive</p><hr /><p><strong>4<br /></strong> <p><em>I cant sleep anymore, my eyes cant stop crying, my body burns i want to die. i dont want to do this anymore i dont want to hear them</p>"
+
+/obj/item/paper/cpt_diary/update_icon()
+	return
+
+/*
+*/

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -151,7 +151,6 @@
 	desc = "It's like the 2090's all over again."
 	icon = 'icons/turf/flooring/linoleum.dmi'
 	icon_base = "lino"
-	can_paint = 1
 	build_type = /obj/item/stack/tile/linoleum
 	flags = TURF_REMOVE_SCREWDRIVER
 	footstep_type = /singleton/footsteps/tiles
@@ -166,7 +165,6 @@
 	damage_temperature = T0C+1400
 	flags = TURF_REMOVE_CROWBAR | TURF_CAN_BREAK | TURF_CAN_BURN
 	build_type = /obj/item/stack/tile/floor
-	can_paint = 1
 	footstep_type = /singleton/footsteps/tiles
 
 /singleton/flooring/tiling/mono
@@ -298,7 +296,6 @@
 	build_time = 30
 	apply_thermal_conductivity = 0.025
 	apply_heat_capacity = 325000
-	can_paint = 1
 	footstep_type = /singleton/footsteps/plating
 
 /singleton/flooring/reinforced/circuit
@@ -307,7 +304,6 @@
 	icon_base = "bcircuit"
 	build_type = null
 	flags = TURF_ACID_IMMUNE | TURF_CAN_BREAK | TURF_REMOVE_WRENCH
-	can_paint = 1
 	can_engrave = FALSE
 
 /singleton/flooring/reinforced/circuit/green
@@ -339,7 +335,6 @@
 	icon = 'icons/turf/shuttle.dmi'
 	build_type = null
 	flags = TURF_ACID_IMMUNE | TURF_CAN_BREAK | TURF_REMOVE_CROWBAR
-	can_paint = 1
 	can_engrave = FALSE
 
 /singleton/flooring/reinforced/shuttle/blue
@@ -426,3 +421,201 @@
 	floor_smooth = SMOOTH_NONE
 	wall_smooth = SMOOTH_NONE
 	space_smooth = SMOOTH_NONE
+
+
+
+// WARHAMMER 40k
+
+/singleton/flooring/tiling
+	name = "floor"
+	desc = "Scuffed from the passage of countless menials."
+	icon = 'icons/turf/flooring/tiles.dmi'
+	icon_base = "steel"
+	color = null
+	has_base_range = 3
+	damage_temperature = T0C+1400
+
+/singleton/flooring/tiling/stone
+	icon_base = "stone"
+
+
+/singleton/flooring/tiling/mono
+	icon_base = "monotile"
+
+/singleton/flooring/tiling/white
+	desc = "How sterile."
+	icon_base = "white"
+	color = null
+	build_type = /obj/item/stack/tile/floor_white
+
+/singleton/flooring/tiling/white/mono
+	icon_base = "monotile"
+
+/singleton/flooring/tiling/dark
+	desc = "How ominous."
+	icon_base = "dark"
+	color = null
+	build_type = /obj/item/stack/tile/floor_dark
+
+/singleton/flooring/tiling/dark/mono
+	icon_base = "monotile"
+
+/singleton/flooring/tiling/freezer
+	desc = "Don't slip."
+	icon_base = "freezer"
+	color = null
+	has_damage_range = null
+	flags = TURF_REMOVE_CROWBAR
+	build_type = /obj/item/stack/tile/floor_freezer
+
+/singleton/flooring/wood
+	name = "wooden floor"
+	desc = "Polished redwood planks."
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_base = "wood"
+	has_damage_range = 6
+	damage_temperature = T0C+200
+	build_type = /obj/item/stack/tile/wood
+	descriptor = "planks"
+	flags = TURF_CAN_BREAK | TURF_IS_FRAGILE | TURF_CAN_BURN
+
+/singleton/flooring/new_wood
+	name = "wooden floor"
+	desc = "Polished redwood planks."
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_base = "new_wood"
+	has_damage_range = 6
+	damage_temperature = T0C+200
+	build_type = /obj/item/stack/tile/wood
+	descriptor = "planks"
+	flags = TURF_CAN_BREAK | TURF_IS_FRAGILE | TURF_CAN_BURN
+
+
+/singleton/flooring/stone
+	name = "stone floor"
+	desc = "Cobblestone flooring"
+	icon = 'icons/turf/flooring/stonefloor.dmi'
+	icon_base = "MAIN"
+	has_damage_range = 6
+	descriptor = "cobble"
+	flags = TURF_CAN_BREAK | TURF_IS_FRAGILE |TURF_ACID_IMMUNE|TURF_HAS_CORNERS|TURF_REMOVE_SHOVEL
+
+/singleton/flooring/stone/one
+	icon_base = "extra"
+
+/singleton/flooring/stone/two
+	icon_base = "extra1"
+
+/singleton/flooring/stone/three
+	icon_base = "extra2"
+
+/singleton/flooring/stone/four
+	icon_base = "extra3"
+
+/singleton/flooring/stone/five
+	icon_base = "extra4"
+
+/singleton/flooring/stone/six
+	icon_base = "extra5"
+
+/singleton/flooring/stone/seven
+	icon_base = "extra6"
+
+/singleton/flooring/stone/eight
+	icon_base = "extra7"
+
+/singleton/flooring/reinforced
+	name = "reinforced floor"
+	desc = "Heavily reinforced with steel plating."
+	icon = 'icons/turf/flooring/tiles.dmi'
+	icon_base = "reinforced"
+	flags = TURF_REMOVE_WRENCH | TURF_ACID_IMMUNE
+	build_type = /obj/item/stack/material/steel
+	build_cost = 1
+	build_time = 30
+	apply_thermal_conductivity = 0.025
+	apply_heat_capacity = 325000
+
+/singleton/flooring/reinforced/circuit
+	name = "processing strata"
+	icon = 'icons/turf/flooring/circuit.dmi'
+	icon_base = "bcircuit"
+	build_type = null
+	flags = TURF_ACID_IMMUNE | TURF_CAN_BREAK | TURF_REMOVE_WRENCH
+
+/singleton/flooring/reinforced/circuit/green
+	icon_base = "gcircuit"
+
+/singleton/flooring/reinforced/circuit/red
+	icon_base = "rcircuit"
+	flags = TURF_ACID_IMMUNE
+
+/singleton/flooring/reinforced/cult
+	name = "engraved floor"
+	desc = "Unsettling whispers waver from the surface..."
+	icon = 'icons/turf/flooring/cult.dmi'
+	icon_base = "cult"
+	build_type = null
+	has_damage_range = 6
+	flags = TURF_ACID_IMMUNE | TURF_CAN_BREAK | TURF_REMOVE_WRENCH
+
+/singleton/flooring/reinforced/shuttle
+	name = "floor"
+	icon = 'icons/turf/shuttle.dmi'
+	build_type = null
+	flags = TURF_ACID_IMMUNE | TURF_CAN_BREAK | TURF_REMOVE_WRENCH
+
+/singleton/flooring/reinforced/shuttle/blue
+	icon_base = "floor"
+
+/singleton/flooring/reinforced/shuttle/yellow
+	icon_base = "floor2"
+
+/singleton/flooring/reinforced/shuttle/white
+	icon_base = "floor3"
+
+/singleton/flooring/reinforced/shuttle/red
+	icon_base = "floor4"
+
+/singleton/flooring/reinforced/shuttle/purple
+	icon_base = "floor5"
+
+/singleton/flooring/reinforced/shuttle/darkred
+	icon_base = "floor6"
+
+/singleton/flooring/reinforced/shuttle/black
+	icon_base = "floor7"
+
+/singleton/flooring/diona
+	name = "biomass"
+	desc = "a mass of small intertwined aliens forming a floor... Creepy."
+	icon = 'icons/turf/floors.dmi'
+	icon_base = "diona"
+	flags = TURF_ACID_IMMUNE | TURF_REMOVE_SHOVEL
+
+/singleton/flooring/reinforced/ramp
+	name = "foot ramp"
+	desc = "An archaic means of locomotion along the Z axis."
+	icon = 'icons/turf/flooring/tiles.dmi'
+	icon_base = "ramptop"
+	build_type = null
+	flags = TURF_ACID_IMMUNE | TURF_CAN_BREAK
+
+/singleton/flooring/reinforced/ramp/bottom
+	icon_base = "rampbot"
+
+/singleton/flooring/diona
+	name = "biomass"
+	desc = "a mass of small intertwined aliens forming a floor... Creepy."
+	icon = 'icons/turf/floors.dmi'
+	icon_base = "diona"
+	flags = TURF_ACID_IMMUNE | TURF_REMOVE_SHOVEL
+
+/singleton/flooring/snow
+	name = "snow"
+	desc = "Mixed snow"
+	icon = 'icons/turf/flooring/stonefloor.dmi'
+	icon_base = "MAIN"
+	has_damage_range = 6
+	descriptor = "snow"
+	flags = TURF_CAN_BREAK | TURF_IS_FRAGILE |TURF_ACID_IMMUNE|TURF_HAS_CORNERS|TURF_REMOVE_SHOVEL

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -1345,3 +1345,368 @@ var/global/list/floor_decals = list()
 
 /obj/floor_decal/stoneborder/corner
 	icon_state = "stoneborder_c"
+
+/obj/effect/floor_decal/newcorner/plazaf
+	icon_state = "plazaf"
+/obj/effect/floor_decal/newcorner/plazaf/quarter
+	icon_state = "plazaf-quarter"
+/obj/effect/floor_decal/newcorner/plazaf/diagonal
+	icon_state = "plazaf-diagonal"
+/obj/effect/floor_decal/newcorner/plazaf/corner
+	icon_state = "plazaf-corner"
+
+/obj/effect/floor_decal/newcorner/plazafalt
+	icon_state = "plazaf2"
+/obj/effect/floor_decal/newcorner/plazafalt/quarter
+	icon_state = "plazaf2-quarter"
+/obj/effect/floor_decal/newcorner/plazafalt/diagonal
+	icon_state = "plazaf2-quarter"
+/obj/effect/floor_decal/newcorner/plazafalt/corner
+	icon_state = "plazaf2-corner"
+
+/obj/effect/floor_decal/newcorner/bar
+	icon_state = "bar"
+/obj/effect/floor_decal/newcorner/bar/quarter
+	icon_state = "bar-quarter"
+/obj/effect/floor_decal/newcorner/bar/corner
+	icon_state = "bar-corner"
+/obj/effect/floor_decal/newcorner/bar/diagonal
+	icon_state = "bar-diagonal"
+
+/obj/effect/floor_decal/newcorner/cafe
+	icon_state = "cafe"
+/obj/effect/floor_decal/newcorner/cafe/quarter
+	icon_state = "cafe-quarter"
+/obj/effect/floor_decal/newcorner/cafe/corner
+	icon_state = "cafe-corner"
+/obj/effect/floor_decal/newcorner/cafe/diagonal
+	icon_state = "cafe-diagonal"
+
+/obj/effect/floor_decal/newcorner/plating
+	icon_state = "plating"
+/obj/effect/floor_decal/newcorner/plating/quarter
+	icon_state = "plating-quarter"
+/obj/effect/floor_decal/newcorner/plating/corner
+	icon_state = "plating-corner"
+/obj/effect/floor_decal/newcorner/plating/diagonal
+	icon_state = "plating-diagonal"
+
+/obj/effect/floor_decal/newcorner/polar
+	icon_state = "polar"
+/obj/effect/floor_decal/newcorner/polar/quarter
+	icon_state = "polar-quarter"
+/obj/effect/floor_decal/newcorner/polar/corner
+	icon_state = "polar-corner"
+
+/obj/effect/floor_decal/newcorner/reinforced
+	icon_state = "reinforced"
+/obj/effect/floor_decal/newcorner/reinforced/corner
+	icon_state = "rcorner"
+
+/obj/effect/floor_decal/newcorner/train
+	icon_state = "train"
+/obj/effect/floor_decal/newcorner/train/corner
+	icon_state = "train_c"
+
+/obj/effect/floor_decal/newcorner/train2
+	icon_state = "train2"
+/obj/effect/floor_decal/newcorner/train2/corner
+	icon_state = "train2_c"
+
+/obj/effect/floor_decal/newcorner/shaft
+	icon_state = "shaftplating"
+/obj/effect/floor_decal/newcorner/shaft/quarter
+	icon_state = "shaftplating-quarter"
+/obj/effect/floor_decal/newcorner/shaft/corner
+	icon_state = "shaftplating-corner"
+/obj/effect/floor_decal/newcorner/shaft/diagonal
+	icon_state = "shaftplating-diagonal"
+
+/obj/effect/floor_decal/newcorner/step
+	icon_state = "step"
+/obj/effect/floor_decal/newcorner/step_i
+	icon_state = "step_i"
+
+/obj/effect/floor_decal/newcorner/nbar
+	icon_state = "nbar"
+/obj/effect/floor_decal/newcorner/nbar/corner
+	icon_state = "nbar_corner"
+
+/obj/effect/floor_decal/newcorner/dwood
+	icon_state = "dwood"
+
+/obj/effect/floor_decal/industrial/direction
+	icon_state = "dir_white"
+/obj/effect/floor_decal/industrial/direction/black
+	icon_state = "dir_black"
+
+/obj/effect/floor_decal/industrial/mark
+	icon_state = "mark_white"
+/obj/effect/floor_decal/industrial/mark/black
+	icon_state = "mark_black"
+
+/obj/effect/floor_decal/industrial/punctuation
+	icon_state = "punctuation_white"
+/obj/effect/floor_decal/industrial/punctuation/black
+	icon_state = "punctuation_black"
+
+/obj/effect/floor_decal/industrial/plaza
+	icon_state = "plaza"
+/obj/effect/floor_decal/industrial/plaza/box
+	icon_state = "plazabox"
+
+/obj/effect/floor_decal/turf/bloodbar
+	icon_state = "bloodbar"
+/obj/effect/floor_decal/turf/bloodbar/off
+	icon_state = "bloodbar2"
+/obj/effect/floor_decal/turf/bar
+	icon_state = "barfull"
+/obj/effect/floor_decal/turf/bar2
+	icon_state = "bar2"
+/obj/effect/floor_decal/turf/bar3
+	icon_state = "bar3"
+
+/obj/effect/floor_decal/turf/cafe
+	icon_state = "cafefull"
+/obj/effect/floor_decal/turf/cafe2
+	icon_state = "cafe2"
+
+/obj/effect/floor_decal/turf/shaft
+	icon_state = "shaft"
+/obj/effect/floor_decal/turf/coldroom
+	icon_state = "coldroom"
+/obj/effect/floor_decal/turf/steel
+	icon_state = "steel"
+
+/obj/effect/floor_decal/turf/piping
+	icon = 'icons/map_project/piping.dmi'
+	icon_state = "trubas"
+
+/obj/effect/floor_decal/turf/big_cables1
+	icon = 'icons/map_project/piping.dmi'
+	icon_state = "cable0"
+
+/obj/effect/floor_decal/turf/big_cables2
+	icon = 'icons/map_project/piping.dmi'
+	icon_state = "cable1"
+
+/obj/effect/floor_decal/turf/armory
+	icon = 'icons/map_project/furniture_and_decor.dmi'
+	icon_state = "arm1"
+//////////////////////////////////
+////////// NEW FLOORING //////////
+//////////////////////////////////
+
+// Even Newer
+/obj/effect/floor_decal/turf/grimy
+	name = "grimy floor"
+	icon = 'icons/turf/flooring/floors.dmi' // It will break without this.
+	icon_state = "grimy"
+
+/obj/effect/floor_decal/turf/nf2
+	name = "stone floor"
+	icon = 'icons/turf/flooring/floors.dmi'
+	icon_state = "nf2"
+
+/obj/effect/floor_decal/turf/lfloorscorched1
+	name = "scorched floor"
+	icon = 'icons/turf/flooring/floors.dmi'
+	icon_state = "lfloorscorched1"
+
+// Slightly New
+/obj/effect/floor_decal/turf/basalt0
+	name = "volcanic floor"
+	icon_state = "basalt0"
+
+/obj/effect/floor_decal/turf/basalt1
+	name = "volcanic floor"
+	icon_state = "basalt1"
+
+/obj/effect/floor_decal/turf/basalt3
+	name = "volcanic floor"
+	icon_state = "basalt3"
+
+/obj/effect/floor_decal/turf/basalt9
+	name = "volcanic floor"
+	icon_state = "basalt9"
+
+/obj/effect/floor_decal/turf/basalt10
+	name = "volcanic floor"
+	icon_state = "basalt10"
+
+/obj/effect/floor_decal/turf/necro1
+	name = "infestation"
+	icon_state = "necro1"
+
+/obj/effect/floor_decal/turf/necro2
+	name = "infestation"
+	icon = 'icons/map_project/eldritch/Flesh_Ground.dmi'
+	icon_state = "flesh_floor-1"
+
+/obj/effect/floor_decal/turf/necro3
+	name = "infestation"
+	icon = 'icons/map_project/eldritch/Flesh_Ground.dmi'
+	icon_state = "flesh_floor-2"
+
+/obj/effect/floor_decal/turf/necro4
+	name = "infestation"
+	icon = 'icons/map_project/eldritch/Flesh_Ground.dmi'
+	icon_state = "flesh_floor-3"
+
+/*
+/obj/effect/floor_decal/turf/necro2
+	name = "horrific infestation"
+	desc = "You notice sharp teeth beneath it's flesh."
+	icon_state = "necro2" */
+
+/obj/effect/floor_decal/turf/oldsmoothdirt
+	name = "dirt floor"
+	icon_state = "oldsmoothdirt"
+
+/obj/effect/floor_decal/turf/tunneldirty
+	name = "tunnel floor"
+	icon_state = "tunneldirty"
+
+/obj/effect/floor_decal/turf/tunnelchess
+	name = "tunnel floor"
+	icon_state = "tunnelchess"
+
+/obj/effect/floor_decal/turf/carpetn00
+	name = "carpet floor"
+	icon_state = "n00"
+
+/obj/effect/floor_decal/turf/surgery2
+	name = "surgery floor"
+	icon_state = "surgery2"
+
+/obj/effect/floor_decal/turf/brothel
+	name = "brothel floor"
+	icon_state = "brothel"
+
+/obj/effect/floor_decal/turf/clockwork
+	name = "alien floor"
+	icon_state = "clockwork"
+
+//////////////////////////////////
+//////// REGULAR FLOORING ////////
+//////////////////////////////////
+
+/obj/effect/floor_decal/turf/aesculapius
+	icon_state = "aesculapius"
+/obj/effect/floor_decal/turf/aesculapius/mem
+	icon_state = "mem"
+/obj/effect/floor_decal/turf/aesculapius/mento
+	icon_state = "mento"
+/obj/effect/floor_decal/turf/aesculapius/mori
+	icon_state = "mori"
+
+/obj/effect/floor_decal/turf/plating
+	icon_state = "platingfull"
+
+/obj/effect/floor_decal/turf/plate
+	icon_state = "plate"
+
+/obj/effect/floor_decal/turf/barnew
+	icon_state = "barnew"
+
+/obj/effect/floor_decal/turf/splate
+	icon_state = "shaftplating"
+
+/obj/effect/floor_decal/turf/checkers
+	icon_state = "checkers1"
+
+/obj/effect/floor_decal/turf/checkers/two
+	icon_state = "checkers2"
+
+/obj/effect/floor_decal/turf/rectangles
+	icon_state = "rectangles1"
+
+
+/obj/effect/floor_decal/turf/rectangles/two
+	icon_state = "rectangles2"
+
+/obj/effect/floor_decal/turf/brick
+	icon_state = "brick1"
+
+/obj/effect/floor_decal/turf/brick/two
+	icon_state = "brick2"
+
+/obj/effect/floor_decal/turf/metal
+	icon_state = "metal1"
+
+/obj/effect/floor_decal/turf/metal/two
+	icon_state = "metal2"
+
+/obj/effect/floor_decal/turf/metal/three
+	icon_state = "metal3"
+
+/obj/effect/floor_decal/turf/metal/four
+	icon_state = "metal4"
+
+/obj/effect/floor_decal/turf/metal/five
+	icon_state = "metal5"
+
+/obj/effect/floor_decal/turf/metal/six
+	icon_state = "metal6"
+
+/obj/effect/floor_decal/turf/metal/seven
+	icon_state = "metal7"
+
+/obj/effect/floor_decal/turf/metal/eight
+	icon_state = "metal8"
+
+/obj/effect/floor_decal/turf/metal/nine
+	icon_state = "metal9"
+
+/obj/effect/floor_decal/turf/metal/ten
+	icon_state = "metal10"
+
+/obj/effect/floor_decal/turf/metal/metal_wall
+	name = "metal wall"
+	icon_state = "2"
+
+
+/obj/effect/floor_decal/newcorner/stone
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "sborder1"
+
+/obj/effect/floor_decal/newcorner/stone/corner
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "sborder2"
+
+/obj/effect/floor_decal/newcorner/caveramp
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "caveramp"
+
+/obj/effect/floor_decal/newcorner/grass
+	icon = 'icons/map_project/furniture_and_decor.dmi'
+	icon_state = "grass1"
+
+/obj/effect/floor_decal/newcorner/trench_flooring
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "trench_flooring"
+
+/obj/effect/floor_decal/newcorner/mine_walls
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "2"
+
+/obj/effect/floor_decal/newcorner/rails
+	icon = 'icons/map_project/furniture_and_decor.dmi'
+	icon_state = "rail"
+	color = "grey" // Else it looks too shining and does not fit
+
+/obj/effect/floor_decal/newcorner/crater_big
+	icon = 'icons/turf/trenches_turfs.dmi'
+	icon_state = "l1"
+
+/obj/effect/floor_decal/newcorner/crater_small
+	icon = 'icons/turf/trenches_turfs.dmi'
+	icon_state = "crater"
+
+/obj/effect/floor_decal/newcorner/entrace
+	icon = 'icons/map_project/gate.dmi'
+	icon_state = "entrance"
+
+/obj/effect/floor_decal/newcorner/brokenwood
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_state = "wood_broken0"

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -41,37 +41,6 @@
 	light_power = 2
 	light_color = COLOR_BLACK
 
-/turf/simulated/floor/wood
-	name = "wooden floor"
-	icon = 'icons/turf/flooring/wood.dmi'
-	icon_state = "wood"
-	color = WOOD_COLOR_GENERIC
-	initial_flooring = /singleton/flooring/wood
-
-/turf/simulated/floor/wood/mahogany
-	color = WOOD_COLOR_RICH
-	initial_flooring = /singleton/flooring/wood/mahogany
-
-/turf/simulated/floor/wood/maple
-	color = WOOD_COLOR_PALE
-	initial_flooring = /singleton/flooring/wood/maple
-
-/turf/simulated/floor/wood/ebony
-	color = WOOD_COLOR_BLACK
-	initial_flooring = /singleton/flooring/wood/ebony
-
-/turf/simulated/floor/wood/walnut
-	color = WOOD_COLOR_CHOCOLATE
-	initial_flooring = /singleton/flooring/wood/walnut
-
-/turf/simulated/floor/wood/bamboo
-	color = WOOD_COLOR_PALE2
-	initial_flooring = /singleton/flooring/wood/bamboo
-
-/turf/simulated/floor/wood/yew
-	color = WOOD_COLOR_YELLOW
-	initial_flooring = /singleton/flooring/wood/yew
-
 /turf/simulated/floor/grass
 	name = "grass patch"
 	icon = 'icons/turf/flooring/grass.dmi'
@@ -87,57 +56,6 @@
 
 /turf/simulated/floor/grass/cut
 	initial_flooring = /singleton/flooring/grass/cut
-
-/turf/simulated/floor/carpet
-	name = "brown carpet"
-	icon = 'icons/turf/flooring/carpet.dmi'
-	icon_state = "brown"
-	initial_flooring = /singleton/flooring/carpet
-
-/turf/simulated/floor/carpet/blue
-	name = "blue carpet"
-	icon_state = "blue1"
-	initial_flooring = /singleton/flooring/carpet/blue
-
-/turf/simulated/floor/carpet/blue2
-	name = "pale blue carpet"
-	icon_state = "blue2"
-	initial_flooring = /singleton/flooring/carpet/blue2
-
-/turf/simulated/floor/carpet/blue3
-	name = "sea blue carpet"
-	icon_state = "blue3"
-	initial_flooring = /singleton/flooring/carpet/blue3
-
-/turf/simulated/floor/carpet/magenta
-	name = "magenta carpet"
-	icon_state = "magenta"
-	initial_flooring = /singleton/flooring/carpet/magenta
-
-/turf/simulated/floor/carpet/purple
-	name = "purple carpet"
-	icon_state = "purple"
-	initial_flooring = /singleton/flooring/carpet/purple
-
-/turf/simulated/floor/carpet/orange
-	name = "orange carpet"
-	icon_state = "orange"
-	initial_flooring = /singleton/flooring/carpet/orange
-
-/turf/simulated/floor/carpet/green
-	name = "green carpet"
-	icon_state = "green"
-	initial_flooring = /singleton/flooring/carpet/green
-
-/turf/simulated/floor/carpet/red
-	name = "red carpet"
-	icon_state = "red"
-	initial_flooring = /singleton/flooring/carpet/red
-
-/turf/simulated/floor/carpet/black
-	name = "black carpet"
-	icon_state = "black"
-	initial_flooring = /singleton/flooring/carpet/black
 
 /turf/simulated/floor/reinforced
 	name = "reinforced floor"
@@ -416,3 +334,369 @@
 			SPAN_WARNING("You feel your entire body tingle, and something pulling you away!")
 		)
 		addtimer(new Callback(GLOBAL_PROC, /proc/do_unstable_teleport_safe, L, GetConnectedZlevels(L.z)), rand(5, 15))
+
+// WARHAMMER 40k //
+
+/turf/simulated/floor/wood
+	name = "wooden floor"
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_state = "wood"
+	color = WOOD_COLOR_GENERIC
+	initial_flooring = /singleton/flooring/wood
+
+/turf/simulated/floor/wood/mahogany
+	color = WOOD_COLOR_RICH
+	initial_flooring = /singleton/flooring/wood/mahogany
+
+/turf/simulated/floor/wood/maple
+	color = WOOD_COLOR_PALE
+	initial_flooring = /singleton/flooring/wood/maple
+
+/turf/simulated/floor/wood/ebony
+	color = WOOD_COLOR_BLACK
+	initial_flooring = /singleton/flooring/wood/ebony
+
+/turf/simulated/floor/wood/walnut
+	color = WOOD_COLOR_CHOCOLATE
+	initial_flooring = /singleton/flooring/wood/walnut
+
+/turf/simulated/floor/wood/bamboo
+	color = WOOD_COLOR_PALE2
+	initial_flooring = /singleton/flooring/wood/bamboo
+
+/turf/simulated/floor/wood/yew
+	color = WOOD_COLOR_YELLOW
+	initial_flooring = /singleton/flooring/wood/yew
+
+/turf/simulated/floor/new_wood
+	name = "wooden floor"
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_state = "new_wood"
+	initial_flooring = /singleton/flooring/new_wood
+
+/turf/simulated/floor/new_wood/two
+	icon_state = "new_wood2"
+
+/turf/simulated/floor/new_wood/three
+	icon_state = "new_wood3"
+
+/turf/simulated/floor/new_wood/four
+	icon_state = "new_wood4"
+/turf/simulated/floor/new_wood/five
+	icon_state = "new_wood5"
+/turf/simulated/floor/new_wood/six
+	icon_state = "new_wood6"
+/turf/simulated/floor/new_wood/seven
+	icon_state = "new_wood7"
+/turf/simulated/floor/new_wood/eight
+	icon_state = "new_wood8"
+/turf/simulated/floor/new_wood/nine
+	icon_state = "new_wood9"
+
+/turf/simulated/floor/stone
+	name = "stone floor"
+	icon = 'icons/turf/flooring/stonefloor.dmi'
+	icon_state = "MAIN"
+	initial_flooring = /singleton/flooring/stone
+
+/turf/simulated/floor/stone/chapel
+	name = "monastic stone floor"
+	holy = 1
+
+/turf/simulated/floor/stone/New()
+	icon_state = pick("main","1","2","3","extra","extra1","extra2","extra3")
+	..()
+
+/turf/simulated/floor/seolite
+	name = "Seolite floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "cluster"
+
+/turf/simulated/floor/tiled/stone
+	name = "stone tiled floor"
+	icon = 'icons/turf/flooring/tiles.dmi'
+	icon_state = "stone"
+	color = "#808080"
+	initial_flooring = /singleton/flooring/tiling/stone
+
+/turf/simulated/floor/carpet
+	name = "brown carpet"
+	icon = 'icons/turf/flooring/carpet.dmi'
+	icon_state = "brown"
+	initial_flooring = /singleton/flooring/carpet
+
+/turf/simulated/floor/carpet/blue
+	name = "blue carpet"
+	icon_state = "blue1"
+	initial_flooring = /singleton/flooring/carpet/blue
+
+/turf/simulated/floor/carpet/blue2
+	name = "pale blue carpet"
+	icon_state = "blue2"
+	initial_flooring = /singleton/flooring/carpet/blue2
+
+/turf/simulated/floor/carpet/blue3
+	name = "sea blue carpet"
+	icon_state = "blue3"
+	initial_flooring = /singleton/flooring/carpet/blue3
+
+/turf/simulated/floor/carpet/magenta
+	name = "magenta carpet"
+	icon_state = "magenta"
+	initial_flooring = /singleton/flooring/carpet/magenta
+
+/turf/simulated/floor/carpet/purple
+	name = "purple carpet"
+	icon_state = "purple"
+	initial_flooring = /singleton/flooring/carpet/purple
+
+/turf/simulated/floor/carpet/orange
+	name = "orange carpet"
+	icon_state = "orange"
+	initial_flooring = /singleton/flooring/carpet/orange
+
+/turf/simulated/floor/carpet/green
+	name = "green carpet"
+	icon_state = "green"
+	initial_flooring = /singleton/flooring/carpet/green
+
+/turf/simulated/floor/carpet/red
+	name = "red carpet"
+	icon_state = "red"
+	initial_flooring = /singleton/flooring/carpet/red
+
+/turf/simulated/floor/carpet/black
+	name = "black carpet"
+	icon_state = "black"
+	initial_flooring = /singleton/flooring/carpet/black
+
+/turf/simulated/floor/tiled/dark
+	name = "dark floor"
+	icon_state = "dark"
+	initial_flooring = /singleton/flooring/tiling/dark
+
+/turf/simulated/floor/tiled/ramp
+	name = "foot ramp"
+	icon = 'icons/turf/flooring/tiles.dmi'
+	icon_state = "ramptop"
+	initial_flooring = /singleton/flooring/reinforced/ramp
+
+/turf/simulated/floor/tiled/ramp/bottom
+	name = "foot ramp"
+	icon = 'icons/turf/flooring/tiles.dmi'
+	icon_state = "rampbot"
+	initial_flooring = /singleton/flooring/reinforced/ramp/bottom
+
+/turf/simulated/floor/concrete
+	name = "concrete floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "concrete"
+
+/turf/simulated/floor/darkfloor
+	name = "steel dark floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "steel_dark"
+
+/turf/simulated/floor/darksteel_floor
+	name = "steel floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "steelnew"
+
+/turf/simulated/floor/surface_floor
+	name = "surface"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "surface"
+
+/turf/simulated/floor/factory_floor
+	name = "plated floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "lev"
+
+// Ceramic Flooring
+
+/turf/simulated/floor/ceramic
+	name = "ceramic flooring"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "newstone2"
+
+/turf/simulated/floor/ceramic/surgery
+	name = "grey ceramic flooring"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "surgery"
+
+/turf/simulated/floor/ceramic/surgery2
+	name = "grey ceramic flooring"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "surgery2"
+
+/turf/simulated/floor/ceramic/old
+	name = "ceramic flooring"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "newstone4"
+
+/turf/simulated/floor/ceramic/blackstone
+	name = "black ceramic flooring"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "bluestone2"
+
+// Wooden flooring
+
+/turf/simulated/floor/darkwood
+	name = "wooden floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "dark_wood"
+
+/turf/simulated/floor/darkwood/rotten
+	name = "decrepit wooden floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "troom3"
+
+// Fancy floors (For the Gov or some housing)
+
+/turf/simulated/floor/fancyfloor
+	name = "fancy floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "metrofull"
+
+/turf/simulated/floor/fancyfloor/edges
+	name = "fancy floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "metroedges"
+
+/turf/simulated/floor/fancyfloor/marble
+	name = "marble floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "marbletile"
+
+/turf/simulated/floor/fancyfloor/coralg
+	name = "coral granite floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "coralgranite"
+
+/turf/simulated/floor/fancyfloor/gray_white
+	name = "gray & white flooring"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "graywhite"
+
+/turf/simulated/floor/fancyfloor/carpet
+	name = "red carpet"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "carpbet2side"
+
+/turf/simulated/floor/fancyfloor/carpet/middle
+	name = "red carpet"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "carpbet2"
+
+/turf/simulated/floor/fancyfloor/carpet/grey
+	name = "grey carpet"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "carpet2side"
+
+/turf/simulated/floor/fancyfloor/carpet/grey/middle
+	name = "grey carpet"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "carpet2"
+
+/turf/simulated/floor/fancyfloor/carpet/blue
+	name = "blue carpet"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "blucarpet2side"
+
+/turf/simulated/floor/fancyfloor/carpet/blue/middle
+	name = "blue carpet"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "carpet3"
+
+/turf/simulated/floor/fancyfloor/carpet/green
+	name = "green carpet"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "carpbet23side"
+
+/turf/simulated/floor/fancyfloor/carpet/green/middle
+	name = "green carpet"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "carpet0"
+
+/turf/simulated/floor/fancyfloor/oldcobble
+	name = "old cobblestone"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "stonefloor4"
+
+/turf/simulated/floor/fancyfloor/ancient_cobble_old
+	name = "dark cobble floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "stone_old"
+
+//broken varients of wood turf
+
+/turf/simulated/floor/fancyfloor/brokenfloor0
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_state = "wood_broken0"
+
+/turf/simulated/floor/fancyfloor/brokenfloor1
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_state = "wood_broken1"
+
+/turf/simulated/floor/fancyfloor/brokenfloor2
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_state = "wood_broken2"
+
+/turf/simulated/floor/fancyfloor/brokenfloor3
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_state = "wood_broken3"
+
+/turf/simulated/floor/fancyfloor/brokenfloor4
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_state = "wood_broken4"
+
+/turf/simulated/floor/fancyfloor/brokenfloor5
+	icon = 'icons/turf/flooring/wood.dmi'
+	icon_state = "wood_broken5"
+
+// Stone Flooring here
+
+/turf/simulated/floor/stone/crafted_floor
+	name = "stone path"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "stonecrafted"
+
+/turf/simulated/floor/stone/old
+	name = "old stone floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "stonefloor"
+
+/turf/simulated/floor/stone/old2
+	name = "old stone floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "stonefloor2"
+
+/turf/simulated/floor/stone/old3
+	name = "old stone floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "stonefloor3"
+
+/turf/simulated/floor/stone/old4
+	name = "old stone floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "stonefloor4"
+
+/turf/simulated/floor/stone/ancient_stone_floor
+	name = "ancient stone floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "stoney"
+
+/turf/simulated/floor/stone/ancient_stone_old
+	name = "ancient stone floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "stone_old"
+
+/turf/simulated/floor/stone/ancient_stone_floor3
+	name = "ancient stone floor"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "stoning"
+
+/turf/simulated/floor/stone/seabed
+	name = "seabed"
+	icon = 'icons/turf/flooring/plating.dmi'
+	icon_state = "seabed"

--- a/code/game/turfs/hive_content.dm
+++ b/code/game/turfs/hive_content.dm
@@ -1,0 +1,91 @@
+/* MAP STUFF
+
+Here's what i added, ported and edited and for the sake of the map, there's a lot of lacking sprites so i will add them here - Graf
+
+Be aware that i was not paid to add all of these, just did it for the sake of doing a fancier map than the original one that is currently there,
+so dont come complaining about it.
+
+This file includes multiple new turfs, structures, items, and code things, i'd really suggest NONE to try and port these, you're gonna have a
+SHIT time just like i did.
+
+*/
+
+// FLOORING
+
+
+
+//*
+
+///// Defenses & Some Fences somewhat (just a reskinned Grille, i really dont want to code all of this new content aaaaaaa) /////
+
+
+
+
+
+
+
+
+
+
+///// DECORATION & FURNITURE - More furniture to decorate some areas with, mainly Governor. /////
+
+// THRONES - Just a fancy way of saying 'Chairs that dont have different directions'
+
+
+
+///// CLOSETS ///// - More decoration
+
+
+
+///// EFFECTS (Just decoration for map stuff)
+
+
+
+
+
+
+// HIVE DECORATION - BIG THINGS SUCH AS STATUES AND THE LIKE HERE
+
+
+
+// CHAOS DRIIIIIIIIIIIIIIINKS - Im bored and this has been lying there for fucking 8 years without use, time to do something with it.
+
+
+
+
+
+
+
+
+// CANDLE/CANDELABRA STUFF & MISC - Cause the other candles were not coded in, gonna put it here guhhh
+
+
+
+
+
+// CASSETTE EASTER EGGS - NOTE: I do it on the icon folder cause my computer for some reason will instantly freeze and die on the blue screen when opening any byond ogg folder - Graf
+
+
+
+
+
+
+
+// MOBS - Very few
+
+
+
+// A thanks for one of my best friends for helping me with the map & giving ideas and suggestions, helmet coming from my old 2019 server so that's why it's odd - Graf
+
+
+
+// Hostile Mobs for Dungeons or in the Magos Biologis Xeno Research Area
+
+
+
+// CLOTHES - Might not port them considering it's such an annoying process and it makes me want to blow my brains out.
+
+
+
+
+

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -214,3 +214,447 @@
 	if (HAS_FLAGS(damage_flags, DAMAGE_FLAG_TURF_BREAKER))
 		damage *= 4
 	. = ..()
+
+/* fix me later
+
+// 40k Dirt
+
+//Dirt!
+/turf/simulated/floor/dirty
+	name = "dirt" //"snowy dirt"
+	icon = 'icons/turf/dirt.dmi'
+	icon_state = "dirt1"
+	movement_delay = 0.1
+	atom_flags = ATOM_FLAG_CLIMBABLE
+	has_coldbreath = FALSE // No more freezing to death indoors.
+	var/has_light = FALSE
+	var/can_generate_water = FALSE // NO MORE RNG WATER> PLACE THE TILES YOURSELF YOU LAZY MAPPERS
+	var/can_be_dug = TRUE
+
+/turf/simulated/floor/dirty/fake
+	desc = "This dirt isn't climbable"
+	atom_flags = null
+	can_generate_water = FALSE
+	can_be_dug = TRUE
+
+/turf/simulated/floor/dirty/tough //this is meant to be the default undiggiable. You can dig it for now though
+	name = "tough dirt"
+	desc = "This dirt may or may not be diggable"
+	can_be_dug = TRUE
+
+/turf/simulated/floor/dirty/tough/lightless
+	can_be_dug = TRUE
+	has_light = FALSE
+
+/turf/simulated/floor/dirty/tough/fake //Can't be click dragged on.
+	desc = "This dirt isn't climbable"
+	atom_flags = null
+
+/turf/simulated/floor/dirty/tough/lightless/fake
+	atom_flags = null
+
+/turf/simulated/floor/dirty/tough/ex_act(severity)//Can't be blown up.
+	return
+
+/turf/simulated/floor/dirty/CanPass(atom/movable/mover, turf/target)
+	if(ishuman(mover))
+		if(istype(get_turf(mover), /turf/simulated/floor/trench))
+			if(!mover.pulledby)
+				return FALSE
+
+	return TRUE
+
+/turf/simulated/floor/dirty/can_climb(var/mob/living/user, post_climb_check=0)
+	if (!(atom_flags & ATOM_FLAG_CLIMBABLE) || !can_touch(user))
+		return FALSE
+
+	if (!user.Adjacent(src))
+		to_chat(user, "<span class='danger'>You can't climb there, the way is blocked.</span>")
+		return FALSE
+
+	return TRUE
+
+/turf/simulated/floor/dirty/do_climb(var/mob/living/user)
+	if(!can_climb(user))
+		return
+/*
+	if(istype(get_area(src), /area/warfare/battlefield/no_mans_land))//We're trying to go into no man's land?
+		if(locate(/obj/item/device/boombox) in user)//Locate the boombox.
+			to_chat(user, "I can't bring this with me onto the battlefield. Wouldn't want to lose it.")//No you fucking don't.
+			return //Keep that boombox at base asshole.
+		if(locate(/obj/item/storage) in user)//Gotta check storage as well.
+			var/obj/item/storage/S = locate() in user
+			if(locate(/obj/item/device/boombox) in S)
+				to_chat(user, "I can't bring this with me onto the battlefield. Wouldn't want to lose it.")
+				return
+*/
+	user.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
+	climbers |= user
+
+	if(!can_climb(user))
+		climbers -= user
+		return
+
+	if(!do_after(user,15))
+		climbers -= user
+		return
+
+	user.forceMove(get_turf(src))
+	user.visible_message("<span class='warning'>[user] climbed onto \the [src]!</span>")
+	climbers -= user
+
+/turf/simulated/floor/dirty/MouseDrop_T(mob/target, mob/user)
+	var/mob/living/H = user
+	if(istype(H) && can_climb(H) && target == user)
+		do_climb(target)
+	else
+		return ..()
+
+/turf/simulated/floor/dirty/indestructable/snow
+	name = "snow"
+	icon = 'icons/turf/snow.dmi'
+	icon_state = "snow"
+
+/turf/simulated/floor/dirty/indestructable/snow/New()
+	icon_state = pick("snow[rand(1,12)]","snow0")
+	..()
+
+/turf/simulated/floor/dirty/New()
+	..()
+	temperature = T0C - 60
+	//icon_state = pick("snow[rand(1,12)]","snow0")
+	dir = pick(GLOB.alldirs)
+	if(!(locate(/obj/effect/lighting_dummy/daylight) in src) && has_light)
+		new /obj/effect/lighting_dummy/daylight(src)
+	spawn(1)
+		overlays.Cut()
+	if(loc.type != /area/warfare/battlefield/no_mans_land) // no base puddles
+		return
+	if(!can_generate_water)//This type can't generate water so don't bother.
+		return
+
+/turf/simulated/floor/dirty/attackby(obj/O as obj, mob/living/user as mob)
+	if(istype(O, /obj/item/shovel))
+		if(!user.doing_something)
+			user.doing_something = TRUE
+			if(src.density)
+				user.doing_something = FALSE
+				return
+			for(var/obj/structure/object in contents)
+				if(object)
+					to_chat(user, "There are things in the way.")
+					user.doing_something = FALSE
+					return
+			playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
+			visible_message("[user] begins to dig some dirt cover!")
+			if(do_after(user, (backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 10)))
+				new /obj/structure/dirt_wall(src)
+				visible_message("[user] finishes digging the dirt cover.")
+				playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)
+
+			user.doing_something = FALSE
+
+		else
+			to_chat(user, "You're already digging.")
+
+/turf/simulated/floor/dirty/RightClick(mob/living/user)
+	if(!CanPhysicallyInteract(user))
+		return
+	var/obj/item/shovel/S = user.get_active_hand()
+	if(!istype(S))
+		return
+	if(!can_be_dug)//No escaping to mid early.
+		return
+	if(!user.doing_something)
+		user.doing_something = TRUE
+		if(src.density)
+			user.doing_something = FALSE
+			return
+		for(var/obj/structure/object in contents)
+			if(object)
+				to_chat(user, "There are things in the way.")
+				user.doing_something = FALSE
+				return
+		playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
+		visible_message("[user] begins to dig a trench!")
+		if(do_after(user, backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 10))
+			ChangeTurf(/turf/simulated/floor/trench)
+			visible_message("[user] finishes digging the trench.")
+			playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)
+			user.doing_something = FALSE
+
+		user.doing_something = FALSE
+
+	else
+		to_chat(user, "You're already digging.")
+
+
+/turf/simulated/floor/snow/RightClick(mob/living/user)
+	if(!CanPhysicallyInteract(user))
+		return
+	var/obj/item/shovel/S = user.get_active_hand()
+	if(!istype(S))
+		return
+	if(!can_be_dug)//No escaping to mid early.
+		return
+	if(!user.doing_something)
+		user.doing_something = TRUE
+		if(src.density)
+			user.doing_something = FALSE
+			return
+		for(var/obj/structure/object in contents)
+			if(object)
+				to_chat(user, "There are things in the way.")
+				user.doing_something = FALSE
+				return
+		playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
+		visible_message("[user] begins to dig a trench!")
+		if(do_after(user, backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 10))
+			ChangeTurf(/turf/simulated/floor/trench)
+			visible_message("[user] finishes digging the trench.")
+			playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)
+			user.doing_something = FALSE
+
+		user.doing_something = FALSE
+
+	else
+		to_chat(user, "You're already digging.")
+
+
+/turf/simulated/floor/snow/attackby(obj/O as obj, mob/living/user as mob)
+	if(istype(O, /obj/item/shovel))
+		if(!user.doing_something)
+			user.doing_something = TRUE
+			if(src.density)
+				user.doing_something = FALSE
+				return
+			for(var/obj/structure/object in contents)
+				if(object)
+					to_chat(user, "There are things in the way.")
+					user.doing_something = FALSE
+					return
+			playsound(src, 'sound/effects/dig_shovel.ogg', 50, 0)
+			visible_message("[user] begins to dig a grave!")
+			if(do_after(user, (backwards_skill_scale(user.SKILL_LEVEL(engineering)) * 10)))
+				new /obj/structure/closet/pit(src)
+				visible_message("[user] finishes digging the grave!")
+				playsound(src, 'sound/effects/empty_shovel.ogg', 50, 0)
+
+			user.doing_something = FALSE
+
+		else
+			to_chat(user, "You're already digging.")
+
+
+/turf/simulated/floor/dirty/update_dirt()
+	return	// Dirt doesn't doesn't become dirty
+
+/turf/simulated/floor/dirty/indestructable
+	desc = "This dirt seems tougher than most other dirts."
+
+/turf/simulated/floor/dirty/indestructable/mud
+	name = "mud"
+	desc = "This mud looks tougher than most other muds."
+	icon_state = "mud"
+	movement_delay = 0.1
+
+/turf/simulated/floor/dirty/indestructable/mud/New()
+	dir = pick(GLOB.alldirs)
+	..()
+
+/turf/simulated/floor/dirty/indestructable/ex_act(severity)//Can't be blown up.
+	return
+
+/turf/simulated/floor/dirty/indestructable/lightless
+	has_light = FALSE
+
+/turf/simulated/floor/dirty/indestructable/lightless/has_trees
+
+/////////
+//WATER//
+/////////
+/turf/simulated/floor/exoplanet/water/shallow
+	name = "water"
+	icon = 'icons/turf/dirt.dmi'//This appears under the water.
+	icon_state = "mud"
+	movement_delay = 1
+	mudpit = 1
+	has_coldbreath = TRUE
+	var/has_light = TRUE
+	atom_flags = ATOM_FLAG_CLIMBABLE
+
+/turf/simulated/floor/exoplanet/water/shallow/update_dirt()
+	return
+
+/turf/simulated/floor/exoplanet/water/shallow/ex_act(severity)
+	return
+
+/turf/simulated/floor/exoplanet/water/shallow/CanPass(atom/movable/mover, turf/target)
+	if(ishuman(mover))
+		if(istype(get_turf(mover), /turf/simulated/floor/trench))
+			if(!mover.pulledby)
+				return FALSE
+
+	return TRUE
+
+/turf/simulated/floor/exoplanet/water/shallow/can_climb(var/mob/living/user, post_climb_check=0)
+	if (!(atom_flags & ATOM_FLAG_CLIMBABLE) || !can_touch(user))
+		return FALSE
+
+	if (!user.Adjacent(src))
+		to_chat(user, "<span class='danger'>You can't climb there, the way is blocked.</span>")
+		return FALSE
+
+	return TRUE
+
+/turf/simulated/floor/exoplanet/water/shallow/do_climb(var/mob/living/user)
+	if(!can_climb(user))
+		return
+
+	user.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
+	climbers |= user
+
+	if(!can_climb(user))
+		climbers -= user
+		return
+
+	if(!do_after(user,15))
+		climbers -= user
+		return
+
+	user.forceMove(get_turf(src))
+	user.visible_message("<span class='warning'>[user] climbed onto \the [src]!</span>")
+	climbers -= user
+
+/turf/simulated/floor/exoplanet/water/shallow/MouseDrop_T(mob/target, mob/user)
+	var/mob/living/H = user
+	if(istype(H) && can_climb(H) && target == user)
+		if(istype(get_area(src), /area/warfare/battlefield/no_mans_land))//We're trying to go into no man's land?
+			if(locate(/obj/item/device/boombox) in user)//Locate the boombox.
+				to_chat(user, "I can't bring this with me onto the battlefield. Wouldn't want to lose it.")//No you fucking don't.
+				return //Keep that boombox at base asshole.
+			if(locate(/obj/item/storage) in user)//Gotta check storage as well.
+				var/obj/item/storage/S = locate() in user
+				if(locate(/obj/item/device/boombox) in S)
+					to_chat(user, "I can't bring this with me onto the battlefield. Wouldn't want to lose it.")
+					return
+		do_climb(target)
+	else
+		return ..()
+
+/turf/simulated/floor/exoplanet/water/shallow/Cross(var/atom/A)//People who are on fire go out.
+	if(isliving(A))
+		var/mob/living/L = A
+		L.ExtinguishMob()
+
+/turf/simulated/floor/exoplanet/water/shallow/lightless
+	has_light = FALSE
+
+/turf/simulated/floor/exoplanet/water/shallow/New()
+	..()
+	if((!locate(/obj/effect/lighting_dummy/daylight) in src) && has_light)
+		new /obj/effect/lighting_dummy/daylight(src)
+	temperature = T0C - 80
+	for(var/obj/effect/water/bottom/B in src)
+		if(B)
+			qdel(B)
+	for(var/obj/effect/water/top/T in src)
+		if(T)
+			qdel(T)
+
+	new /obj/effect/water/bottom(src)//Put it right on top of the water so that they look like they're the same.
+	new /obj/effect/water/top(src)
+	spawn(5)
+		update_icon()
+		for(var/turf/simulated/floor/exoplanet/water/shallow/T in range(1))
+			T.update_icon()
+
+/turf/simulated/floor/exoplanet/water/shallow/update_icon()
+
+	overlays.Cut()
+	for(var/direction in GLOB.cardinal)
+		var/turf/turf_to_check = get_step(src,direction)
+		if(istype(turf_to_check, /turf/simulated/floor/exoplanet/water/shallow))
+			continue
+
+		else if(istype(turf_to_check, /turf/simulated))
+			var/image/water_side = image('icons/obj/warfare.dmi', "over_water1", dir = direction)//turn(direction, 180))
+			water_side.plane = EFFECTS_BELOW_LIGHTING_PLANE
+
+			overlays += water_side
+		var/image/wave_overlay = image('icons/obj/warfare.dmi', "waves")
+		overlays += wave_overlay
+
+/turf/simulated/floor/exoplanet/water/shallow/Destroy()
+	. = ..()
+	for(var/obj/effect/water/bottom/B in src)
+		qdel(B)
+	for(var/obj/effect/water/top/T in src)
+		qdel(T)
+
+/turf/simulated/floor/exoplanet/water/shallow/attackby(obj/item/O, mob/user)
+	if(istype(O, /obj/item/reagent_containers))
+		var/obj/item/reagent_containers/RG = O
+		if (istype(RG) && RG.is_open_container())
+			RG.reagents.add_reagent(/datum/reagent/water, min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
+			user.visible_message("<span class='notice'>[user] fills \the [RG] using \the [src].</span>","<span class='notice'>You fill \the [RG] using \the [src].</span>")
+			return 1
+
+	if (istype(O, /obj/item/stack/duckboard))
+		var/obj/item/stack/duckboard/S = O
+		if (S.get_amount() < 1)
+			return
+		playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+		S.use(1)
+		ChangeTurf(/turf/simulated/floor/trenches)
+		return
+
+/turf/simulated/floor/exoplanet/water/shallow/ChangeTurf(turf/N, tell_universe, force_lighting_update)
+	var/obj/effect/water/top/T = locate() in loc
+	if(T)
+		qdel(T)
+	var/obj/effect/water/bottom/B = locate() in loc
+	if(B)
+		qdel(B)
+	. = ..()
+	for(var/turf/simulated/floor/exoplanet/water/shallow/S in range(1))
+		S.update_icon()
+
+
+/obj/effect/water/top//This one appears over objects but under mobs.
+	name = "water"
+	icon = 'icons/obj/warfare.dmi'
+	icon_state = "trench_water_top"
+	plane = ABOVE_OBJ_PLANE
+	layer = ABOVE_OBJ_LAYER
+	density = FALSE
+	anchored = TRUE
+	mouse_opacity = FALSE
+
+/obj/effect/water/bottom//This one appears over mobs.
+	name = "water"
+	icon = 'icons/obj/warfare.dmi'
+	icon_state = "trench_water_bottom"
+	plane = ABOVE_HUMAN_PLANE
+	layer = ABOVE_HUMAN_LAYER
+	density = FALSE
+	anchored = TRUE
+	mouse_opacity = FALSE//Don't want this being clicked.
+
+/turf/simulated/floor/exoplanet/water/update_dirt()
+	return	// Water doesn't become dirty
+
+
+
+/obj/item/stack/duckboard
+	name = "duckboards"
+	singular_name = "duckboard"
+	w_class = 1
+	force = 0
+	throwforce = 0
+	max_amount = 20
+	gender = PLURAL
+	desc = "For building over water."
+	icon = 'icons/turf/trenches_turfs.dmi'
+	icon_state = "wood0"
+*/


### PR DESCRIPTION
Associated code with previous icon PR.

Ports decals, turfs, decor and content made by Graf to RogueTrader.

Also included the RND Code and edits to stockparts so that RND is accomplished via finding high tech items or archeotech research parts / exploration loot.

Please do not attempt to uncomment 'turf/simulated/floor/dirty' it needs to be refactored. Anything similarly ported that is commented is work that I don't  have time to do which will be worked on later.