### PR TITLE
RogueTrader - V1.0.4.1.5 - Armor

### DIFF
--- a/code/game/gamemodes/wizard/servant_items/champion.dm
+++ b/code/game/gamemodes/wizard/servant_items/champion.dm
@@ -12,7 +12,7 @@
 		)
 
 /obj/item/clothing/suit/champarmor
-	name = "champion's armor"
+	name = "champion's armour"
 	desc = "A mighty suit of silver and gold armor, with a gleaming blue crystal inlaid into its left gaunlet."
 	icon_state = "champarmor"
 	siemens_coefficient = 0.5

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -377,7 +377,7 @@
 
 /obj/random/loot/randomarmor
 	name = "Random Armor"
-	desc = "This is a loot spawner that spawns pilgrim and pilgrim+ level armor"
+	desc = "This is a loot spawner that spawns pilgrim and pilgrim+ level armour"
 	icon_state = "randomarmor"
 
 /obj/random/loot/randomarmor/spawn_choices()

--- a/code/game/turfs/dungeon_ship.dm
+++ b/code/game/turfs/dungeon_ship.dm
@@ -210,7 +210,7 @@ NOTE: This dungeon is made to be unforgiving, brutal and merciless, but giving e
 
 
 /obj/item/clothing/suit/armor/leper
-	name = "leper armor"
+	name = "leper armour"
 	desc = "An ancient armor from millenia ago, it's state is very much pristine and looks like it was masterfully crafted."
 	icon_state = "leper"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
@@ -233,7 +233,7 @@ NOTE: This dungeon is made to be unforgiving, brutal and merciless, but giving e
 	sales_price = 0 // Only 1 in the map
 
 /obj/item/clothing/suit/armor/cerb
-	name = "cerberus armor"
+	name = "cerberus armour"
 	desc = "A questionable armor of unknown origin, it does seem familiar though.."
 	icon_state = "TrustworthyCerberus"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS

--- a/code/modules/augment/passive/armor.dm
+++ b/code/modules/augment/passive/armor.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/internal/augment/armor
-	name = "subdermal armor"
+	name = "subdermal armour"
 	augment_slots = AUGMENT_ARMOR
 	icon_state = "armor-chest"
 	desc = "A flexible composite mesh designed to prevent tearing and puncturing of underlying tissue."

--- a/code/modules/clothing/spacesuits/captain.dm
+++ b/code/modules/clothing/spacesuits/captain.dm
@@ -21,7 +21,7 @@
 
 //Captain's space suit This is not the proper path but I don't currently know enough about how this all works to mess with it.
 /obj/item/clothing/suit/armor/captain
-	name = "Captain's armor"
+	name = "Captain's armour"
 	desc = "A bulky, heavy-duty piece of exclusive imperial armor. YOU are in charge!"
 	icon_state = "caparmor"
 	item_state_slots = list(

--- a/code/modules/clothing/suits/alien.dm
+++ b/code/modules/clothing/suits/alien.dm
@@ -52,7 +52,7 @@
 //Voxclothing
 
 /obj/item/clothing/suit/armor/vox_scrap
-	name = "rusted metal armor"
+	name = "rusted metal armour"
 	desc = "A hodgepodge of various pieces of metal scrapped together into a rudimentary vox-shaped piece of armor."
 	allowed = list(/obj/item/gun, /obj/item/tank)
 	armor = list(

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -46,7 +46,7 @@
 		)
 
 /obj/item/clothing/suit/armor/vest/old/security
-	name = "militarum armor"
+	name = "militarum armour"
 	desc = "An armored vest that protects against some damage. This one has a imperial badge."
 	icon_state = "armorsec"
 
@@ -95,7 +95,7 @@
 //Reactive armor
 //When the wearer gets hit, this armor will teleport the user a short distance away (to safety or to more danger, no one knows. That's the fun of it!)
 /obj/item/clothing/suit/armor/reactive
-	name = "reactive teleport armor"
+	name = "reactive teleport armour"
 	desc = "Someone separated our Chief Science Officer from their own head!"
 	active = 0.0
 	icon_state = "reactiveoff"
@@ -148,7 +148,7 @@
 //Non-hardsuit ERT armor.
 //Commander
 /obj/item/clothing/suit/armor/vest/ert
-	name = "asset protection command armor"
+	name = "asset protection command armour"
 	desc = "A set of armor worn by many imperial and private asset protection forces. Has blue highlights."
 	icon_state = "ertarmor_cmd"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
@@ -162,19 +162,19 @@
 
 //Security
 /obj/item/clothing/suit/armor/vest/ert/security
-	name = "asset protection militarum armor"
+	name = "asset protection militarum armour"
 	desc = "A set of armor worn by many imperial and private asset protection forces. Has red highlights."
 	icon_state = "ertarmor_sec"
 
 //Engineer
 /obj/item/clothing/suit/armor/vest/ert/engineer
-	name = "asset protection engineering armor"
+	name = "asset protection engineering armour"
 	desc = "A set of armor worn by many imperial and private asset protection forces. Has orange highlights."
 	icon_state = "ertarmor_eng"
 
 //Medical
 /obj/item/clothing/suit/armor/vest/ert/medical
-	name = "asset protection medical armor"
+	name = "asset protection medical armour"
 	desc = "A set of armor worn by many imperial and private asset protection forces. Has red and white highlights."
 	icon_state = "ertarmor_med"
 
@@ -261,7 +261,7 @@
 	icon_state = "tacwebvest"
 
 /obj/item/clothing/suit/armor/grim/storage/vest/merc
-	name = "heavy combat armor"
+	name = "heavy combat armour"
 	desc = "A high-quality armored vest made from a hard synthetic material. It is surprisingly flexible and light, despite formidable armor plating."
 	icon_state = "mercwebvest"
 	armor = list(
@@ -278,7 +278,7 @@
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS
 
 /obj/item/clothing/suit/armor/makeshift
-	name = "makeshift armor"
+	name = "makeshift armour"
 	desc = "A pair of sheets held together by rods and wires, meant to cover your upper body and back."
 	icon_state = "makeshift-armor"
 	blood_overlay_type = "armor"
@@ -300,7 +300,7 @@
 
 
 /obj/item/clothing/suit/armor/centcomm
-	name = "\improper Cent. Com. armor"
+	name = "\improper Cent. Com. armour"
 	desc = "A suit that protects against some damage."
 	icon_state = "centcom"
 	w_class = ITEM_SIZE_HUGE//bulky item
@@ -319,7 +319,7 @@
 	siemens_coefficient = 0
 
 /obj/item/clothing/suit/armor/heavy
-	name = "heavy armor"
+	name = "heavy armour"
 	desc = "A heavily armored suit that protects against moderate damage."
 	icon_state = "heavy"
 	w_class = ITEM_SIZE_HUGE//bulky item

--- a/code/modules/clothing/suits/grimarmor.dm
+++ b/code/modules/clothing/suits/grimarmor.dm
@@ -14,7 +14,7 @@
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+150
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+100
 	slowdown_general = 0.04
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-2,
@@ -60,8 +60,8 @@
 	icon_state = "explorer"
 	item_state = "explorer"
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-40 // Merc gear is outfitted for combat not extended ops
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35 // Merc gear is outfitted for combat not extended ops
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
 	slowdown_general = 0.06
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE-1,
@@ -76,14 +76,14 @@
 // MILITARUM
 
 /obj/item/clothing/suit/armor/grim/cadian
-	name = "cadian pattern flak armor"
+	name = "cadian pattern flak armour"
 	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, reinforced with heavy flak inserts for better protection in the field."
 	icon_state = "farmor"
 	item_state = "farmor"
 	body_parts_covered = LEGS|ARMS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flakheavy)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+450
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
 	slowdown_general = 0.04
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-1,
@@ -96,55 +96,22 @@
 	)
 
 /obj/item/clothing/suit/armor/grim/cadian/medicae
-	name = "cadian medicae flak armor"
+	name = "cadian medicae flak armour"
 	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, It is so common that it became symbol of the Astra Militarum as a whole. This one is in it light configuration, bearing the Red Cross of a Combat Medicae. This one is made to be lighter to accomodate movement."
 	icon_state = "medicae"
 	item_state = "medicae"
-	body_parts_covered = LEGS|ARMS
-	accessories = list(/obj/item/clothing/accessory/armor_plate/flak) // Lighter. More mobile.
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-40
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
-	slowdown_general = 0.03
-	armor = list(
-		melee = ARMOR_MELEE_FLAK-1,
-		bullet = ARMOR_BALLISTIC_FLAK-1,
-		laser = ARMOR_LASER_FLAK-1,
-		energy = ARMOR_ENERGY_MINOR-1,
-		bio = ARMOR_BIO_MINOR,
-		rad = ARMOR_RAD_MINOR,
-		bomb = ARMOR_BOMB_MINOR
-	)
-
-/obj/item/clothing/suit/armor/grim/cadian/conscript
-	name = "cadian light flak armor"
-	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, It is so common that it became symbol of the Astra Militarum as a whole. This one is in it light configuration, issued to the Whiteshields."
-	icon_state = "fvest"
-	item_state = "fvest"
-	body_parts_covered = LEGS|ARMS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+350
-	slowdown_general = 0.04
-	armor = list(
-		melee = ARMOR_MELEE_FLAK-1,
-		bullet = ARMOR_BALLISTIC_FLAK-2,
-		laser = ARMOR_LASER_FLAK-2,
-		energy = ARMOR_ENERGY_MINOR-1,
-		bio = ARMOR_BIO_MINOR,
-		rad = ARMOR_RAD_MINOR,
-		bomb = ARMOR_BOMB_MINOR
-	)
 
 /obj/item/clothing/suit/armor/grim/cadian/heavy
-	name = "cadian heavy flak armor"
+	name = "cadian heavy flak armour"
 	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, It is so common that it became symbol of the Astra Militarum as a whole. This one is in it heavy configuration"
 	icon_state = "fharmor"
 	item_state = "fharmor"
 	body_parts_covered = LEGS|ARMS // Same as regular Cadian but provides better leg/arm protection.
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flakheavy)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-55
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
-	slowdown_general = 0.07
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	slowdown_general = 0.055
 	armor = list(
 		melee = ARMOR_MELEE_FLAK+1,
 		bullet = ARMOR_BALLISTIC_FLAK+1,
@@ -155,6 +122,26 @@
 		bomb = ARMOR_BOMB_MINOR+4
 	)
 
+/obj/item/clothing/suit/armor/grim/cadian/sergeant
+	name = "cadian sergeant's carapace armour"
+	desc = "The reinforced carapace armor worn by Cadian Sergeants, offering enhanced protection with carapace inserts."
+	icon_state = "fharmor"
+	item_state = "fharmor"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-55
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE-1,
+		bullet = ARMOR_BALLISTIC_CARAPACE,
+		laser = ARMOR_LASER_CARAPACE,
+		energy = ARMOR_ENERGY_MINOR+10,
+		bio = ARMOR_BIO_MINOR+15,
+		rad = ARMOR_RAD_MINOR+25,
+		bomb = ARMOR_BOMB_MINOR+15
+	)
+
 /obj/item/clothing/suit/armor/grim/cadian/carapace
 	name = "cadian pattern carapace armour"
 	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, reinforced with carapace plates for enhanced protection in combat zones."
@@ -162,16 +149,77 @@
 	item_state = "fharmor"
 	body_parts_covered = LEGS|ARMS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-60
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
 	slowdown_general = 0.06
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE-1,
 		bullet = ARMOR_BALLISTIC_CARAPACE,
 		laser = ARMOR_LASER_CARAPACE,
-		energy = ARMOR_ENERGY_MINOR,
+		energy = ARMOR_ENERGY_MINOR+10,
 		bio = ARMOR_BIO_MINOR+15,
 		rad = ARMOR_RAD_MINOR+25,
+		bomb = ARMOR_BOMB_MINOR+15
+	)
+
+/obj/item/clothing/suit/armor/grim/krieger
+	name = "krieg overcoat"
+	desc = "A reinforced Krieg flak overcoat, resistant to environmental hazards like radiation and biohazards, with decent ballistic and thermal protection."
+	icon_state = "kriegcoat"
+	item_state = "kriegcoat"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-40
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	slowdown_general = 0.055
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK+1,
+		laser = ARMOR_LASER_FLAK+1,
+		energy = ARMOR_ENERGY_MINOR+2,
+		rad = ARMOR_RAD_MINOR+40,
+		bio = ARMOR_BIO_MINOR+40,
+		bomb = ARMOR_BOMB_MINOR+10
+	)
+
+/obj/item/clothing/suit/armor/grim/krieger/sergeant
+	name = "krieg watchmaster's overcoat"
+	desc = "The reinforced carapace overcoat of a Krieg Watchmaster, offering additional protection against hazardous environments and combat damage."
+	icon_state = "kriegcoat"
+	item_state = "kriegcoat"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	slowdown_general = 0.065 // Light carapace.
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE,
+		laser = ARMOR_LASER_CARAPACE,
+		energy = ARMOR_ENERGY_MINOR+15,
+		rad = ARMOR_RAD_MINOR+25,
+		bio = ARMOR_BIO_MINOR+15,
+		bomb = ARMOR_BOMB_MINOR+15
+	)
+
+
+/obj/item/clothing/suit/armor/grim/krieger/grenadier
+	name = "krieg grenadier overcoat"
+	desc = "A Krieg grenadier carapace-plated overcoat, offering excellent protection at the cost of movement."
+	icon_state = "grencoat"
+	item_state = "grencoat"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	slowdown_general = 0.075 // Similar to cadian carapace but heavier. Krieg gear is for slow -- defensive/siege warfare.
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE+1,
+		laser = ARMOR_LASER_CARAPACE+1,
+		energy = ARMOR_ENERGY_MINOR+15,
+		rad = ARMOR_RAD_MINOR+25,
+		bio = ARMOR_BIO_MINOR+15,
 		bomb = ARMOR_BOMB_MINOR+15
 	)
 
@@ -183,8 +231,8 @@
 	body_parts_covered = LEGS|ARMS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flaklamellar) // Flak Padding. lighter and weaker.
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+350
-	slowdown_general = 0.02
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
+	slowdown_general = 0.025
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-1,
 		bullet = ARMOR_BALLISTIC_FLAK-1,
@@ -195,15 +243,304 @@
 		bomb = ARMOR_BOMB_MINOR
 		)
 
+/obj/item/clothing/suit/armor/grim/valhallan
+	name = "valhallan overcoat"
+	desc = "A thermal flak overcoat designed for Valhallan Ice Warriors, providing standard protection against energy projectiles and blunt force."
+	icon_state = "valarmor"
+	item_state = "valarmor"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flaklamellar)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-60
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
+	slowdown_general = 0.04
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK+1,
+		energy = ARMOR_ENERGY_MINOR,
+		rad = ARMOR_RAD_MINOR+10,
+		bio = ARMOR_BIO_MINOR,
+		bomb = ARMOR_BOMB_MINOR-5
+	)
+
+/obj/item/clothing/suit/armor/grim/valhallan/medicae
+	name = "valhallan medicae vercoat"
+	desc = "A lightweight, thermally insulated Valhallan overcoat worn by Combat Medicae, offering basic protection with increased mobility."
+	icon_state = "mvalarmor"
+	item_state = "mvalarmor"
+
+/obj/item/clothing/suit/armor/grim/valhallan/sergeant
+	name = "valhalan sergeant's overcoat"
+	desc = "A Valhallan overcoat with additional markings and improved protection, worn by Sergeants."
+	body_parts_covered = LEGS | ARMS
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE-1,
+		laser = ARMOR_LASER_CARAPACE+1,
+		energy = ARMOR_ENERGY_MINOR+10,
+		bio = ARMOR_BIO_MINOR+15,
+		rad = ARMOR_RAD_MINOR+5,
+		bomb = ARMOR_BOMB_MINOR+5
+	)
+
+
+/obj/item/clothing/suit/armor/grim/maccabian
+	name = "maccabian carapace armor"
+	desc = "The standard carapace armor worn by Maccabian Jannisaries, designed for resilience in the field."
+	icon_state = "M_Armor-Icon"
+	item_state = "M_Armor-Icon"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	slowdown_general = 0.065
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE,
+		laser = ARMOR_LASER_CARAPACE,
+		energy = ARMOR_ENERGY_MINOR+10,
+		rad = ARMOR_RAD_MINOR+10,
+		bio = ARMOR_BIO_MINOR+5,
+		bomb = ARMOR_BOMB_MINOR+5
+	)
+
+/obj/item/clothing/suit/armor/grim/maccabian/sergeant
+	name = "maccabian sergeant's armor"
+	desc = "The flak armor worn by Maccabian Sergeants, reinforced with carapace plates for enhanced protection."
+	icon_state = "M_SArmor-Icon"
+	item_state = "M_SArmor-Icon"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+450
+	slowdown_general = 0.075
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE+1,
+		bullet = ARMOR_BALLISTIC_CARAPACE+1,
+		laser = ARMOR_LASER_CARAPACE+1,
+		energy = ARMOR_ENERGY_MINOR+10,
+		rad = ARMOR_RAD_MINOR+10,
+		bio = ARMOR_BIO_MINOR+5,
+		bomb = ARMOR_BOMB_MINOR+5
+	)
+
+
+/obj/item/clothing/suit/armor/grim/catachan
+	name = "catachan flak vest"
+	desc = "A light flak vest worn by Catachan Guardsmen, designed for mobility over protection."
+	icon_state = "Catachan_Vest"
+	item_state = "Catachan_Vest"
+	body_parts_covered = LEGS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
+	slowdown_general = 0
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-1,
+		energy = ARMOR_ENERGY_MINOR-2,
+		rad = ARMOR_RAD_MINOR,
+		bio = ARMOR_BIO_MINOR,
+		bomb = ARMOR_BOMB_MINOR
+	)
+
+/obj/item/clothing/suit/armor/grim/catachan/sergeant
+	name = "Catachan Sergeant's Flak Vest"
+	desc = "A decorated Catachan flak vest worn by sergeants, offering slightly better protection without compromising mobility."
+	body_parts_covered = LEGS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
+
+/obj/item/clothing/suit/armor/grim/cadian/conscript
+	name = "cadian light flak armour"
+	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, It is so common that it became symbol of the Astra Militarum as a whole. This one is in it light configuration, issued to the Whiteshields."
+	icon_state = "fvest"
+	item_state = "fvest"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-25
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+200
+	slowdown_general = 0.04
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-2,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR-1,
+		bio = ARMOR_BIO_MINOR,
+		rad = ARMOR_RAD_MINOR,
+		bomb = ARMOR_BOMB_MINOR
+	)
+
+/obj/item/clothing/suit/armor/grim/cadian/conscript/pdf
+	name = "PDF flak armour"
+	desc = "A non standard pattern of flak armour issued to planetary defense forces, this particular variant being inferior to guard issue kit."
+	icon_state = "PDF-T"
+	item_state = "PDF-T"
+
+/obj/item/clothing/suit/armor/grim/cadian/conscript/medic
+	name = "PDF medicae armour"
+	icon_state = "PDF-MedicT"
+	item_state = "PDF-MedicT"
+
+/obj/item/clothing/suit/armor/grim/cadian/conscript/spec
+	name = "PDF heavy armour"
+	icon_state = "PDF-SpecialT"
+	item_state = "PDF-SpecialT"
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flakheavy)
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR,
+		rad = ARMOR_RAD_MINOR,
+		bomb = ARMOR_BOMB_MINOR
+	)
+
+/obj/item/clothing/suit/armor/grim/commissar
+	name = "commissar's greatcoat"
+	desc = "The infamous greatcoat worn by an Imperial Commissar, reinforced with carapace-lamellar lining for additional protection."
+	icon_state = "commissar4"
+	item_state = "commissar4"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster) // There's only a handful of commissar's to a regiment. They get the good stuff.
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	slowdown_general = 0.075 // Commissar's aren't fast.
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE+1,
+		bullet = ARMOR_BALLISTIC_CARAPACE+1,
+		laser = ARMOR_LASER_CARAPACE+1,
+		energy = ARMOR_ENERGY_MINOR+20,
+		bio = ARMOR_BIO_MINOR+25,
+		rad = ARMOR_RAD_MINOR+35,
+		bomb = ARMOR_BOMB_MINOR+15
+	)
+
+/obj/item/clothing/suit/armor/grim/commissar/krieg
+	name = "commissar's breastplate"
+	desc = "The Commissar's iconic coat, this out tailored to match more of the uniform theme of the Officers of Krieg. Though the Krieg Guardsmen don't fear you, the others certainly will."
+	icon_state = "Kriegissarplate"
+	item_state = "Kriegissarplate"
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	slowdown_general = 0.065
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE,
+		laser = ARMOR_LASER_CARAPACE,
+		energy = ARMOR_ENERGY_MINOR+15,
+		rad = ARMOR_RAD_MINOR+25,
+		bio = ARMOR_BIO_MINOR+15,
+		bomb = ARMOR_BOMB_MINOR+15
+	)
+
+
+/obj/item/clothing/suit/armor/grim/commissar/catachan
+	name = "commissar's trenchjacket"
+	desc = "What used to be a decorated and custom tailored coat of the Officio Prefectus is now crudely stripped of decoration and cut down to be lighter and more breathable for the jungles of Catachan, although, also padded to be more resistant to melee attacks. Though, wearing something like this out here is more of a power move."
+	icon_state = "catacommissar"
+	item_state = "catacommissar"
+
+/obj/item/clothing/suit/armor/grim/commissar/mordian
+	name = "commissar's dress formals"
+	desc = "A Mordian Commissar's formal uniform, tailored to specifically meet regulation standards. The wearer shall make guardsman follow orders to the letter."
+	icon_state = "MordianC"
+	item_state = "MordianC"
+
+
+/obj/item/clothing/suit/armor/stormtrooper
+	name = "stormtrooper's carapace armour"
+	desc = "The carapace armor worn by Inquisitorial Stormtroopers, designed for heavy frontline combat. Shows signs of extensive use."
+	icon_state = "i-Stormtrooper Armor"
+	item_state = "i-Stormtrooper Armor"
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	slowdown_general = 0.10
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE-1, // No wasted weight on melee protection for Stormtroopers.
+		bullet = ARMOR_BALLISTIC_CARAPACE+1,
+		laser = ARMOR_LASER_CARAPACE+1,
+		energy = ARMOR_ENERGY_MINOR+15,
+		rad = ARMOR_RAD_MINOR+35,
+		bio = ARMOR_BIO_MINOR+25,
+		bomb = ARMOR_BOMB_PADDED+15
+		)
+
+/obj/item/clothing/suit/armor/grim/cadian/officer
+	name = "militarum officer's coat"
+	desc = "A formal coat worn by command staff of the Imperial Guard, reinforced with integrated carapace and armourplas plates. It has an insignia spear belonging to that of the general staff for the local Lord General Militant."
+	icon_state = "officertanjacket"
+	item_state = "officertanjacket"
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
+	body_parts_covered = LEGS | ARMS
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE-1,
+		bullet = ARMOR_BALLISTIC_CARAPACE-1,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR+5,
+		bomb = ARMOR_BOMB_MINOR+15,
+		rad = ARMOR_RAD_MINOR+10,
+		bio = ARMOR_BIO_MINOR+10
+	)
+	slowdown_general = 0.045
+
+// ORDOS / HERETIC
+/obj/item/clothing/suit/armor/grim/agent
+	name = "carapace coat"
+	desc = "A brilliantly made carapace coat for Inquisitorial Agents, adorned with holy seals and the Rosette to ward off Chaos corruption."
+	icon_state = "acolytecoat"
+	item_state = "acolytecoat"
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -40
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +400
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE + 1,
+		bullet = ARMOR_BALLISTIC_CARAPACE + 1,
+		laser = ARMOR_LASER_CARAPACE + 1,
+		energy = ARMOR_ENERGY_MINOR + 25,
+		bio = ARMOR_BIO_MINOR + 20,
+		rad = ARMOR_RAD_MINOR + 30,
+		bomb = ARMOR_BOMB_PADDED + 20
+	)
+
+/obj/item/clothing/suit/armor/grim/agent/inquisitor
+	name = "masterwork carapace coat"
+	desc = "The formidable, brilliantly made Carapace Armour for the Inquisitorial Agent, bearing the holy symbol of the Inquisition, the Rosette."
+	icon_state = "inqcoat"
+	item_state = "inqcoat"
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +500
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE + 1,
+		bullet = ARMOR_BALLISTIC_CARAPACE + 2,
+		laser = ARMOR_LASER_CARAPACE + 2,
+		energy = ARMOR_ENERGY_MINOR + 35,
+		bio = ARMOR_BIO_MINOR + 30,
+		rad = ARMOR_RAD_MINOR + 40,
+		bomb = ARMOR_BOMB_PADDED + 30
+	)
+
+
+
+
 /obj/item/clothing/suit/armor/grim/bloodpact
-	name = "Sekite Armor"
+	name = "sekite armour"
 	desc = "War torn and suited to savage needs. This is the armor of a Sekite warrior. It has certainly seen blood flown upon it."
 	icon_state = "heretmil"
 	item_state = "heretmil"
 	body_parts_covered = LEGS|ARMS // Sekites scavenge and use any armor attachments they can.
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace,/obj/item/clothing/accessory/leg_guards/reactiveslug)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+450
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
 	slowdown_general = 0.04
 	armor = list(
 		melee = ARMOR_MELEE_FLAK,
@@ -215,18 +552,17 @@
 		bomb = ARMOR_BOMB_MINOR
 	)
 
-
-
-//// ADMINISTRATUM
+//// MAGISTRATUM
 /obj/item/clothing/suit/armor/grim/bountyhunter
-	name = "bounty hunter's armor"
+	name = "bounty hunter's armour"
 	desc = "Worn by those who make a living tracking down Imperial fugitives or collecting bounties, this armor is built for mobility and resilience."
 	icon_state = "valhalla"
 	item_state = "valhalla"
 	body_parts_covered = LEGS|ARMS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-40
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+350
+	slowdown_general = 0.025
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-25
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+200
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-1,
 		bullet = ARMOR_BALLISTIC_FLAK-1,
@@ -238,12 +574,12 @@
 		)
 
 /obj/item/clothing/suit/armor/enforcermarshal
-	name = "marshal's patrol armor"
+	name = "marshal's patrol armour"
 	desc = "The carapace armor worn by Magistratum Marshals, reinforced to provide superior protection against explosions and small arms fire. Lighter than standard carapace suits but still robust."
 	icon_state = "MarshalArmor"
 	item_state = "MarshalArmor"
 	body_parts_covered = LEGS|ARMS|FULL_TORSO
-	slowdown_general = 0.12 // Hard armor sets get more slowdown for having equalized protection. They are fully superior to traditional armors with no weaknesses.
+	slowdown_general = 0.11 // Better slowdown then standard modular armors.
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
 	armor = list(
@@ -257,14 +593,14 @@
 		)
 
 /obj/item/clothing/suit/armor/enforcer2
-	name = "enforcer's patrol armor"
+	name = "enforcer's patrol armour"
 	desc = "The flak armor worn by a Magistratum Enforcer. Heavy and robust, its distinctive blue design provides superior protection against explosions and small arms fire in urban combat."
 	icon_state = "PalaniteArmor"
 	item_state = "PalaniteArmour"
 	body_parts_covered = LEGS|ARMS|FULL_TORSO
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-40
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
-	slowdown_general = 0.10
+	slowdown_general = 0.09
 	armor = list(
 		melee = ARMOR_MELEE_FLAK,
 		bullet = ARMOR_BALLISTIC_FLAK+1,
@@ -284,7 +620,7 @@
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-30
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
-	slowdown_general = 0.04
+	slowdown_general = 0.035
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-1,
 		bullet = ARMOR_BALLISTIC_FLAK-1,
@@ -301,10 +637,10 @@
 	icon_state = "enforcercoat"
 	item_state = "enforcercoat"
 	body_parts_covered = LEGS|ARMS
-	slowdown_general = 0.06
+	slowdown_general = 0.055
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy) // Heavy cheaper plates. Marshals can't have two sets of masterwork.
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+350
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-40
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE-1,
 		bullet = ARMOR_BALLISTIC_CARAPACE-1,
@@ -321,10 +657,10 @@
 	icon_state = "towntrench_heavy"
 	item_state = "towntrench_heavy"
 	body_parts_covered = LEGS|ARMS
-	slowdown_general = 0.04 // Light due to missing parts of the armor.
+	slowdown_general = 0.035 // Light due to missing parts of the armor.
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+350
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE-1,
 		bullet = ARMOR_BALLISTIC_CARAPACE-2,
@@ -336,12 +672,12 @@
 	)
 
 /obj/item/clothing/suit/armor/arbitrator
-	name = "arbitrator's carapace armor"
+	name = "arbitrator's carapace armour"
 	desc = "Worn by Magistratum Arbitrators, this carapace armor offers exceptional protection against explosives and small arms fire, balancing mobility with heavy-duty defense."
 	icon_state = "Judge"
 	item_state = "Judge"
 	body_parts_covered = LEGS|ARMS|FULL_TORSO
-	slowdown_general = 0.11 // Hard armor sets get more slowdown for having equalized protection. They are fully superior to traditional armors with no weaknesses.
+	slowdown_general = 0.1 // Hard armor sets get more slowdown for having equalized protection. They are fully superior to traditional armors with no weaknesses.
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
 	armor = list(
@@ -385,7 +721,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_INVALID_FOR_CHAMELEON
 
 /obj/item/clothing/suit/armor/riot
-	name = "heavy ganger armor"
+	name = "heavy ganger armour"
 	desc = "An armored flak suit with heavy padding to protect against melee attacks."
 	icon_state = "riotcarrier"
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_ARMS, ACCESSORY_SLOT_ARMOR_LEGS)
@@ -400,7 +736,7 @@
 		bomb = ARMOR_BOMB_MINOR-6
 		)
 	flags_inv = CLOTHING_BULKY
-	slowdown_general = 0.11
+	slowdown_general = 0.06
 	siemens_coefficient = 0.5
 	accessories = list(/obj/item/clothing/accessory/arm_guards/flak,/obj/item/clothing/accessory/leg_guards/flak)
 
@@ -412,16 +748,16 @@
 	restricted_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_ARMS, ACCESSORY_SLOT_ARMOR_LEGS)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	armor = list(
-		melee = ARMOR_MELEE_FLAK-1,
+		melee = ARMOR_MELEE_FLAK,
 		bullet = ARMOR_BALLISTIC_FLAK+2,
-		laser = ARMOR_LASER_FLAK-2,
+		laser = ARMOR_LASER_FLAK-1,
 		energy = ARMOR_ENERGY_MINOR,
 		bio = ARMOR_BIO_MINOR-8,
 		rad = ARMOR_RAD_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 		)
 	flags_inv = CLOTHING_BULKY
-	slowdown_general = 0.12
+	slowdown_general = 0.09
 	siemens_coefficient = 0.7
 
 /obj/item/clothing/suit/armor/bulletproof/vest //because apparently some map uses this somewhere and I'm too lazy to go looking for and replacing it.
@@ -437,14 +773,14 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	armor = list(
 		melee = ARMOR_MELEE_FLAK,
-		bullet = ARMOR_BALLISTIC_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK+1,
 		laser = ARMOR_LASER_FLAK+2,
 		bio = ARMOR_BIO_MINOR-8,
 		rad = ARMOR_RAD_MINOR,
 		energy = ARMOR_ENERGY_RESISTANT
 		)
 	flags_inv = CLOTHING_BULKY
-	slowdown_general = 0.13
+	slowdown_general = 0.1
 	siemens_coefficient = 0
 
 /obj/item/clothing/suit/armor/laserproof/handle_shield(mob/user, damage, atom/damage_source = null, mob/attacker = null, def_zone = null, attack_text = "the attack")

--- a/code/modules/clothing/suits/grimarmor.dm
+++ b/code/modules/clothing/suits/grimarmor.dm
@@ -123,7 +123,7 @@
 	)
 
 /obj/item/clothing/suit/armor/grim/cadian/sergeant
-	name = "cadian sergeant's carapace armour"
+	name = "cadian carapace armour"
 	desc = "The reinforced carapace armor worn by Cadian Sergeants, offering enhanced protection with carapace inserts."
 	icon_state = "fharmor"
 	item_state = "fharmor"
@@ -143,11 +143,12 @@
 	)
 
 /obj/item/clothing/suit/armor/grim/cadian/carapace
-	name = "cadian pattern carapace armour"
+	name = "cadian carapace armour"
 	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, reinforced with carapace plates for enhanced protection in combat zones."
 	icon_state = "fharmor"
 	item_state = "fharmor"
 	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
@@ -163,7 +164,7 @@
 	)
 
 /obj/item/clothing/suit/armor/grim/krieger
-	name = "krieg overcoat"
+	name = "krieg flak overcoat"
 	desc = "A reinforced Krieg flak overcoat, resistant to environmental hazards like radiation and biohazards, with decent ballistic and thermal protection."
 	icon_state = "kriegcoat"
 	item_state = "kriegcoat"
@@ -209,6 +210,7 @@
 	icon_state = "grencoat"
 	item_state = "grencoat"
 	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
@@ -244,7 +246,7 @@
 		)
 
 /obj/item/clothing/suit/armor/grim/valhallan
-	name = "valhallan overcoat"
+	name = "valhallan flak overcoat"
 	desc = "A thermal flak overcoat designed for Valhallan Ice Warriors, providing standard protection against energy projectiles and blunt force."
 	icon_state = "valarmor"
 	item_state = "valarmor"
@@ -270,8 +272,9 @@
 	item_state = "mvalarmor"
 
 /obj/item/clothing/suit/armor/grim/valhallan/sergeant
-	name = "valhalan sergeant's overcoat"
+	name = "valhalan carapace overcoat"
 	desc = "A Valhallan overcoat with additional markings and improved protection, worn by Sergeants."
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
 	body_parts_covered = LEGS | ARMS
 	slowdown_general = 0.06
 	armor = list(
@@ -284,13 +287,13 @@
 		bomb = ARMOR_BOMB_MINOR+5
 	)
 
-
 /obj/item/clothing/suit/armor/grim/maccabian
 	name = "maccabian carapace armor"
 	desc = "The standard carapace armor worn by Maccabian Jannisaries, designed for resilience in the field."
 	icon_state = "M_Armor-Icon"
 	item_state = "M_Armor-Icon"
 	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
@@ -306,11 +309,12 @@
 	)
 
 /obj/item/clothing/suit/armor/grim/maccabian/sergeant
-	name = "maccabian sergeant's armor"
+	name = "maccabian carapace armor"
 	desc = "The flak armor worn by Maccabian Sergeants, reinforced with carapace plates for enhanced protection."
 	icon_state = "M_SArmor-Icon"
 	item_state = "M_SArmor-Icon"
 	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+450
@@ -324,7 +328,6 @@
 		bio = ARMOR_BIO_MINOR+5,
 		bomb = ARMOR_BOMB_MINOR+5
 	)
-
 
 /obj/item/clothing/suit/armor/grim/catachan
 	name = "catachan flak vest"
@@ -347,7 +350,7 @@
 	)
 
 /obj/item/clothing/suit/armor/grim/catachan/sergeant
-	name = "Catachan Sergeant's Flak Vest"
+	name = "catachan flak vest"
 	desc = "A decorated Catachan flak vest worn by sergeants, offering slightly better protection without compromising mobility."
 	body_parts_covered = LEGS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
@@ -437,7 +440,6 @@
 		bomb = ARMOR_BOMB_MINOR+15
 	)
 
-
 /obj/item/clothing/suit/armor/grim/commissar/catachan
 	name = "commissar's trenchjacket"
 	desc = "What used to be a decorated and custom tailored coat of the Officio Prefectus is now crudely stripped of decoration and cut down to be lighter and more breathable for the jungles of Catachan, although, also padded to be more resistant to melee attacks. Though, wearing something like this out here is more of a power move."
@@ -450,12 +452,12 @@
 	icon_state = "MordianC"
 	item_state = "MordianC"
 
-
 /obj/item/clothing/suit/armor/stormtrooper
 	name = "stormtrooper's carapace armour"
 	desc = "The carapace armor worn by Inquisitorial Stormtroopers, designed for heavy frontline combat. Shows signs of extensive use."
 	icon_state = "i-Stormtrooper Armor"
 	item_state = "i-Stormtrooper Armor"
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	body_parts_covered = LEGS|ARMS|FULL_TORSO
 	slowdown_general = 0.10
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
@@ -496,7 +498,8 @@
 	item_state = "acolytecoat"
 	body_parts_covered = LEGS | ARMS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -40
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -45
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +400
 	slowdown_general = 0.06
 	armor = list(
@@ -504,8 +507,8 @@
 		bullet = ARMOR_BALLISTIC_CARAPACE + 1,
 		laser = ARMOR_LASER_CARAPACE + 1,
 		energy = ARMOR_ENERGY_MINOR + 25,
-		bio = ARMOR_BIO_MINOR + 20,
-		rad = ARMOR_RAD_MINOR + 30,
+		bio = ARMOR_BIO_MINOR + 30,
+		rad = ARMOR_RAD_MINOR + 40,
 		bomb = ARMOR_BOMB_PADDED + 20
 	)
 
@@ -515,22 +518,61 @@
 	icon_state = "inqcoat"
 	item_state = "inqcoat"
 	body_parts_covered = LEGS | ARMS
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -50
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +500
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -60
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
 	slowdown_general = 0.06
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE + 1,
 		bullet = ARMOR_BALLISTIC_CARAPACE + 2,
 		laser = ARMOR_LASER_CARAPACE + 2,
 		energy = ARMOR_ENERGY_MINOR + 35,
-		bio = ARMOR_BIO_MINOR + 30,
-		rad = ARMOR_RAD_MINOR + 40,
+		bio = ARMOR_BIO_MINOR + 40,
+		rad = ARMOR_RAD_MINOR + 50,
 		bomb = ARMOR_BOMB_PADDED + 30
 	)
 
+/obj/item/clothing/suit/armor/grim/agent/hereticus
+	name = "masterwork carapace coat"
+	desc = "The Inquisitor's holy coat, forged from a Tech-priest of Mars for his use in his path of holy fire toward enemies of our Emperor, Hanging from the coat a Inquisitorial Rosette, It shines brightly as if it is the Emperor himself is present, For he'll cleanse the darkness."
+	icon_state = "hereticuscoat"
+	item_state = "hereticuscoat"
+	body_parts_covered = LEGS | ARMS
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -60
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE + 1,
+		bullet = ARMOR_BALLISTIC_CARAPACE + 2,
+		laser = ARMOR_LASER_CARAPACE + 2,
+		energy = ARMOR_ENERGY_MINOR + 35,
+		bio = ARMOR_BIO_MINOR + 40,
+		rad = ARMOR_RAD_MINOR + 50,
+		bomb = ARMOR_BOMB_PADDED + 30
+	)
 
-
+/obj/item/clothing/suit/armor/inqparmor
+	name = "relic power armour"
+	desc = "This ancient and sacred power armour was forged by the tech-priests of Mars, sanctified for the Inquisitor's righteous crusade against the enemies of the Emperor. Bearing the engraved Inquisitorial Rosette, its gleaming surface radiates with the Emperor's divine light, as if his presence guides the wearer to purge the darkness."
+	icon_state = "inqarmor"
+	item_state = "inqarmor"
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1000
+	slowdown_general = 0.12 // Tiny bit slow. Design wise power armor is more rare then a lemun russ tank, it has no downsides. It simply is superior to all other armor.
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
+		laser = ARMOR_LASER_POWER_ARMOUR,
+		energy = ARMOR_ENERGY_MINOR + 55,
+		bio = ARMOR_BIO_MINOR + 84,
+		rad = ARMOR_RAD_MINOR + 86,
+		bomb = ARMOR_BOMB_PADDED + 45
+	)
 
 /obj/item/clothing/suit/armor/grim/bloodpact
 	name = "sekite armour"
@@ -538,6 +580,7 @@
 	icon_state = "heretmil"
 	item_state = "heretmil"
 	body_parts_covered = LEGS|ARMS // Sekites scavenge and use any armor attachments they can.
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace,/obj/item/clothing/accessory/leg_guards/reactiveslug)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
@@ -551,6 +594,225 @@
 		rad = ARMOR_RAD_MINOR,
 		bomb = ARMOR_BOMB_MINOR
 	)
+
+// ADEPTA SORORITAS
+/obj/item/clothing/suit/armor/sister/sacredrosepower
+	name = "sacred rose power armour"
+	desc = "The Sacred and holy Power Armour adorned by Battle Sister of the Order Of The Sacred Rose, It's illuminate the field with it glorious light, Being near it make you feels safer and secured."
+	icon_state = "sister"
+	item_state = "sister"
+	flags_inv = HIDEJUMPSUIT
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1000
+	slowdown_general = 0.11 // Slightly faster then inqisitorial, these relics are icons to the sisters and treated as extensions of the emperor.
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
+		laser = ARMOR_LASER_POWER_ARMOUR,
+		energy = ARMOR_ENERGY_MINOR + 55,
+		bio = ARMOR_BIO_MINOR + 84,
+		rad = ARMOR_RAD_MINOR + 86,
+		bomb = ARMOR_BOMB_PADDED + 45
+	)
+
+/obj/item/clothing/suit/armor/sister/repentia
+	name = "repentia carapace armour"
+	desc = "The tattered garb of a penitent sister of battle. The minimal carapace of armor is a symbol of their faith on the Repentia's deathmarch towards a glorious end."
+	icon_state = "repentia_chest"
+	item_state = "repentia_chest"
+	flags_inv = HIDEJUMPSUIT
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -25 // The temp resistance is more the sisters faith then anything.
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +250
+	slowdown_general = 0.07
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE-1,
+		bullet = ARMOR_BALLISTIC_CARAPACE-1,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR + 15,
+		bio = ARMOR_BIO_MINOR + 14,
+		rad = ARMOR_RAD_MINOR + 16,
+		bomb = ARMOR_BOMB_MINOR +15
+	)
+
+/obj/item/clothing/suit/armor/sister/martyredpower
+	name = "ourt martyred lady power armour"
+	desc = "The Sacred and holy Power Armour adorned by Battle Sister of the Order Of Our Martyred Lady. Being near it make you feels safer and secured."
+	icon_state = "mlsister"
+	item_state = "mlsister"
+	flags_inv = HIDEJUMPSUIT
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1000
+	slowdown_general = 0.11
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
+		laser = ARMOR_LASER_POWER_ARMOUR,
+		energy = ARMOR_ENERGY_MINOR + 55,
+		bio = ARMOR_BIO_MINOR + 84,
+		rad = ARMOR_RAD_MINOR + 86,
+		bomb = ARMOR_BOMB_PADDED + 45
+	)
+
+/obj/item/clothing/suit/armor/sister/bloodyrosepower
+	name = "bloody rose power armour"
+	desc = "The blood red power armor of The Order of the Bloody Rose."
+	icon_state = "brsister"
+	item_state = "brsister"
+	flags_inv = HIDEJUMPSUIT
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1000
+	slowdown_general = 0.11
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
+		laser = ARMOR_LASER_POWER_ARMOUR,
+		energy = ARMOR_ENERGY_MINOR + 55,
+		bio = ARMOR_BIO_MINOR + 84,
+		rad = ARMOR_RAD_MINOR + 86,
+		bomb = ARMOR_BOMB_PADDED + 45
+	)
+
+/obj/item/clothing/suit/armor/sister/novitae
+	name = "novitae ceramite armor"
+	desc = "The Ancient and Deconsecrated Ceramite Armour adorned by Novice Militants during their training in Messina' Monastarium. Stripped of almost all iconography and with damaged plating. It has scriptures across it's surface, recounting the triumph and martyrdom of countless saints."
+	icon_state = "ooml"
+	item_state = "ooml"
+	flags_inv = HIDEJUMPSUIT
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +500
+	slowdown_general = 0.11 // Same speed as sister but trash stats compared.
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM-1,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR-2, // 1 point above carapace
+		laser = ARMOR_LASER_POWER_ARMOUR-2,
+		energy = ARMOR_ENERGY_MINOR + 35,
+		bio = ARMOR_BIO_MINOR + 64,
+		rad = ARMOR_RAD_MINOR + 66,
+		bomb = ARMOR_BOMB_PADDED + 15
+	)
+
+// MECHANICUS
+/obj/item/clothing/suit/armor/grim/storage/hooded/magos
+	name = "Magos Biologis robes"
+	desc = "Green robes riddled with augments, scanners and syringes. The robes look incredibly old and worn, you can tell this magos has lived a long and scholarly life."
+	icon_state = "genetor"
+	item_state = "genetor"
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/mechplate)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -70
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +700
+	slowdown_general = 0.08
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_CARAPACE-2,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+	action_button_name = "Toggle Hood"
+	hoodtype = /obj/item/clothing/head/hoodiehood
+
+
+/obj/item/clothing/suit/armor/grim/storage/hooded/skitarii
+	name = "skitarii exoskeleton"
+	desc = "Tailored and reinforced by the Adeptus Mechanicus, these sturdy and protective robes are being issued to Skitarii warriors."
+	icon_state = "skitsuit"
+	item_state = "skitsuit"
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -65
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
+	slowdown_general = 0.07 // Skitarii get superior armor stats to tech priests and slowdown since they're engineered to be combat units. Tech priests aren't designed for that.
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE,
+		laser = ARMOR_LASER_CARAPACE,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+	action_button_name = "Toggle Hood"
+	hoodtype = /obj/item/clothing/head/hoodiehood
+
+/obj/item/clothing/suit/armor/grim/storage/hooded/stalker
+	name = "ruststalker exoskeleton"
+	desc = "Tailored and reinforced by the Adeptus Mechanicus, this strange armour is issued to Skitarii Ruststalkers. It shimmers oddly in the light, and seems to have storage pouches for skulls."
+	icon_state = "skitsuit"
+	item_state = "skitsuit"
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -65
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
+	slowdown_general = 0.055
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE-1,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR+10,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+5
+		)
+	action_button_name = "Toggle Hood"
+	hoodtype = /obj/item/clothing/head/hoodiehood
+
+/obj/item/clothing/suit/armor/grim/storage/hooded/vanguard
+	name = "vanguard exoskeleton"
+	desc = "Tailored and reinforced by the Adeptus Mechanicus, these heavy ceramite plates offer near-complete protection from attack."
+	icon_state = "rig-hazardhardsuit"
+	item_state = "rig-hazardhardsuit"
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -95
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +900
+	slowdown_general = 0.08
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE+1,
+		laser = ARMOR_LASER_CARAPACE+1,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+	action_button_name = "Toggle Hood"
+	hoodtype = /obj/item/clothing/head/hoodiehood
+
+/*
+
+/obj/item/clothing/suit/storage/hooded/genestealer
+	name = "tyranid chitin"
+	desc = "The hide of a Tyranid Genestealer"
+	armor = list(melee = 10, bullet = 30, laser = 30, energy = 20, bomb = 30, bio = 100, rad = 100)
+	icon_state = "gsfeet"
+	item_state = "gsfeet"
+	canremove = 0
+	unacidable = 1
+	species_restricted = list(SPECIES_TYRANID) */
 
 //// MAGISTRATUM
 /obj/item/clothing/suit/armor/grim/bountyhunter
@@ -579,6 +841,7 @@
 	icon_state = "MarshalArmor"
 	item_state = "MarshalArmor"
 	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	slowdown_general = 0.11 // Better slowdown then standard modular armors.
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
@@ -598,6 +861,7 @@
 	icon_state = "PalaniteArmor"
 	item_state = "PalaniteArmour"
 	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-40
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
 	slowdown_general = 0.09
@@ -677,6 +941,7 @@
 	icon_state = "Judge"
 	item_state = "Judge"
 	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	slowdown_general = 0.1 // Hard armor sets get more slowdown for having equalized protection. They are fully superior to traditional armors with no weaknesses.
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500

--- a/code/modules/clothing/under/accessories/armor_plate.dm
+++ b/code/modules/clothing/under/accessories/armor_plate.dm
@@ -215,6 +215,27 @@
 		bomb = ARMOR_BOMB_MINOR-2
 		)
 
+/obj/item/clothing/accessory/armor_plate/mechplate
+	name = "hazard plating"
+	desc = "A special tech hazard plating used primarily by mechanicus tech priests -- it's been ripped out..."
+	icon = 'icons/obj/clothing/obj_suit.dmi'
+	icon_state = "helmcover_green"
+	item_flags = ITEM_FLAG_THICKMATERIAL
+	color = COLOR_BEASTY_BROWN
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-70
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+700
+	slowdown = 0.08
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_CARAPACE,
+		laser = ARMOR_LASER_CARAPACE,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+
 /obj/item/clothing/accessory/armor_plate/bodyglovebio
 	name = "biohazard bodyglove" // DO NOT EVER ATTACH TO ARMOR. BODYGLOVES ARE NOT ARMOR ACCESORIES. THEY ARE UNIFORM ATTACHMENTS
 	desc = "Composed of layered polymer fibers, attached to a uniform, this chemical bodyglove offers lightweight and flexible protection, suitable for menial mechanicus duties and light exploration."

--- a/code/modules/clothing/under/accessories/armor_plate.dm
+++ b/code/modules/clothing/under/accessories/armor_plate.dm
@@ -14,8 +14,8 @@
 		bullet = ARMOR_BALLISTIC_FLAK-2,
 		laser = ARMOR_LASER_FLAK-2,
 		energy = ARMOR_ENERGY_MINOR-2,
-		bio = ARMOR_BIO_MINOR-2,
-		rad = ARMOR_RAD_MINOR,
+		bio = ARMOR_BIO_MINOR,
+		rad = ARMOR_RAD_MINOR+5,
 		bomb = ARMOR_BOMB_MINOR-2
 		)
 	slot = ACCESSORY_SLOT_ARMOR_CHEST
@@ -33,8 +33,8 @@
 		bullet = ARMOR_BALLISTIC_FLAK+1,
 		laser = ARMOR_LASER_FLAK+1,
 		energy = ARMOR_ENERGY_MINOR+1,
-		bio = ARMOR_BIO_MINOR+5,
-		rad = ARMOR_RAD_MINOR+10,
+		bio = ARMOR_BIO_MINOR+10,
+		rad = ARMOR_RAD_MINOR+20,
 		bomb = ARMOR_BOMB_MINOR+2
 		)
 	slowdown = 0.06
@@ -51,8 +51,8 @@
 		bullet = ARMOR_BALLISTIC_FLAK+2,
 		laser = ARMOR_LASER_FLAK+2,
 		energy = ARMOR_ENERGY_MINOR+2,
-		bio = ARMOR_BIO_MINOR+8,
-		rad = ARMOR_RAD_MINOR+15,
+		bio = ARMOR_BIO_MINOR+20,
+		rad = ARMOR_RAD_MINOR+30,
 		bomb = ARMOR_BOMB_MINOR+8
 		)
 	slowdown = 0.08
@@ -69,8 +69,8 @@
 		bullet = ARMOR_BALLISTIC_FLAK-1,
 		laser = ARMOR_LASER_FLAK-1,
 		energy = ARMOR_ENERGY_MINOR-1,
-		bio = ARMOR_BIO_MINOR,
-		rad = ARMOR_RAD_MINOR+5,
+		bio = ARMOR_BIO_MINOR+10,
+		rad = ARMOR_RAD_MINOR+20,
 		bomb = ARMOR_BOMB_MINOR-2
 	)
 	slowdown = 0.04 // Lighter weight, allows for better mobility
@@ -88,8 +88,8 @@
 		bullet = ARMOR_BALLISTIC_CARAPACE+1,
 		laser = ARMOR_LASER_CARAPACE+1,
 		energy = ARMOR_ENERGY_MINOR+10,
-		rad = ARMOR_RAD_MINOR+10,
-		bio = ARMOR_BIO_MINOR,
+		rad = ARMOR_RAD_MINOR+30,
+		bio = ARMOR_BIO_MINOR+20,
 		bomb = ARMOR_BOMB_PADDED-5
 		)
 
@@ -107,8 +107,8 @@
 		bullet = ARMOR_BALLISTIC_CARAPACE+2,
 		laser = ARMOR_LASER_CARAPACE+2,
 		energy = ARMOR_ENERGY_MINOR+12,
-		rad = ARMOR_RAD_MINOR+25,
-		bio = ARMOR_BIO_MINOR+15,
+		rad = ARMOR_RAD_MINOR+45,
+		bio = ARMOR_BIO_MINOR+35,
 		bomb = ARMOR_BOMB_PADDED+5
 		)
 
@@ -126,8 +126,8 @@
 		bullet = ARMOR_BALLISTIC_CARAPACE+2,
 		laser = ARMOR_LASER_CARAPACE+2,
 		energy = ARMOR_ENERGY_MINOR+12,
-		rad = ARMOR_RAD_MINOR+20,
-		bio = ARMOR_BIO_MINOR+10,
+		rad = ARMOR_RAD_MINOR+40,
+		bio = ARMOR_BIO_MINOR+20,
 		bomb = ARMOR_BOMB_PADDED
 		)
 	slowdown = 0.09
@@ -210,13 +210,13 @@
 		bullet = ARMOR_BALLISTIC_PRIMAL+1,
 		laser = ARMOR_LASER_PRIMAL+1,
 		energy = ARMOR_ENERGY_MINOR+4,
-		rad = ARMOR_RAD_RESISTANT+35,
-		bio = ARMOR_BIO_RESISTANT+35,
+		rad = ARMOR_RAD_RESISTANT+45,
+		bio = ARMOR_BIO_RESISTANT+45,
 		bomb = ARMOR_BOMB_MINOR-2
 		)
 
 /obj/item/clothing/accessory/armor_plate/bodyglovebio
-	name = "biohazard bodyglove"
+	name = "biohazard bodyglove" // DO NOT EVER ATTACH TO ARMOR. BODYGLOVES ARE NOT ARMOR ACCESORIES. THEY ARE UNIFORM ATTACHMENTS
 	desc = "Composed of layered polymer fibers, attached to a uniform, this chemical bodyglove offers lightweight and flexible protection, suitable for menial mechanicus duties and light exploration."
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	siemens_coefficient = 0.1
@@ -232,8 +232,8 @@
 	slot = ACCESSORY_SLOT_UTILITY // Worn alongside a carrier plate.
 	w_class = ITEM_SIZE_NORMAL
 	blood_overlay_type = "armor" // Bodygloves use base armor_plate temp protection.
-	icon_state = "jensen_s"
-	item_state = "jensen_s"
+	icon_state = "robotics"
+	item_state = "robotics_s"
 	slowdown = 0.03
 	flags_inv = null
 	armor = list(
@@ -263,8 +263,8 @@
 	slot = ACCESSORY_SLOT_UTILITY // Worn alongside a carrier plate.
 	w_class = ITEM_SIZE_NORMAL
 	blood_overlay_type = "armor"
-	icon_state = "jensen_s"
-	item_state = "jensen_s"
+	icon_state = "robotics"
+	item_state = "robotics_s"
 	slowdown = 0.04
 	flags_inv = null
 	armor = list(
@@ -336,7 +336,7 @@
 		)
 
 /obj/item/clothing/accessory/armor_plate/bodyglovecatachan
-	name = "catachan under armor"
+	name = "catachan under armour"
 	desc = "Made from tech polymers, attached to a uniform, this death world variant balances energy protection with advanced bio defense systems, though it is vulnerable to primitive firearms and melee attacks, it's users rarely have to worry about losing when it comes to glorious melee."
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS // SLEEVES ARE BULLSHIT
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-40

--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -636,7 +636,7 @@
 	id = "augment_booster_muscles"
 
 /datum/design/item/mechfab/augment/armor
-	name = "Subdermal armor"
+	name = "Subdermal armour"
 	build_path = /obj/item/organ/internal/augment/armor
 	materials = list(MATERIAL_STEEL = 10000, MATERIAL_GLASS = 750)
 	id = "augment_armor"


### PR DESCRIPTION
Edited armor names and descriptions slightly.

Added pressure protection to certain armors like carapace suits, so Kasrkin, etc can go into high pressure environments.

Renamed sergeant armors to be called Carapace to allow traitors to more easily blend in using stolen armors.

Added ordos, sister of battle and mechanicus armor suits. to-do; mechanicus hoodies.

Added mechanicus hazard plating which represents a tech priests robe plating. Decided tech priests would get modular chest pieces since I'd imagine they want to get archeotech plating and stick it inside themselves.

Added british spelling for armour. GW writes it that way so I'll do it as well.

Added more guard pattern suits.

Commissar coats are added. Alongside is the militarum officer's coat.