### PR TITLE
RogueTrader - V1.0.4.2 - Armor

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1664,6 +1664,8 @@
 #include "code\modules\clothing\suits\jobs.dm"
 #include "code\modules\clothing\suits\labcoat.dm"
 #include "code\modules\clothing\suits\miscellaneous.dm"
+#include "code\modules\clothing\suits\pilgrimarmor.dm"
+#include "code\modules\clothing\suits\retinuearmor.dm"
 #include "code\modules\clothing\suits\storage.dm"
 #include "code\modules\clothing\suits\toggles.dm"
 #include "code\modules\clothing\suits\utility.dm"

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -8,7 +8,7 @@
 	plural_icon_state = "rod-mult"
 	max_icon_state = "rod-max"
 	w_class = ITEM_SIZE_LARGE
-	attack_cooldown = 21
+	attack_cooldown = 7
 	melee_accuracy_bonus = -5
 	throw_speed = 5
 	throw_range = 20

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -29,7 +29,7 @@
 	desc = "A large, unwieldy blade haphazardly tied together with rod and wire. The weapon of the modern caveman."
 	icon_state = "makeshift_sword"
 	force_multiplier = 0.3
-	attack_cooldown = 30 // slow.
+	attack_cooldown = 8
 	thrown_force_multiplier = 0.2
 	base_parry_chance = 15
 	worth_multiplier = 5

--- a/code/game/objects/items/weapons/material/warhammer.dm
+++ b/code/game/objects/items/weapons/material/warhammer.dm
@@ -154,7 +154,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	base_parry_chance = 25
 	wielded_parry_bonus = 10
 	melee_accuracy_bonus = 10
-	equip_delay = 0.6 SECONDS
 
 /obj/item/material/twohanded/warhammer/sword/broadsword/adamantine
 	name = "Adamantine Broadsword"
@@ -197,7 +196,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	armor_penetration = 4
 	base_parry_chance = 25
 	melee_accuracy_bonus = 5
-	equip_delay = 0.4 SECONDS
 
 /obj/item/material/twohanded/warhammer/sword/chopper/heavy/adamantine
 	name = "Heavy Adamantine Chopper"
@@ -251,7 +249,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 5
 	attack_cooldown_modifier = 0
 	melee_accuracy_bonus = 10
-	equip_delay = 0.5 SECONDS
+
 
 /obj/item/material/twohanded/warhammer/axe
 	name = "Trench Axe"
@@ -277,7 +275,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 15
 	attack_cooldown_modifier = 1
 	melee_accuracy_bonus = 5
-	equip_delay = 0.75 SECONDS
+
 
 /obj/item/material/twohanded/warhammer/axe/spear
 	name = "Hunting Spear"
@@ -303,7 +301,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 20 // Defending eezi
 	attack_cooldown_modifier = 0.7
 	melee_accuracy_bonus = 7 // Primitive easy to use weapon.
-	equip_delay = 0.3 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/spear/adamantine
 	name = "Adamantine Spear"
@@ -334,7 +331,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 30 // Long reach good defense.
 	attack_cooldown_modifier = 1.2
 	melee_accuracy_bonus = 7
-	equip_delay = 0.65 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/spear/fuscina/adamantine
 	name = "Adamantine Fuscina"
@@ -365,7 +361,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	attack_cooldown_modifier = 1.6
 	melee_accuracy_bonus = 10
 	does_spin = FALSE // Spear.
-	equip_delay = 0.8 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/saintie/adamantine
 	name = "Adamantine Saintie"
@@ -393,7 +388,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 15
 	attack_cooldown_modifier = 1.4
 	melee_accuracy_bonus = 5
-	equip_delay = 0.75 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/bardiche/adamantine
 	name = "Adamantine Bardiche"
@@ -428,7 +422,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 5
 	attack_cooldown_modifier = 1.2 // Chainblade.
 	melee_accuracy_bonus = 10 // Chainblades don't miss.
-	equip_delay = 0.5 SECONDS
 
 /obj/item/material/twohanded/warhammer/chainsword/guard
 	name = "Imperial Guard chainsword"
@@ -445,7 +438,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 5
 	attack_cooldown_modifier = 0.9 // Lighter one handed variant of the Mercy, faster attack, higher accuracy and defense in exchange for damage.
 	melee_accuracy_bonus = 15
-	equip_delay = 0.4 SECONDS
 
 /obj/item/material/twohanded/warhammer/chainsword/relic
 	name = "Relic Pattern Chainsword"
@@ -457,7 +449,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	force_multiplier = 0.66
 	unwielded_force_divisor =  0.64
 	melee_accuracy_bonus = 15
-	equip_delay = 0.5 SECONDS
 
 /obj/item/material/twohanded/warhammer/chainsword/eviscerator
 	name = "Eviscerator Pattern Chainsword"
@@ -472,7 +463,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	melee_accuracy_bonus = 15
 	attack_cooldown_modifier = 2
 	base_parry_chance = 35
-	equip_delay = 0.65 SECONDS
 
 /obj/item/material/twohanded/warhammer/chainsword/drusian
 	name = "Drusian Pattern Chainsword"
@@ -488,7 +478,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 5
 	attack_cooldown_modifier = 0.85 // Same design as guard just higher quality.
 	melee_accuracy_bonus = 17
-	equip_delay = 0.4 SECONDS
 
 /obj/item/material/twohanded/warhammer/chainsword/astartes
 	name = "Mark I Pattern Chainsword"
@@ -506,7 +495,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	base_parry_chance = 25 // Astartes melee skill is crazy high.
 	wielded_parry_bonus = 5
 	str_requirement = 1 // Does a skill check. Do not set to anything else.
-	equip_delay = 0.1 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/thunderhammer
 	name = "Thunder Hammer"
@@ -531,7 +519,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 20
 	attack_cooldown_modifier = 1.6
 	melee_accuracy_bonus = 10
-	equip_delay = 0.8 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/thunderhammer/astartes
 	name = "Astartes Thunder Hammer"
@@ -546,7 +533,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	attack_cooldown_modifier = 1 // Astartes melee skill is crazy high.
 	melee_accuracy_bonus = 10
 	str_requirement = 1
-	equip_delay = 0.2 SECONDS
 
 // XENOS / HERETIC WEAPONS
 
@@ -620,7 +606,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 10
 	attack_cooldown_modifier = 0.7
 	melee_accuracy_bonus = 15 // Tis a whip.
-	equip_delay = 0.3 SECONDS
 
 /obj/item/material/twohanded/warhammer/lashoftorment/New() // Magic
 	..()
@@ -778,7 +763,6 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	atom_flags = ATOM_FLAG_NO_BLOOD
 	attack_verb = list("beaten", "smashed")
 	armor_penetration = 5 // Non Lethal Shock
-	equip_delay = 0.5 SECONDS
 	var/stunforce = 0
 	var/agonyforce = 50
 

--- a/code/game/objects/items/weapons/material/warhammer.dm
+++ b/code/game/objects/items/weapons/material/warhammer.dm
@@ -154,6 +154,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	base_parry_chance = 25
 	wielded_parry_bonus = 10
 	melee_accuracy_bonus = 10
+	equip_delay = 0.6 SECONDS
 
 /obj/item/material/twohanded/warhammer/sword/broadsword/adamantine
 	name = "Adamantine Broadsword"
@@ -196,6 +197,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	armor_penetration = 4
 	base_parry_chance = 25
 	melee_accuracy_bonus = 5
+	equip_delay = 0.4 SECONDS
 
 /obj/item/material/twohanded/warhammer/sword/chopper/heavy/adamantine
 	name = "Heavy Adamantine Chopper"
@@ -249,7 +251,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 5
 	attack_cooldown_modifier = 0
 	melee_accuracy_bonus = 10
-
+	equip_delay = 0.5 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe
 	name = "Trench Axe"
@@ -275,7 +277,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 15
 	attack_cooldown_modifier = 1
 	melee_accuracy_bonus = 5
-
+	equip_delay = 0.75 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/spear
 	name = "Hunting Spear"
@@ -301,6 +303,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 20 // Defending eezi
 	attack_cooldown_modifier = 0.7
 	melee_accuracy_bonus = 7 // Primitive easy to use weapon.
+	equip_delay = 0.3 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/spear/adamantine
 	name = "Adamantine Spear"
@@ -331,6 +334,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 30 // Long reach good defense.
 	attack_cooldown_modifier = 1.2
 	melee_accuracy_bonus = 7
+	equip_delay = 0.65 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/spear/fuscina/adamantine
 	name = "Adamantine Fuscina"
@@ -361,6 +365,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	attack_cooldown_modifier = 1.6
 	melee_accuracy_bonus = 10
 	does_spin = FALSE // Spear.
+	equip_delay = 0.8 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/saintie/adamantine
 	name = "Adamantine Saintie"
@@ -388,6 +393,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 15
 	attack_cooldown_modifier = 1.4
 	melee_accuracy_bonus = 5
+	equip_delay = 0.75 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/bardiche/adamantine
 	name = "Adamantine Bardiche"
@@ -422,6 +428,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 5
 	attack_cooldown_modifier = 1.2 // Chainblade.
 	melee_accuracy_bonus = 10 // Chainblades don't miss.
+	equip_delay = 0.5 SECONDS
 
 /obj/item/material/twohanded/warhammer/chainsword/guard
 	name = "Imperial Guard chainsword"
@@ -438,6 +445,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 5
 	attack_cooldown_modifier = 0.9 // Lighter one handed variant of the Mercy, faster attack, higher accuracy and defense in exchange for damage.
 	melee_accuracy_bonus = 15
+	equip_delay = 0.4 SECONDS
 
 /obj/item/material/twohanded/warhammer/chainsword/relic
 	name = "Relic Pattern Chainsword"
@@ -449,6 +457,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	force_multiplier = 0.66
 	unwielded_force_divisor =  0.64
 	melee_accuracy_bonus = 15
+	equip_delay = 0.5 SECONDS
 
 /obj/item/material/twohanded/warhammer/chainsword/eviscerator
 	name = "Eviscerator Pattern Chainsword"
@@ -463,6 +472,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	melee_accuracy_bonus = 15
 	attack_cooldown_modifier = 2
 	base_parry_chance = 35
+	equip_delay = 0.65 SECONDS
 
 /obj/item/material/twohanded/warhammer/chainsword/drusian
 	name = "Drusian Pattern Chainsword"
@@ -478,6 +488,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 5
 	attack_cooldown_modifier = 0.85 // Same design as guard just higher quality.
 	melee_accuracy_bonus = 17
+	equip_delay = 0.4 SECONDS
 
 /obj/item/material/twohanded/warhammer/chainsword/astartes
 	name = "Mark I Pattern Chainsword"
@@ -495,6 +506,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	base_parry_chance = 25 // Astartes melee skill is crazy high.
 	wielded_parry_bonus = 5
 	str_requirement = 1 // Does a skill check. Do not set to anything else.
+	equip_delay = 0.1 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/thunderhammer
 	name = "Thunder Hammer"
@@ -519,6 +531,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 20
 	attack_cooldown_modifier = 1.6
 	melee_accuracy_bonus = 10
+	equip_delay = 0.8 SECONDS
 
 /obj/item/material/twohanded/warhammer/axe/thunderhammer/astartes
 	name = "Astartes Thunder Hammer"
@@ -533,6 +546,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	attack_cooldown_modifier = 1 // Astartes melee skill is crazy high.
 	melee_accuracy_bonus = 10
 	str_requirement = 1
+	equip_delay = 0.2 SECONDS
 
 // XENOS / HERETIC WEAPONS
 
@@ -606,6 +620,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	wielded_parry_bonus = 10
 	attack_cooldown_modifier = 0.7
 	melee_accuracy_bonus = 15 // Tis a whip.
+	equip_delay = 0.3 SECONDS
 
 /obj/item/material/twohanded/warhammer/lashoftorment/New() // Magic
 	..()
@@ -763,6 +778,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	atom_flags = ATOM_FLAG_NO_BLOOD
 	attack_verb = list("beaten", "smashed")
 	armor_penetration = 5 // Non Lethal Shock
+	equip_delay = 0.5 SECONDS
 	var/stunforce = 0
 	var/agonyforce = 50
 

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -6,7 +6,7 @@
 	item_state = "toolbox_red"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	force = 22
-	attack_cooldown = 21
+	attack_cooldown = 7
 	melee_accuracy_bonus = -5
 	throwforce = 10
 	throw_speed = 1
@@ -78,7 +78,7 @@
 	icon_state = "syndicate"
 	item_state = "toolbox_syndi"
 	origin_tech = list(TECH_COMBAT = 1, TECH_ESOTERIC = 1)
-	attack_cooldown = 10
+	attack_cooldown = 6
 	base_parry_chance = 30
 	startswith = list(
 		/obj/item/clothing/gloves/insulated,

--- a/code/game/objects/items/weapons/tools/swapper.dm
+++ b/code/game/objects/items/weapons/tools/swapper.dm
@@ -100,7 +100,7 @@
 	attack_verb = list("crushed", "sliced")
 	w_class = ITEM_SIZE_NORMAL
 	force = 20.0
-	attack_cooldown = 30.0
+	attack_cooldown = 7
 	throwforce = 8.0
 	hitsound = 'sound/items/jaws_pry.ogg'
 	toolspeed = 0.5

--- a/code/game/objects/items/weapons/tools_crystal.dm
+++ b/code/game/objects/items/weapons/tools_crystal.dm
@@ -128,7 +128,6 @@
 	icon_state = "crystal"
 	item_state = "toolbox_crystal"
 	origin_tech = list(TECH_COMBAT = 1, TECH_MATERIAL = 3)
-	attack_cooldown = 15
 
 /obj/item/storage/toolbox/crystal/Initialize()
 	new /obj/item/device/multitool/crystal(src)

--- a/code/modules/ZAS/Phoron.dm
+++ b/code/modules/ZAS/Phoron.dm
@@ -48,10 +48,13 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 	else if (item_flags & ITEM_FLAG_WASHER_ALLOWED) return 1
 
 /obj/item/proc/contaminate()
-	//Do a contamination overlay? Temporary measure to keep contamination less deadly than it was.
-	if(!contaminated)
-		contaminated = 1
-		AddOverlays(contamination_overlay)
+    // Do a contamination overlay? Temporary measure to keep contamination less deadly than it was.
+    if(!contaminated)
+        contaminated = 1
+        AddOverlays(contamination_overlay)
+        spawn(1000)
+            if(contaminated)  // After 100 seconds clothing will naturally decontaminate. We don't use FETHING washing machine in the 41st millenium.
+                decontaminate()
 
 /obj/item/proc/decontaminate()
 	contaminated = 0

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -3,7 +3,7 @@
 	desc = "A piece of headgear used in dangerous working conditions to protect the head. Comes with a built-in flashlight."
 	icon_state = "hardhat0_yellow"
 	action_button_name = "Toggle Headlamp"
-	brightness_on = 0.5 //luminosity when on
+	brightness_on = 0.4
 	light_overlay = "hardhat_light"
 	w_class = ITEM_SIZE_NORMAL
 	item_flags = null

--- a/code/modules/clothing/suits/darkarmor.dm
+++ b/code/modules/clothing/suits/darkarmor.dm
@@ -5,16 +5,192 @@
 	desc = "The sturdy armour, issued to Adeptus Astartes Scouts for their service until they prove themselves worthy to become full-fledged Battlebrothers."
 	icon_state = "fharmor"
 	item_state = "fharmor"
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	body_parts_covered = LEGS|ARMS|FULL_TORSO // Remember to make power gloves and booties.
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-60
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+600
-	slowdown_general = 0.13
+	slowdown_general = 0.11
 	armor = list(
-		melee = ARMOR_MELEE_CARAPACE,
-		bullet = ARMOR_BALLISTIC_CARAPACE+4,
-		laser = ARMOR_LASER_CARAPACE+4,
-		energy = ARMOR_ENERGY_MINOR+16,
+		melee = ARMOR_MELEE_POWER_ARM-2,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR-1,
+		laser = ARMOR_LASER_POWER_ARMOUR-2,
+		energy = ARMOR_ENERGY_MINOR+26,
 		rad = ARMOR_RAD_MINOR+25,
 		bio = ARMOR_BIO_MINOR+15,
 		bomb = ARMOR_BOMB_PADDED+5
 		)
+
+
+// Tau
+/obj/item/clothing/suit/armor/tau
+	name = "fire warrior battle suit"
+	desc = "The impeccable yellow and brown armor of the Tau warrior caste"
+	icon_state = "fw_armor"
+	item_state = "fw_armor"
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	slowdown_general = 0.11
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM-2,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR-2,
+		laser = ARMOR_LASER_POWER_ARMOUR-2,
+		energy = ARMOR_ENERGY_MINOR+26,
+		rad = ARMOR_RAD_MINOR+55,
+		bio = ARMOR_BIO_MINOR+35,
+		bomb = ARMOR_BOMB_PADDED+5
+		)
+
+/obj/item/clothing/suit/armor/tau/breacher
+	name = "fire warrior breacher suit"
+	desc = "The white and bright armor of a Tau Breacher."
+	icon_state = "tbrea"
+	item_state = "tbrea"
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	slowdown_general = 0.125
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM-1,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR-1,
+		laser = ARMOR_LASER_POWER_ARMOUR-1,
+		energy = ARMOR_ENERGY_MINOR+26,
+		rad = ARMOR_RAD_MINOR+65,
+		bio = ARMOR_BIO_MINOR+45,
+		bomb = ARMOR_BOMB_PADDED+15
+		)
+
+/obj/item/clothing/suit/armor/tau/scout
+	name = "fire warrior scout suit"
+	desc = "The impeccable yellow and brown armor of the Tau warrior caste. This one is specially modified for use by recon elements of the Tau warriors."
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	slowdown_general = 0.09
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM-3,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR-3,
+		laser = ARMOR_LASER_POWER_ARMOUR-2,
+		energy = ARMOR_ENERGY_MINOR+26,
+		rad = ARMOR_RAD_MINOR+55,
+		bio = ARMOR_BIO_MINOR+35,
+		bomb = ARMOR_BOMB_PADDED
+		)
+
+// Eldar
+/obj/item/clothing/suit/armor/eldar
+	name = "guardian armour"
+	desc = "A ancient armor. It looks like it's made from Thermoplas in a scale like pattern."
+	icon_state = "eldarmor"
+	item_state = "eldarmor"
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	slowdown_general = 0.1 // Marshal's carapace is 0.11
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE+1,
+		bullet = ARMOR_BALLISTIC_CARAPACE+2,
+		laser = ARMOR_LASER_CARAPACE+2,
+		energy = ARMOR_ENERGY_MINOR+30,
+		rad = ARMOR_RAD_MINOR+65,
+		bio = ARMOR_BIO_MINOR+65,
+		bomb = ARMOR_BOMB_PADDED+5
+		)
+
+/obj/item/clothing/suit/armor/eldar/drukhari
+	name = "dark plate armour"
+	desc = "A ancient armor. It looks as if made from hardened resin in a thin-scale like pattern. It cackles with electrical power."
+	icon_state = "deldarmor"
+	item_state = "deldarmor"
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	slowdown_general = 0.085
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE+1,
+		bullet = ARMOR_BALLISTIC_CARAPACE+1,
+		laser = ARMOR_LASER_CARAPACE+1,
+		energy = ARMOR_ENERGY_MINOR+30,
+		rad = ARMOR_RAD_MINOR+55,
+		bio = ARMOR_BIO_MINOR+55,
+		bomb = ARMOR_BOMB_PADDED+5
+		)
+
+/obj/item/clothing/suit/armor/eldar/corsair
+	name = "corsair armour"
+	desc = "The dark and shadowy armor of a voidscarred Corsair.."
+	icon_state = "aeldar_armor"
+	item_state = "aeldar_armor"
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	slowdown_general = 0.08 // Faster. But weaker to rad/primitive weapons.
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE+1,
+		laser = ARMOR_LASER_CARAPACE+2,
+		energy = ARMOR_ENERGY_MINOR+30,
+		rad = ARMOR_RAD_MINOR+55,
+		bio = ARMOR_BIO_MINOR+55,
+		bomb = ARMOR_BOMB_PADDED+5
+		)
+
+/obj/item/clothing/suit/armor/eldar/ranger
+	name = "ranger armour"
+	desc = "An Eldar Ranger's Armour, comprised of many layers of cameoline materials with an underlying thermoplas player.."
+	icon_state = "ranger"
+	item_state = "ranger"
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	slowdown_general = 0.1 // Marshal's carapace is 0.11
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE+1,
+		bullet = ARMOR_BALLISTIC_CARAPACE+2,
+		laser = ARMOR_LASER_CARAPACE+2,
+		energy = ARMOR_ENERGY_MINOR+30,
+		rad = ARMOR_RAD_MINOR+65,
+		bio = ARMOR_BIO_MINOR+65,
+		bomb = ARMOR_BOMB_PADDED+5
+		)
+
+/obj/item/clothing/suit/armor/eldar/ranger/verb/toggle_eldar_camo()
+	set name = "Toggle Eldar Camo"
+	set category = "Eldar"
+	var/stealth_alpha = 15
+	if(alpha == stealth_alpha)
+		to_chat(usr,"You disable your armour's stealth features.")
+		animate(src, alpha = 255, time = 1.5 SECONDS)
+	else
+		to_chat(usr,"You enable your armour's stealth features.")
+		animate(src, alpha = stealth_alpha, time = 1.5 SECONDS)
+
+/mob/living/carbon/human/proc/eldar_active_camo()
+	set category = "Abilities"
+	set name = "Active Camo"
+	set desc = "Camouflage yourself"
+	var/stealth_alpha = 15
+
+	if(alpha == stealth_alpha)
+		animate(src, alpha = 255, time = 1.5 SECONDS)
+	else
+		animate(src, alpha = stealth_alpha, time = 1.5 SECONDS)
+
+/*
+
+/obj/item/clothing/suit/storage/hooded/genestealer
+	name = "tyranid chitin"
+	desc = "The hide of a Tyranid Genestealer"
+	armor = list(melee = 10, bullet = 30, laser = 30, energy = 20, bomb = 30, bio = 100, rad = 100)
+	icon_state = "gsfeet"
+	item_state = "gsfeet"
+	canremove = 0
+	unacidable = 1
+	species_restricted = list(SPECIES_TYRANID) */

--- a/code/modules/clothing/suits/grimarmor.dm
+++ b/code/modules/clothing/suits/grimarmor.dm
@@ -14,12 +14,12 @@
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+100
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-200
 	slowdown_general = 0.04
 	armor = list(
-		melee = ARMOR_MELEE_FLAK-2,
-		bullet = ARMOR_BALLISTIC_FLAK-6,
-		laser = ARMOR_LASER_FLAK-6,
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-2,
+		laser = ARMOR_LASER_FLAK-2,
 		energy = ARMOR_ENERGY_MINOR-6,
 		bio = ARMOR_BIO_MINOR-6,
 		rad = ARMOR_RAD_MINOR-10,
@@ -34,45 +34,6 @@
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flak, /obj/item/clothing/accessory/storage/pouches)
 	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_INVALID_FOR_CHAMELEON
 
-
-/obj/item/clothing/suit/armor/grim/merc
-	name = "mercenary flak armour"
-	desc = "An altered fabrication of Imperial Pattern Flak Armor - this particular version is commonly used by mercenaries guilds in service to the renegade houses of the frontier."
-	icon_state = "merc"
-	item_state = "merc"
-	body_parts_covered = LEGS|ARMS
-	accessories = list(/obj/item/clothing/accessory/armor_plate/flak) // All flak armors should use plate/medium unless shoddy
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-25
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+250 // Consider militarum patterns to have good rad and temp resistance so we don't get guardsmen in EVA suits
-	armor = list(
-		melee = ARMOR_MELEE_FLAK-1,
-		bullet = ARMOR_BALLISTIC_FLAK-1,
-		laser = ARMOR_LASER_FLAK-1,
-		energy = ARMOR_ENERGY_MINOR-4,
-		rad = ARMOR_RAD_MINOR-5,
-		bio = ARMOR_BIO_MINOR-5,
-		bomb = ARMOR_BOMB_MINOR-6
-		)
-
-/obj/item/clothing/suit/armor/grim/merc/carapace
-	name = "mercenary carapace armour"
-	desc = "An altered fabrication of Imperial Pattern Carapace Armor - this particular version is commonly used by mercenaries guilds in service to the renegade houses of the frontier."
-	icon_state = "explorer"
-	item_state = "explorer"
-	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35 // Merc gear is outfitted for combat not extended ops
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
-	slowdown_general = 0.06
-	armor = list(
-		melee = ARMOR_MELEE_CARAPACE-1,
-		bullet = ARMOR_BALLISTIC_CARAPACE-1,
-		laser = ARMOR_LASER_CARAPACE-1,
-		energy = ARMOR_ENERGY_MINOR,
-		rad = ARMOR_RAD_MINOR+15,
-		bio = ARMOR_BIO_MINOR+10,
-		bomb = ARMOR_BOMB_MINOR+5
-		)
-
 // MILITARUM
 
 /obj/item/clothing/suit/armor/grim/cadian
@@ -81,9 +42,10 @@
 	icon_state = "farmor"
 	item_state = "farmor"
 	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flakheavy)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 	slowdown_general = 0.04
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-1,
@@ -100,6 +62,7 @@
 	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, It is so common that it became symbol of the Astra Militarum as a whole. This one is in it light configuration, bearing the Red Cross of a Combat Medicae. This one is made to be lighter to accomodate movement."
 	icon_state = "medicae"
 	item_state = "medicae"
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
 
 /obj/item/clothing/suit/armor/grim/cadian/heavy
@@ -107,10 +70,11 @@
 	desc = "The standard armour found throughout the Cadian-oriented PDF and Cadian Regiments, It is so common that it became symbol of the Astra Militarum as a whole. This one is in it heavy configuration"
 	icon_state = "fharmor"
 	item_state = "fharmor"
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	body_parts_covered = LEGS|ARMS // Same as regular Cadian but provides better leg/arm protection.
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flakheavy)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+50
 	slowdown_general = 0.055
 	armor = list(
 		melee = ARMOR_MELEE_FLAK+1,
@@ -128,9 +92,10 @@
 	icon_state = "fharmor"
 	item_state = "fharmor"
 	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-55
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+100
 	slowdown_general = 0.06
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE-1,
@@ -148,10 +113,10 @@
 	icon_state = "fharmor"
 	item_state = "fharmor"
 	body_parts_covered = LEGS|ARMS
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+100
 	slowdown_general = 0.06
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE-1,
@@ -169,9 +134,10 @@
 	icon_state = "kriegcoat"
 	item_state = "kriegcoat"
 	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-40
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+80
 	slowdown_general = 0.055
 	armor = list(
 		melee = ARMOR_MELEE_FLAK,
@@ -189,9 +155,10 @@
 	icon_state = "kriegcoat"
 	item_state = "kriegcoat"
 	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+120
 	slowdown_general = 0.065 // Light carapace.
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE,
@@ -210,10 +177,10 @@
 	icon_state = "grencoat"
 	item_state = "grencoat"
 	body_parts_covered = LEGS|ARMS
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+120
 	slowdown_general = 0.075 // Similar to cadian carapace but heavier. Krieg gear is for slow -- defensive/siege warfare.
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE,
@@ -233,7 +200,7 @@
 	body_parts_covered = LEGS|ARMS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flaklamellar) // Flak Padding. lighter and weaker.
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 	slowdown_general = 0.025
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-1,
@@ -251,9 +218,10 @@
 	icon_state = "valarmor"
 	item_state = "valarmor"
 	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flaklamellar)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-60
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-200 // No good at heat.
 	slowdown_general = 0.04
 	armor = list(
 		melee = ARMOR_MELEE_FLAK,
@@ -296,7 +264,7 @@
 	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+120 // Maccabian carapace is like a space suit.
 	slowdown_general = 0.065
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE,
@@ -317,7 +285,7 @@
 	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+450
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+120
 	slowdown_general = 0.075
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE+1,
@@ -337,7 +305,7 @@
 	body_parts_covered = LEGS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 	slowdown_general = 0
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-1,
@@ -363,7 +331,7 @@
 	body_parts_covered = LEGS|ARMS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-25
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+200
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-100
 	slowdown_general = 0.04
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-1,
@@ -410,7 +378,7 @@
 	body_parts_covered = LEGS|ARMS
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster) // There's only a handful of commissar's to a regiment. They get the good stuff.
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+60
 	slowdown_general = 0.075 // Commissar's aren't fast.
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE+1,
@@ -428,7 +396,7 @@
 	icon_state = "Kriegissarplate"
 	item_state = "Kriegissarplate"
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+120
 	slowdown_general = 0.065
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE,
@@ -461,7 +429,7 @@
 	body_parts_covered = LEGS|ARMS|FULL_TORSO
 	slowdown_general = 0.10
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+120
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE-1, // No wasted weight on melee protection for Stormtroopers.
 		bullet = ARMOR_BALLISTIC_CARAPACE+1,
@@ -490,329 +458,7 @@
 	)
 	slowdown_general = 0.045
 
-// ORDOS / HERETIC
-/obj/item/clothing/suit/armor/grim/agent
-	name = "carapace coat"
-	desc = "A brilliantly made carapace coat for Inquisitorial Agents, adorned with holy seals and the Rosette to ward off Chaos corruption."
-	icon_state = "acolytecoat"
-	item_state = "acolytecoat"
-	body_parts_covered = LEGS | ARMS
-	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -45
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +400
-	slowdown_general = 0.06
-	armor = list(
-		melee = ARMOR_MELEE_CARAPACE + 1,
-		bullet = ARMOR_BALLISTIC_CARAPACE + 1,
-		laser = ARMOR_LASER_CARAPACE + 1,
-		energy = ARMOR_ENERGY_MINOR + 25,
-		bio = ARMOR_BIO_MINOR + 30,
-		rad = ARMOR_RAD_MINOR + 40,
-		bomb = ARMOR_BOMB_PADDED + 20
-	)
 
-/obj/item/clothing/suit/armor/grim/agent/inquisitor
-	name = "masterwork carapace coat"
-	desc = "The formidable, brilliantly made Carapace Armour for the Inquisitorial Agent, bearing the holy symbol of the Inquisition, the Rosette."
-	icon_state = "inqcoat"
-	item_state = "inqcoat"
-	body_parts_covered = LEGS | ARMS
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
-	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -60
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
-	slowdown_general = 0.06
-	armor = list(
-		melee = ARMOR_MELEE_CARAPACE + 1,
-		bullet = ARMOR_BALLISTIC_CARAPACE + 2,
-		laser = ARMOR_LASER_CARAPACE + 2,
-		energy = ARMOR_ENERGY_MINOR + 35,
-		bio = ARMOR_BIO_MINOR + 40,
-		rad = ARMOR_RAD_MINOR + 50,
-		bomb = ARMOR_BOMB_PADDED + 30
-	)
-
-/obj/item/clothing/suit/armor/grim/agent/hereticus
-	name = "masterwork carapace coat"
-	desc = "The Inquisitor's holy coat, forged from a Tech-priest of Mars for his use in his path of holy fire toward enemies of our Emperor, Hanging from the coat a Inquisitorial Rosette, It shines brightly as if it is the Emperor himself is present, For he'll cleanse the darkness."
-	icon_state = "hereticuscoat"
-	item_state = "hereticuscoat"
-	body_parts_covered = LEGS | ARMS
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
-	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -60
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
-	slowdown_general = 0.06
-	armor = list(
-		melee = ARMOR_MELEE_CARAPACE + 1,
-		bullet = ARMOR_BALLISTIC_CARAPACE + 2,
-		laser = ARMOR_LASER_CARAPACE + 2,
-		energy = ARMOR_ENERGY_MINOR + 35,
-		bio = ARMOR_BIO_MINOR + 40,
-		rad = ARMOR_RAD_MINOR + 50,
-		bomb = ARMOR_BOMB_PADDED + 30
-	)
-
-/obj/item/clothing/suit/armor/inqparmor
-	name = "relic power armour"
-	desc = "This ancient and sacred power armour was forged by the tech-priests of Mars, sanctified for the Inquisitor's righteous crusade against the enemies of the Emperor. Bearing the engraved Inquisitorial Rosette, its gleaming surface radiates with the Emperor's divine light, as if his presence guides the wearer to purge the darkness."
-	icon_state = "inqarmor"
-	item_state = "inqarmor"
-	body_parts_covered = LEGS|ARMS|FULL_TORSO
-	max_pressure_protection = RIG_MAX_PRESSURE
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1000
-	slowdown_general = 0.12 // Tiny bit slow. Design wise power armor is more rare then a lemun russ tank, it has no downsides. It simply is superior to all other armor.
-	armor = list(
-		melee = ARMOR_MELEE_POWER_ARM,
-		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
-		laser = ARMOR_LASER_POWER_ARMOUR,
-		energy = ARMOR_ENERGY_MINOR + 55,
-		bio = ARMOR_BIO_MINOR + 84,
-		rad = ARMOR_RAD_MINOR + 86,
-		bomb = ARMOR_BOMB_PADDED + 45
-	)
-
-/obj/item/clothing/suit/armor/grim/bloodpact
-	name = "sekite armour"
-	desc = "War torn and suited to savage needs. This is the armor of a Sekite warrior. It has certainly seen blood flown upon it."
-	icon_state = "heretmil"
-	item_state = "heretmil"
-	body_parts_covered = LEGS|ARMS // Sekites scavenge and use any armor attachments they can.
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
-	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace,/obj/item/clothing/accessory/leg_guards/reactiveslug)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
-	slowdown_general = 0.04
-	armor = list(
-		melee = ARMOR_MELEE_FLAK,
-		bullet = ARMOR_BALLISTIC_FLAK,
-		laser = ARMOR_LASER_FLAK,
-		energy = ARMOR_ENERGY_MINOR,
-		bio = ARMOR_BIO_MINOR,
-		rad = ARMOR_RAD_MINOR,
-		bomb = ARMOR_BOMB_MINOR
-	)
-
-// ADEPTA SORORITAS
-/obj/item/clothing/suit/armor/sister/sacredrosepower
-	name = "sacred rose power armour"
-	desc = "The Sacred and holy Power Armour adorned by Battle Sister of the Order Of The Sacred Rose, It's illuminate the field with it glorious light, Being near it make you feels safer and secured."
-	icon_state = "sister"
-	item_state = "sister"
-	flags_inv = HIDEJUMPSUIT
-	body_parts_covered = LEGS|ARMS|FULL_TORSO
-	max_pressure_protection = RIG_MAX_PRESSURE
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1000
-	slowdown_general = 0.11 // Slightly faster then inqisitorial, these relics are icons to the sisters and treated as extensions of the emperor.
-	armor = list(
-		melee = ARMOR_MELEE_POWER_ARM,
-		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
-		laser = ARMOR_LASER_POWER_ARMOUR,
-		energy = ARMOR_ENERGY_MINOR + 55,
-		bio = ARMOR_BIO_MINOR + 84,
-		rad = ARMOR_RAD_MINOR + 86,
-		bomb = ARMOR_BOMB_PADDED + 45
-	)
-
-/obj/item/clothing/suit/armor/sister/repentia
-	name = "repentia carapace armour"
-	desc = "The tattered garb of a penitent sister of battle. The minimal carapace of armor is a symbol of their faith on the Repentia's deathmarch towards a glorious end."
-	icon_state = "repentia_chest"
-	item_state = "repentia_chest"
-	flags_inv = HIDEJUMPSUIT
-	body_parts_covered = LEGS|ARMS|FULL_TORSO
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -25 // The temp resistance is more the sisters faith then anything.
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +250
-	slowdown_general = 0.07
-	armor = list(
-		melee = ARMOR_MELEE_CARAPACE-1,
-		bullet = ARMOR_BALLISTIC_CARAPACE-1,
-		laser = ARMOR_LASER_CARAPACE-1,
-		energy = ARMOR_ENERGY_MINOR + 15,
-		bio = ARMOR_BIO_MINOR + 14,
-		rad = ARMOR_RAD_MINOR + 16,
-		bomb = ARMOR_BOMB_MINOR +15
-	)
-
-/obj/item/clothing/suit/armor/sister/martyredpower
-	name = "ourt martyred lady power armour"
-	desc = "The Sacred and holy Power Armour adorned by Battle Sister of the Order Of Our Martyred Lady. Being near it make you feels safer and secured."
-	icon_state = "mlsister"
-	item_state = "mlsister"
-	flags_inv = HIDEJUMPSUIT
-	body_parts_covered = LEGS|ARMS|FULL_TORSO
-	max_pressure_protection = RIG_MAX_PRESSURE
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1000
-	slowdown_general = 0.11
-	armor = list(
-		melee = ARMOR_MELEE_POWER_ARM,
-		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
-		laser = ARMOR_LASER_POWER_ARMOUR,
-		energy = ARMOR_ENERGY_MINOR + 55,
-		bio = ARMOR_BIO_MINOR + 84,
-		rad = ARMOR_RAD_MINOR + 86,
-		bomb = ARMOR_BOMB_PADDED + 45
-	)
-
-/obj/item/clothing/suit/armor/sister/bloodyrosepower
-	name = "bloody rose power armour"
-	desc = "The blood red power armor of The Order of the Bloody Rose."
-	icon_state = "brsister"
-	item_state = "brsister"
-	flags_inv = HIDEJUMPSUIT
-	body_parts_covered = LEGS|ARMS|FULL_TORSO
-	max_pressure_protection = RIG_MAX_PRESSURE
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1000
-	slowdown_general = 0.11
-	armor = list(
-		melee = ARMOR_MELEE_POWER_ARM,
-		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
-		laser = ARMOR_LASER_POWER_ARMOUR,
-		energy = ARMOR_ENERGY_MINOR + 55,
-		bio = ARMOR_BIO_MINOR + 84,
-		rad = ARMOR_RAD_MINOR + 86,
-		bomb = ARMOR_BOMB_PADDED + 45
-	)
-
-/obj/item/clothing/suit/armor/sister/novitae
-	name = "novitae ceramite armor"
-	desc = "The Ancient and Deconsecrated Ceramite Armour adorned by Novice Militants during their training in Messina' Monastarium. Stripped of almost all iconography and with damaged plating. It has scriptures across it's surface, recounting the triumph and martyrdom of countless saints."
-	icon_state = "ooml"
-	item_state = "ooml"
-	flags_inv = HIDEJUMPSUIT
-	body_parts_covered = LEGS|ARMS|FULL_TORSO
-	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -50
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +500
-	slowdown_general = 0.11 // Same speed as sister but trash stats compared.
-	armor = list(
-		melee = ARMOR_MELEE_POWER_ARM-1,
-		bullet = ARMOR_BALLISTIC_POWER_ARMOUR-2, // 1 point above carapace
-		laser = ARMOR_LASER_POWER_ARMOUR-2,
-		energy = ARMOR_ENERGY_MINOR + 35,
-		bio = ARMOR_BIO_MINOR + 64,
-		rad = ARMOR_RAD_MINOR + 66,
-		bomb = ARMOR_BOMB_PADDED + 15
-	)
-
-// MECHANICUS
-/obj/item/clothing/suit/armor/grim/storage/hooded/magos
-	name = "Magos Biologis robes"
-	desc = "Green robes riddled with augments, scanners and syringes. The robes look incredibly old and worn, you can tell this magos has lived a long and scholarly life."
-	icon_state = "genetor"
-	item_state = "genetor"
-	canremove = 0
-	unacidable = 1
-	body_parts_covered = LEGS | ARMS
-	accessories = list(/obj/item/clothing/accessory/armor_plate/mechplate)
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -70
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +700
-	slowdown_general = 0.08
-	armor = list(
-		melee = ARMOR_MELEE_FLAK,
-		bullet = ARMOR_BALLISTIC_CARAPACE-2,
-		laser = ARMOR_LASER_CARAPACE-1,
-		energy = ARMOR_ENERGY_MINOR+20,
-		rad = ARMOR_RAD_RESISTANT+48,
-		bio = ARMOR_BIO_RESISTANT+48,
-		bomb = ARMOR_BOMB_MINOR+10
-		)
-	action_button_name = "Toggle Hood"
-	hoodtype = /obj/item/clothing/head/hoodiehood
-
-
-/obj/item/clothing/suit/armor/grim/storage/hooded/skitarii
-	name = "skitarii exoskeleton"
-	desc = "Tailored and reinforced by the Adeptus Mechanicus, these sturdy and protective robes are being issued to Skitarii warriors."
-	icon_state = "skitsuit"
-	item_state = "skitsuit"
-	canremove = 0
-	unacidable = 1
-	body_parts_covered = LEGS | ARMS
-	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -65
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
-	slowdown_general = 0.07 // Skitarii get superior armor stats to tech priests and slowdown since they're engineered to be combat units. Tech priests aren't designed for that.
-	armor = list(
-		melee = ARMOR_MELEE_CARAPACE,
-		bullet = ARMOR_BALLISTIC_CARAPACE,
-		laser = ARMOR_LASER_CARAPACE,
-		energy = ARMOR_ENERGY_MINOR+20,
-		rad = ARMOR_RAD_RESISTANT+48,
-		bio = ARMOR_BIO_RESISTANT+48,
-		bomb = ARMOR_BOMB_MINOR+10
-		)
-	action_button_name = "Toggle Hood"
-	hoodtype = /obj/item/clothing/head/hoodiehood
-
-/obj/item/clothing/suit/armor/grim/storage/hooded/stalker
-	name = "ruststalker exoskeleton"
-	desc = "Tailored and reinforced by the Adeptus Mechanicus, this strange armour is issued to Skitarii Ruststalkers. It shimmers oddly in the light, and seems to have storage pouches for skulls."
-	icon_state = "skitsuit"
-	item_state = "skitsuit"
-	canremove = 0
-	unacidable = 1
-	body_parts_covered = LEGS | ARMS
-	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -65
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
-	slowdown_general = 0.055
-	armor = list(
-		melee = ARMOR_MELEE_CARAPACE,
-		bullet = ARMOR_BALLISTIC_CARAPACE-1,
-		laser = ARMOR_LASER_CARAPACE-1,
-		energy = ARMOR_ENERGY_MINOR+10,
-		rad = ARMOR_RAD_RESISTANT+48,
-		bio = ARMOR_BIO_RESISTANT+48,
-		bomb = ARMOR_BOMB_MINOR+5
-		)
-	action_button_name = "Toggle Hood"
-	hoodtype = /obj/item/clothing/head/hoodiehood
-
-/obj/item/clothing/suit/armor/grim/storage/hooded/vanguard
-	name = "vanguard exoskeleton"
-	desc = "Tailored and reinforced by the Adeptus Mechanicus, these heavy ceramite plates offer near-complete protection from attack."
-	icon_state = "rig-hazardhardsuit"
-	item_state = "rig-hazardhardsuit"
-	canremove = 0
-	unacidable = 1
-	body_parts_covered = LEGS | ARMS
-	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -95
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +900
-	slowdown_general = 0.08
-	armor = list(
-		melee = ARMOR_MELEE_CARAPACE,
-		bullet = ARMOR_BALLISTIC_CARAPACE+1,
-		laser = ARMOR_LASER_CARAPACE+1,
-		energy = ARMOR_ENERGY_MINOR+20,
-		rad = ARMOR_RAD_RESISTANT+48,
-		bio = ARMOR_BIO_RESISTANT+48,
-		bomb = ARMOR_BOMB_MINOR+10
-		)
-	action_button_name = "Toggle Hood"
-	hoodtype = /obj/item/clothing/head/hoodiehood
-
-/*
-
-/obj/item/clothing/suit/storage/hooded/genestealer
-	name = "tyranid chitin"
-	desc = "The hide of a Tyranid Genestealer"
-	armor = list(melee = 10, bullet = 30, laser = 30, energy = 20, bomb = 30, bio = 100, rad = 100)
-	icon_state = "gsfeet"
-	item_state = "gsfeet"
-	canremove = 0
-	unacidable = 1
-	species_restricted = list(SPECIES_TYRANID) */
 
 //// MAGISTRATUM
 /obj/item/clothing/suit/armor/grim/bountyhunter
@@ -850,8 +496,8 @@
 		bullet = ARMOR_BALLISTIC_CARAPACE+1,
 		laser = ARMOR_LASER_CARAPACE+1,
 		energy = ARMOR_ENERGY_MINOR+10,
-		rad = ARMOR_RAD_MINOR+25,
-		bio = ARMOR_BIO_MINOR+15,
+		rad = ARMOR_RAD_MINOR+45,
+		bio = ARMOR_BIO_MINOR+35,
 		bomb = ARMOR_BOMB_PADDED+5
 		)
 
@@ -870,8 +516,8 @@
 		bullet = ARMOR_BALLISTIC_FLAK+1,
 		laser = ARMOR_LASER_FLAK+1,
 		energy = ARMOR_ENERGY_MINOR+1,
-		bio = ARMOR_BIO_MINOR+8,
-		rad = ARMOR_RAD_MINOR+15,
+		bio = ARMOR_BIO_MINOR+28,
+		rad = ARMOR_RAD_MINOR+35,
 		bomb = ARMOR_BOMB_MINOR+8
 		)
 
@@ -954,6 +600,316 @@
 		bio = ARMOR_BIO_MINOR+25,
 		bomb = ARMOR_BOMB_PADDED+15
 		)
+
+// MECHANICUS
+/obj/item/clothing/suit/armor/grim/storage/hooded/mechanicus/bondsman
+	name = "mechanicus hazard suit"
+	desc = "A heavy protective suit made from chemically treated fabrics that protect the wearer from toxic death world environment, this particular set is fitted with carapace pauldrons and plate to protect it's wearer from dangers only the Cogboys seem wise enough to prepare for."
+	icon_state = "MineWorkerS"
+	item_state = "MineWorkerS"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/mechplate)
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+100
+	slowdown_general = 0.055
+	hoodtype = /obj/item/clothing/head/hardhat/bondsman
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_MINOR+5,
+		bio = ARMOR_BIO_MINOR+20,
+		rad = ARMOR_RAD_MINOR+30,
+		bomb = ARMOR_BOMB_MINOR+15
+		)
+/obj/item/clothing/head/hardhat/bondsman // hardhats have light toggle code
+	name = "hazard helmet"
+	desc = "A heavy filtration mask fitted with carapace and a heavy hood to protect against burns."
+	icon_state = "MineWorkerH"
+	item_state = "MineWorkerH"
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+100
+	slowdown_general = 0.007
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-1,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR+20,
+		rad = ARMOR_RAD_MINOR+30,
+		bomb = ARMOR_BOMB_MINOR+5
+		)
+
+/obj/item/clothing/suit/armor/grim/mechanicus
+	name = "tech priest robes"
+	desc = "Green robes riddled with augments, scanners, and syringes. Worn and weathered, these robes have clearly seen the long service of a veteran Tech-Priest, their ancient mechanisms still thrumming with life."
+	icon_state = "techpriest"
+	item_state = "techpriest"
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/mechplate)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -70
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
+	slowdown_general = 0.08
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_CARAPACE-2,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+/obj/item/clothing/head/hardhat/techpriest
+	name = "augmented head"
+	desc = "The augmented skull and hood signifying one is a priest of the Adeptus Mechanicus."
+	icon_state = "techpriestnew"
+	item_state = "techpriestnew"
+	brightness_on = 6
+	unacidable = 1
+	canremove = 0
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_CARAPACE-2,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+	flags_inv = BLOCKHAIR|BLOCKHEADHAIR|HIDEEARS|HIDEEYES
+	flash_protection = FLASH_PROTECTION_MAJOR
+
+/obj/item/clothing/suit/armor/grim/mechanicus/biologis
+	name = "biologis robes"
+	desc = "Plain robes adorned with various wriggling mechanical appendages. These robes belong to a Magos Biologis, devoted to unlocking the biological mysteries of the universe with a machine-like precision."
+	icon_state = "genetor"
+	item_state = "genetor"
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/mechplate)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -70
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
+	slowdown_general = 0.08
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_CARAPACE-2,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+/obj/item/clothing/head/genehood
+	name = "Biologis' hood"
+	desc = "An ancient cowl covering a heavily augmented face."
+	icon_state = "genetor"
+	item_state = "genetor"
+	flags_inv = HIDEEARS | BLOCKHAIR
+	unacidable = 1
+	armor = list(melee = 8, bullet = 30, laser = 40,energy = 30, bomb = 70, bio = 100, rad = 20)
+	flags_inv = BLOCKHAIR|BLOCKHEADHAIR|HIDEEARS|HIDEEYES
+	flash_protection = FLASH_PROTECTION_MAJOR
+
+/obj/item/clothing/suit/armor/grim/mechanicus/magos
+	name = "magos robes"
+	desc = "Magnificent robes brimming with advanced augments, scanners, and syringes. These ancient garments have been worn by countless Magi, their layered machinery acting as a testament to the long, unrelenting pursuit of knowledge."
+	icon_state = "magos"
+	item_state = "magos"
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/mechplatemagos)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -70
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
+	slowdown_general = 0.08
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_CARAPACE-2,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+/obj/item/clothing/head/hardhat/techpriest/magos
+	icon_state = "magoshelm"
+	item_state = "magoshelm"
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_CARAPACE-2,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+
+/obj/item/clothing/suit/armor/grim/storage/hooded/skitarii
+	name = "skitarii exoskeleton"
+	desc = "Tailored and reinforced by the Adeptus Mechanicus, these sturdy and protective robes are being issued to Skitarii warriors."
+	icon_state = "skitsuit"
+	item_state = "skitsuit"
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -65
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +550
+	slowdown_general = 0.07 // Skitarii get superior armor stats to tech priests and slowdown since they're engineered to be combat units. Tech priests aren't designed for that.
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE,
+		laser = ARMOR_LASER_CARAPACE,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+	action_button_name = "Toggle Hood"
+	hoodtype = /obj/item/clothing/head/skithood
+/obj/item/clothing/head/skithood
+	name = "skitarii hood"
+	desc = "A blood red hood with embroidered with the Adeptus Mechanicus' logo."
+	icon_state = "skithood"
+	item_state = "skithood"
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -65
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +550
+	body_parts_covered = HEAD|FACE|EYES
+	flags_inv = HIDEEARS | BLOCKHAIR
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE,
+		laser = ARMOR_LASER_CARAPACE,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+/obj/item/clothing/suit/armor/grim/storage/hooded/stalker
+	name = "ruststalker exoskeleton"
+	desc = "Tailored and reinforced by the Adeptus Mechanicus, this strange armour is issued to Skitarii Ruststalkers. It shimmers oddly in the light, and seems to have storage pouches for skulls."
+	icon_state = "skitsuit"
+	item_state = "skitsuit"
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -65
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +600
+	slowdown_general = 0.055
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE-1,
+		bullet = ARMOR_BALLISTIC_CARAPACE-1,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR+10,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+5
+		)
+	action_button_name = "Toggle Hood"
+	hoodtype = /obj/item/clothing/head/rusthood
+/obj/item/clothing/head/rusthood
+	name = "ruststalker hood"
+	desc = "A shiny hood embroidered with the Adeptus Mechanicus' logo."
+	icon_state = "skithood"
+	item_state = "skithood"
+	body_parts_covered = HEAD|FACE|EYES
+	flags_inv = HIDEEARS | BLOCKHAIR
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -65
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +550
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE-1,
+		bullet = ARMOR_BALLISTIC_CARAPACE-1,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR+10,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+5
+		)
+
+/obj/item/clothing/suit/armor/grim/storage/hooded/vanguard
+	name = "vanguard exoskeleton"
+	desc = "Tailored and reinforced by the Adeptus Mechanicus, these heavy ceramite plates offer near-complete protection from attack."
+	icon_state = "rig-hazardhardsuit"
+	item_state = "rig-hazardhardsuit"
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -95
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +700
+	slowdown_general = 0.08
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE-1,
+		bullet = ARMOR_BALLISTIC_CARAPACE+1,
+		laser = ARMOR_LASER_CARAPACE+1,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+	action_button_name = "Toggle Hood"
+	hoodtype = /obj/item/clothing/head/vanhelm
+/obj/item/clothing/head/vanhelm
+	name = "vanguard helmet"
+	desc = "A shiny helmet covered in Mechanicus etchings."
+	icon_state = "rghelmet2"
+	item_state = "rghelmet2"
+	body_parts_covered = HEAD|FACE|EYES
+	flags_inv = HIDEEARS | BLOCKHAIR
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -65
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +550
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_CARAPACE+1,
+		laser = ARMOR_LASER_CARAPACE+1,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+
+
+/obj/item/clothing/suit/armor/servitor
+	name = "servitor's exoskeleton"
+	desc = "The heavily armoured exoskeleton of a servitor, the extensive augmentation ensuring that nothing short of a krak rocket is capable of ending it's misery."
+	icon_state = "servitor_robe"
+	item_state = "servitor_robe" // to-do. make some servitor guns and a heavier combat version of this plating.
+	canremove = 0
+	unacidable = 1
+	body_parts_covered = FULL_BODY
+	max_pressure_protection = RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -220
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1600 // Really highlights why servitors are used by the mechanicus.
+	slowdown_general = 0.4
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR, // In the books killing a servitor is like trying to blow up a chimera.
+		laser = ARMOR_LASER_POWER_ARMOUR,
+		energy = ARMOR_ENERGY_MINOR+20,
+		rad = ARMOR_RAD_RESISTANT+48,
+		bio = ARMOR_BIO_RESISTANT+48,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+
+/obj/item/clothing/suit/armor/servitor/janitor
+	icon_state = "servitor_robe2"
+	item_state = "servitor_robe2"
+
 
 // SS13 PLATE SYSTEMS
 

--- a/code/modules/clothing/suits/pilgrimarmor.dm
+++ b/code/modules/clothing/suits/pilgrimarmor.dm
@@ -1,0 +1,557 @@
+
+// CULTISTS
+
+/obj/item/clothing/suit/armor/grim/cult
+	name = "heavy overcoat" // name a lot of generic armors this so only experienced players recognise them as chaos.
+	desc = "A rough overcoat made from leather and poorly forged steel plates. It appears unremarkable at first glance."
+	icon_state = "heretmil"
+	item_state = "heretmil"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
+	slowdown_general = 0.04
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK-1,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR+15,
+		rad = ARMOR_RAD_MINOR+15,
+		bomb = ARMOR_BOMB_MINOR+10
+	)
+
+/obj/item/clothing/suit/armor/grim/cult/tzee
+	name = "heavy overcoat"
+	desc = "This robe is woven from an unnatural silk-like material, covered in crude runes and symbols. Being near it fills you with the eerie sensation of being observed."
+	icon_state = "tzeecult"
+	item_state = "tzeecult"
+	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
+	accessories = list(/obj/item/clothing/accessory/armor_plate/tzeentch)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+150
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK+1,
+		laser = ARMOR_LASER_FLAK+1,
+		energy = ARMOR_ENERGY_MINOR+2,
+		bio = ARMOR_BIO_MINOR+35,
+		rad = ARMOR_RAD_MINOR+25,
+		bomb = ARMOR_BOMB_MINOR+15
+	)
+
+/obj/item/clothing/suit/armor/grim/cult/nurgle
+	name = "heavy overcoat"
+	desc = "A decaying leather coat smeared in filth, exuding a foul stench of rot, vomit, and waste. Even approaching it tests your willpower."
+	icon_state = "nurgc"
+	item_state = "nurgc"
+	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
+	accessories = list(/obj/item/clothing/accessory/armor_plate/nurgle)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+100
+	slowdown_general = 0.065
+	armor = list(
+		melee = ARMOR_MELEE_FLAK+1,
+		bullet = ARMOR_BALLISTIC_FLAK+1,
+		laser = ARMOR_LASER_FLAK+1,
+		energy = ARMOR_ENERGY_MINOR+10,
+		bio = ARMOR_BIO_MINOR+25,
+		rad = ARMOR_RAD_MINOR+25,
+		bomb = ARMOR_BOMB_MINOR+25
+	)
+
+/obj/item/clothing/suit/armor/grim/cult/nurgleheavy
+	name = "heavy overcoat"
+	desc = "This heavy leather coat reeks of filth, covered in the same nauseating mixture of rot and human waste. Its stench precedes its presence."
+	icon_state = "nurgc"
+	item_state = "nurgc"
+	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
+	accessories = list(/obj/item/clothing/accessory/armor_plate/nurgleheavy)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+150
+	slowdown_general = 0.08
+	armor = list(
+		melee = ARMOR_MELEE_FLAK+2,
+		bullet = ARMOR_BALLISTIC_FLAK+2,
+		laser = ARMOR_LASER_FLAK+2,
+		energy = ARMOR_ENERGY_MINOR+15,
+		bio = ARMOR_BIO_MINOR+35,
+		rad = ARMOR_RAD_MINOR+35,
+		bomb = ARMOR_BOMB_MINOR+35
+	)
+
+/obj/item/clothing/suit/armor/grim/cult/renegade
+	name = "renegade armour"
+	desc = "Makeshift steel armor, while not refined, it will protect you vital organs. It has strange marks carved into it"
+	icon_state = "renegade_militia_armor"
+	item_state = "renegade_militia_armor"
+	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+35
+	slowdown_general = 0.04
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK-1,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR,
+		rad = ARMOR_RAD_MINOR,
+		bomb = ARMOR_BOMB_MINOR
+	)
+
+/obj/item/clothing/suit/armor/grim/cult/bloodpact
+	name = "bloodpact armor"
+	desc = "Makeshift steel armor, while not refined, it will protect you vital organs. It has strange marks carved into it devoted to Khorne."
+	icon_state = "BP_Armor"
+	item_state = "BP_Armor"
+	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy,/obj/item/clothing/accessory/leg_guards/flak) // Bloodpact are heavily armoured shock troops.
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+35
+	slowdown_general = 0.05
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR,
+		rad = ARMOR_RAD_MINOR,
+		bomb = ARMOR_BOMB_MINOR
+	)
+
+/obj/item/clothing/suit/armor/grim/cult/sekite
+	name = "sekite armour"
+	desc = "War torn and suited to savage needs. This is the armor of a Sekite warrior. It has certainly seen blood flown upon it."
+	icon_state = "heretmil"
+	item_state = "heretmil"
+	body_parts_covered = LEGS|ARMS
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace,/obj/item/clothing/accessory/leg_guards/reactiveslug)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+35
+	slowdown_general = 0.05
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR,
+		rad = ARMOR_RAD_MINOR,
+		bomb = ARMOR_BOMB_MINOR
+	)
+
+// ECCLESIARCHY
+/obj/item/clothing/suit/armor/sister/sacredrosepower
+	name = "sacred rose power armour"
+	desc = "The Sacred and holy Power Armour adorned by Battle Sister of the Order Of The Sacred Rose, It's illuminate the field with it glorious light, Being near it make you feels safer and secured."
+	icon_state = "sister"
+	item_state = "sister"
+	flags_inv = HIDEJUMPSUIT
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1500
+	slowdown_general = 0.11 // Slightly faster then inqisitorial, these relics are icons to the sisters and treated as extensions of the emperor.
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
+		laser = ARMOR_LASER_POWER_ARMOUR,
+		energy = ARMOR_ENERGY_MINOR + 55,
+		bio = ARMOR_BIO_MINOR + 84,
+		rad = ARMOR_RAD_MINOR + 86,
+		bomb = ARMOR_BOMB_PADDED + 45
+	)
+
+/obj/item/clothing/suit/armor/sister/martyredpower
+	name = "martyred power armour"
+	desc = "The Sacred and holy Power Armour adorned by Battle Sister of the Order Of Our Martyred Lady. Being near it make you feels safer and secured."
+	icon_state = "mlsister"
+	item_state = "mlsister"
+	flags_inv = HIDEJUMPSUIT
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1500
+	slowdown_general = 0.11
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
+		laser = ARMOR_LASER_POWER_ARMOUR,
+		energy = ARMOR_ENERGY_MINOR + 55,
+		bio = ARMOR_BIO_MINOR + 84,
+		rad = ARMOR_RAD_MINOR + 86,
+		bomb = ARMOR_BOMB_PADDED + 45
+	)
+
+/obj/item/clothing/suit/armor/sister/bloodyrosepower
+	name = "bloody rose power armour"
+	desc = "The blood red power armor of The Order of the Bloody Rose."
+	icon_state = "brsister"
+	item_state = "brsister"
+	flags_inv = HIDEJUMPSUIT
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1500
+	slowdown_general = 0.11
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
+		laser = ARMOR_LASER_POWER_ARMOUR,
+		energy = ARMOR_ENERGY_MINOR + 55,
+		bio = ARMOR_BIO_MINOR + 84,
+		rad = ARMOR_RAD_MINOR + 86,
+		bomb = ARMOR_BOMB_PADDED + 45
+	)
+
+/obj/item/clothing/suit/armor/sister/novitae
+	name = "novitae ceramite armor"
+	desc = "The Ancient and Deconsecrated Ceramite Armour adorned by Novice Militants during their training in Messina' Monastarium. Stripped of almost all iconography and with damaged plating. It has scriptures across it's surface, recounting the triumph and martyrdom of countless saints."
+	icon_state = "ooml"
+	item_state = "ooml"
+	flags_inv = HIDEJUMPSUIT
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1100
+	slowdown_general = 0.11 // Same speed as sister but trash stats compared.
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM-1,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR-2, // 1 point above carapace
+		laser = ARMOR_LASER_POWER_ARMOUR-2,
+		energy = ARMOR_ENERGY_MINOR + 35,
+		bio = ARMOR_BIO_MINOR + 64,
+		rad = ARMOR_RAD_MINOR + 66,
+		bomb = ARMOR_BOMB_PADDED + 15
+	)
+
+/obj/item/clothing/suit/armor/sister/repentia
+	name = "repentia carapace armour"
+	desc = "The tattered garb of a penitent sister of battle. The minimal carapace of armor is a symbol of their faith on the Repentia's deathmarch towards a glorious end."
+	icon_state = "repentia_chest"
+	item_state = "repentia_chest"
+	flags_inv = HIDEJUMPSUIT
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
+	slowdown_general = 0.07
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE-1,
+		bullet = ARMOR_BALLISTIC_CARAPACE-1,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR + 15,
+		bio = ARMOR_BIO_MINOR + 14,
+		rad = ARMOR_RAD_MINOR + 16,
+		bomb = ARMOR_BOMB_MINOR +15
+	)
+
+/obj/item/clothing/suit/armor/grim/zealot
+	name = "heavy mantle"
+	desc = "An imperial cult mantle with heavy flak plates blessed by the Ecceliarchy to protect the wearer from threats to aid in protecting the faithful and to repel the heretic."
+	icon_state = "zealot"
+	item_state = "zealot"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flakheavy)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-150
+	slowdown_general = 0.06 // heavy crude armor. better then conscript but considerable slowdown.
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR-1,
+		bio = ARMOR_BIO_MINOR+15,
+		rad = ARMOR_RAD_MINOR+15,
+		bomb = ARMOR_BOMB_MINOR+10
+	)
+
+/obj/item/clothing/suit/armor/grim/ministorumrobes
+	name = "ministorum robes"
+	desc = "Gorgeous robes littered  with holy seals and writs. Smells faintly of incense. This one has been fitted with a special hidden armor plate for extra protection."
+	icon_state = "ministorum_priest"
+	item_state = "ministorum_priest"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flak)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-150
+	slowdown_general = 0.065
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR-1,
+		bio = ARMOR_BIO_MINOR+15,
+		rad = ARMOR_RAD_MINOR+15,
+		bomb = ARMOR_BOMB_MINOR+10
+	)
+
+// MERCANTILE
+
+/obj/item/clothing/suit/armor/grim/merc
+	name = "mercenary flak armour"
+	desc = "An altered fabrication of Imperial Pattern Flak Armor - this particular version is commonly used by mercenaries guilds in service to the renegade houses of the frontier."
+	icon_state = "merc"
+	item_state = "merc"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flak) // All flak armors should use plate/medium unless shoddy
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-25
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-100 // Consider militarum patterns to have good rad and temp resistance so we don't get guardsmen in EVA suits
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR-4,
+		rad = ARMOR_RAD_MINOR-5,
+		bio = ARMOR_BIO_MINOR-5,
+		bomb = ARMOR_BOMB_MINOR-6
+		)
+
+/obj/item/clothing/suit/armor/grim/merc/carapace
+	name = "mercenary carapace armour"
+	desc = "An altered fabrication of Imperial Pattern Carapace Armor - this particular version is commonly used by mercenaries guilds in service to the renegade houses of the frontier."
+	icon_state = "explorer"
+	item_state = "explorer"
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15 // Merc gear is outfitted for combat not extended ops
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+100
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE-1,
+		bullet = ARMOR_BALLISTIC_CARAPACE-1,
+		laser = ARMOR_LASER_CARAPACE-1,
+		energy = ARMOR_ENERGY_MINOR,
+		rad = ARMOR_RAD_MINOR+15,
+		bio = ARMOR_BIO_MINOR+10,
+		bomb = ARMOR_BOMB_MINOR+5
+		)
+
+
+// PILGRIMS
+
+/obj/item/clothing/suit/armor/grim/pilgrim/musician
+	name = "musician's garb"
+	desc = "A colorful yet somewhat tattered uniform."
+	icon_state = "xomrobe"
+	item_state = "xomrobe"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingheavy)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.03
+	armor = list(
+		melee = ARMOR_MELEE_PRIMAL,
+		bullet = ARMOR_BALLISTIC_PRIMAL+1,
+		laser = ARMOR_LASER_PRIMAL+1,
+		energy = ARMOR_ENERGY_MINOR-3,
+		bio = ARMOR_BIO_MINOR,
+		rad = ARMOR_RAD_MINOR+10,
+		bomb = ARMOR_BOMB_MINOR-4
+		)
+
+/obj/item/clothing/suit/armor/grim/pilgrim/admin
+	name = "administrator's garb"
+	desc = "Elegant clothing for a wealthy administrator, this one seems to have a hidden carapace armor plate in it... the plate seems to be of a cheap quality..."
+	icon_state = "robes"
+	item_state = "robes_item"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingheavy)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.04 // High quality cloth
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR-3,
+		bio = ARMOR_BIO_MINOR+10,
+		rad = ARMOR_RAD_MINOR+20,
+		bomb = ARMOR_BOMB_MINOR
+		)
+
+
+/obj/item/clothing/suit/armor/grim/pilgrim/merchant
+	name = "mercantile suit"
+	desc = "Elegant clothing for a wealthy trader."
+	icon_state = "male2"
+	item_state = "male2"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flak) // Trader's got monei
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.03
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR+10,
+		rad = ARMOR_RAD_MINOR+20, // no rads for the money man
+		bomb = ARMOR_BOMB_MINOR
+		)
+
+/obj/item/clothing/suit/armor/grim/pilgrim/penitent
+	name = "ragged robes"
+	desc = "Stinking, torn robes"
+	icon_state = "grosthrobe"
+	item_state = "grosthrobe"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingheavy)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.03
+	armor = list(
+		melee = ARMOR_MELEE_PRIMAL,
+		bullet = ARMOR_BALLISTIC_PRIMAL+1,
+		laser = ARMOR_LASER_PRIMAL+1,
+		energy = ARMOR_ENERGY_MINOR-3,
+		bio = ARMOR_BIO_MINOR,
+		rad = ARMOR_RAD_MINOR+10,
+		bomb = ARMOR_BOMB_MINOR-4
+		)
+
+/obj/item/clothing/suit/armor/grim/pilgrim/innapron
+	name = "heavy overcoat"
+	desc = "An amasec and caff stained apron."
+	icon_state = "mapron"
+	item_state = "mapron"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingheavy)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.03
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR+10,
+		rad = ARMOR_RAD_MINOR+20, // no rads for the money man
+		bomb = ARMOR_BOMB_MINOR
+		)
+
+/obj/item/clothing/suit/armor/grim/pilgrim/stalker
+	name = "light overcoat"
+	desc = "A red hunters uniform"
+	icon_state = "chokha"
+	item_state = "chokha"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/flaklamellar)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.045
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK-1, // Good overall defense but slow.
+		laser = ARMOR_LASER_FLAK-1,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR+10,
+		rad = ARMOR_RAD_MINOR+20,
+		bomb = ARMOR_BOMB_MINOR
+		)
+
+/obj/item/clothing/suit/armor/grim/pilgrim/pathfinder
+	name = "light overcoat"
+	desc = "A pathfinder's vestaments"
+	icon_state = "sherpa"
+	item_state = "sherpa"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingheavy)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.035
+	armor = list(
+		melee = ARMOR_MELEE_FLAK, // Good melee.
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR+10,
+		rad = ARMOR_RAD_MINOR+20,
+		bomb = ARMOR_BOMB_MINOR
+		)
+
+/obj/item/clothing/suit/armor/grim/pilgrim/smuggler
+	name = "light overcoat"
+	desc = "A jacket that only the shadiest of characters would wear, this one has two light flak armor plates glued to it's internal pockets."
+	icon_state = "scum"
+	item_state = "scum"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingheavy)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.03
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR,
+		bio = ARMOR_BIO_MINOR+10,
+		rad = ARMOR_RAD_MINOR+20,
+		bomb = ARMOR_BOMB_MINOR
+		)
+
+/obj/item/clothing/suit/armor/grim/pilgrim/medicae
+	name = "practioner robes"
+	desc = "Worn by practioners and other surgoens."
+	icon_state = "prac_robes"
+	item_state = "prac_robes"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingmech)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.04
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR+2,
+		bio = ARMOR_BIO_MINOR+30,
+		rad = ARMOR_RAD_MINOR+40,
+		bomb = ARMOR_BOMB_MINOR+5
+		)
+
+/obj/item/clothing/suit/storage/sistersuperiorsuit
+	name = "sister hospitaller's suit"
+	desc = "The holy garments marking the wearer as sister hospitaller"
+	icon_state = "hospitaller"
+	item_state = "hospitaller"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingmech)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.045
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK+1,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_MINOR+2,
+		bio = ARMOR_BIO_MINOR+50,
+		rad = ARMOR_RAD_MINOR+60,
+		bomb = ARMOR_BOMB_MINOR+20
+		)
+
+/obj/item/clothing/suit/storage/sistersuit
+	name = "sister discipulus's suit"
+	desc = "The holy garments marking the wearer as a discipulus hospitaller"
+	icon_state = "hospitallerold"
+	item_state = "hospitallerold"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingmech)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.04
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_MINOR+2,
+		bio = ARMOR_BIO_MINOR+40,
+		rad = ARMOR_RAD_MINOR+50,
+		bomb = ARMOR_BOMB_MINOR+10
+		)

--- a/code/modules/clothing/suits/pilgrimarmor.dm
+++ b/code/modules/clothing/suits/pilgrimarmor.dm
@@ -252,6 +252,66 @@
 		bomb = ARMOR_BOMB_MINOR +15
 	)
 
+/obj/item/clothing/suit/armor/grim/pilgrim/medicae
+	name = "practioner robes"
+	desc = "Worn by practioners and other surgoens."
+	icon_state = "prac_robes"
+	item_state = "prac_robes"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingmech)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.04
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-2,
+		energy = ARMOR_ENERGY_MINOR+2,
+		bio = ARMOR_BIO_MINOR+30,
+		rad = ARMOR_RAD_MINOR+40,
+		bomb = ARMOR_BOMB_MINOR+5
+		)
+
+/obj/item/clothing/suit/storage/sistersuperiorsuit
+	name = "sister hospitaller's suit"
+	desc = "The holy garments marking the wearer as sister hospitaller"
+	icon_state = "hospitaller"
+	item_state = "hospitaller"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingmech)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.045
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK+1,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_MINOR+2,
+		bio = ARMOR_BIO_MINOR+50,
+		rad = ARMOR_RAD_MINOR+60,
+		bomb = ARMOR_BOMB_MINOR+20
+		)
+
+/obj/item/clothing/suit/storage/sistersuit
+	name = "sister discipulus's suit"
+	desc = "The holy garments marking the wearer as a discipulus hospitaller"
+	icon_state = "hospitallerold"
+	item_state = "hospitallerold"
+	body_parts_covered = LEGS|ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingmech)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
+	slowdown_general = 0.04
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_MINOR+2,
+		bio = ARMOR_BIO_MINOR+40,
+		rad = ARMOR_RAD_MINOR+50,
+		bomb = ARMOR_BOMB_MINOR+10
+		)
+
 /obj/item/clothing/suit/armor/grim/zealot
 	name = "heavy mantle"
 	desc = "An imperial cult mantle with heavy flak plates blessed by the Ecceliarchy to protect the wearer from threats to aid in protecting the faithful and to repel the heretic."
@@ -494,64 +554,4 @@
 		bio = ARMOR_BIO_MINOR+10,
 		rad = ARMOR_RAD_MINOR+20,
 		bomb = ARMOR_BOMB_MINOR
-		)
-
-/obj/item/clothing/suit/armor/grim/pilgrim/medicae
-	name = "practioner robes"
-	desc = "Worn by practioners and other surgoens."
-	icon_state = "prac_robes"
-	item_state = "prac_robes"
-	body_parts_covered = LEGS|ARMS
-	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingmech)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
-	slowdown_general = 0.04
-	armor = list(
-		melee = ARMOR_MELEE_FLAK-1,
-		bullet = ARMOR_BALLISTIC_FLAK-1,
-		laser = ARMOR_LASER_FLAK-2,
-		energy = ARMOR_ENERGY_MINOR+2,
-		bio = ARMOR_BIO_MINOR+30,
-		rad = ARMOR_RAD_MINOR+40,
-		bomb = ARMOR_BOMB_MINOR+5
-		)
-
-/obj/item/clothing/suit/storage/sistersuperiorsuit
-	name = "sister hospitaller's suit"
-	desc = "The holy garments marking the wearer as sister hospitaller"
-	icon_state = "hospitaller"
-	item_state = "hospitaller"
-	body_parts_covered = LEGS|ARMS
-	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingmech)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
-	slowdown_general = 0.045
-	armor = list(
-		melee = ARMOR_MELEE_FLAK,
-		bullet = ARMOR_BALLISTIC_FLAK+1,
-		laser = ARMOR_LASER_FLAK,
-		energy = ARMOR_ENERGY_MINOR+2,
-		bio = ARMOR_BIO_MINOR+50,
-		rad = ARMOR_RAD_MINOR+60,
-		bomb = ARMOR_BOMB_MINOR+20
-		)
-
-/obj/item/clothing/suit/storage/sistersuit
-	name = "sister discipulus's suit"
-	desc = "The holy garments marking the wearer as a discipulus hospitaller"
-	icon_state = "hospitallerold"
-	item_state = "hospitallerold"
-	body_parts_covered = LEGS|ARMS
-	accessories = list(/obj/item/clothing/accessory/armor_plate/paddingmech)
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-15
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE-300
-	slowdown_general = 0.04
-	armor = list(
-		melee = ARMOR_MELEE_FLAK,
-		bullet = ARMOR_BALLISTIC_FLAK,
-		laser = ARMOR_LASER_FLAK,
-		energy = ARMOR_ENERGY_MINOR+2,
-		bio = ARMOR_BIO_MINOR+40,
-		rad = ARMOR_RAD_MINOR+50,
-		bomb = ARMOR_BOMB_MINOR+10
 		)

--- a/code/modules/clothing/suits/retinuearmor.dm
+++ b/code/modules/clothing/suits/retinuearmor.dm
@@ -1,0 +1,1370 @@
+
+
+/obj/item/clothing/suit/armor/prince
+	name = "Prince's Plate"
+	desc = "The Border Prince's personal Plate Armor"
+	icon_state = "prince"
+	item_state = "prince"
+
+// ORDOS INQUISITION
+/obj/item/clothing/suit/armor/grim/agent
+	name = "carapace coat"
+	desc = "A brilliantly made carapace coat for Inquisitorial Agents, adorned with holy seals and the Rosette to ward off Chaos corruption."
+	icon_state = "acolytecoat"
+	item_state = "acolytecoat"
+	body_parts_covered = LEGS | ARMS
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapaceheavy)
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -45
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +100
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE + 1,
+		bullet = ARMOR_BALLISTIC_CARAPACE + 1,
+		laser = ARMOR_LASER_CARAPACE + 1,
+		energy = ARMOR_ENERGY_MINOR + 25,
+		bio = ARMOR_BIO_MINOR + 30,
+		rad = ARMOR_RAD_MINOR + 40,
+		bomb = ARMOR_BOMB_PADDED + 20
+	)
+
+/obj/item/clothing/suit/armor/grim/agent/inquisitor
+	name = "masterwork carapace coat"
+	desc = "The formidable, brilliantly made Carapace Armour for the Inquisitorial Agent, bearing the holy symbol of the Inquisition, the Rosette."
+	icon_state = "inqcoat"
+	item_state = "inqcoat"
+	body_parts_covered = LEGS | ARMS
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -60
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +150
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE + 1,
+		bullet = ARMOR_BALLISTIC_CARAPACE + 2,
+		laser = ARMOR_LASER_CARAPACE + 2,
+		energy = ARMOR_ENERGY_MINOR + 35,
+		bio = ARMOR_BIO_MINOR + 40,
+		rad = ARMOR_RAD_MINOR + 50,
+		bomb = ARMOR_BOMB_PADDED + 30
+	)
+
+/obj/item/clothing/suit/armor/grim/agent/hereticus
+	name = "masterwork carapace coat"
+	desc = "The Inquisitor's holy coat, forged from a Tech-priest of Mars for his use in his path of holy fire toward enemies of our Emperor, Hanging from the coat a Inquisitorial Rosette, It shines brightly as if it is the Emperor himself is present, For he'll cleanse the darkness."
+	icon_state = "hereticuscoat"
+	item_state = "hereticuscoat"
+	body_parts_covered = LEGS | ARMS
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	accessories = list(/obj/item/clothing/accessory/armor_plate/carapacemaster)
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -60
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +150
+	slowdown_general = 0.06
+	armor = list(
+		melee = ARMOR_MELEE_CARAPACE + 1,
+		bullet = ARMOR_BALLISTIC_CARAPACE + 2,
+		laser = ARMOR_LASER_CARAPACE + 2,
+		energy = ARMOR_ENERGY_MINOR + 35,
+		bio = ARMOR_BIO_MINOR + 40,
+		rad = ARMOR_RAD_MINOR + 50,
+		bomb = ARMOR_BOMB_PADDED + 30
+	)
+
+/obj/item/clothing/suit/armor/grim/storage/hooded/inqparmor
+	name = "relic power armour"
+	desc = "This ancient and sacred power armour was forged by the tech-priests of Mars, sanctified for the Inquisitor's righteous crusade against the enemies of the Emperor. Bearing the engraved Inquisitorial Rosette, its gleaming surface radiates with the Emperor's divine light, as if his presence guides the wearer to purge the darkness."
+	icon_state = "inqarmor"
+	item_state = "inqarmor"
+	valid_accessory_slots = null // So you can't remove or attach armor acceesories.
+	restricted_accessory_slots = null
+	accessories = null
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	max_pressure_protection = RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1500
+	slowdown_general = 0.12 // Tiny bit slow. Design wise power armor is more rare then a lemun russ tank, it has no downsides. It simply is superior to all other armor.
+	hoodtype = /obj/item/clothing/head/inqhood
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR,
+		laser = ARMOR_LASER_POWER_ARMOUR,
+		energy = ARMOR_ENERGY_MINOR + 55,
+		bio = ARMOR_BIO_MINOR + 84,
+		rad = ARMOR_RAD_MINOR + 86,
+		bomb = ARMOR_BOMB_PADDED + 45
+	)
+/obj/item/clothing/head/inqhood
+	name = "inquisitor's hood"
+	desc = "A blood red hood with golden trim"
+	icon_state = "inqhood"
+	item_state = "inqhood"
+	max_pressure_protection = RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE -100
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE +1500
+	flags_inv = HIDEMASK|HIDEEYES|HIDEFACE|HIDEEARS|BLOCKHAIR|BLOCKHEADHAIR
+	unacidable = 1
+	slowdown_general = 0.005
+	armor = list(
+		melee = ARMOR_MELEE_POWER_ARM-1,
+		bullet = ARMOR_BALLISTIC_POWER_ARMOUR-1,
+		laser = ARMOR_LASER_POWER_ARMOUR-1,
+		energy = ARMOR_ENERGY_MINOR + 55,
+		bio = ARMOR_BIO_MINOR + 84,
+		rad = ARMOR_RAD_MINOR + 86,
+		bomb = ARMOR_BOMB_PADDED + 45
+	)
+
+
+
+/obj/item/clothing/suit/armor/orkarmor
+	name = "'Eavy Metal Ork Armor"
+	desc = "Scavenged 'eavy bitz to keep ya' krumpin' longa'!"
+	icon_state = "ork_m_armor"
+	item_state = "ork_m_armor"
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
+	body_parts_covered = LEGS|ARMS|FULL_TORSO
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+50
+	slowdown_general = 0.4 // Make sure to set ork speed to match this slowdown. So it only slows down non-orks wearing it.
+	armor = list(
+		melee = ARMOR_MELEE_FLAK+2,
+		bullet = ARMOR_BALLISTIC_FLAK+1,
+		laser = ARMOR_LASER_FLAK+1,
+		energy = ARMOR_ENERGY_MINOR+10,
+		bio = ARMOR_BIO_MINOR+20,
+		rad = ARMOR_RAD_MINOR+40,
+		bomb = ARMOR_BOMB_MINOR+20
+	)
+
+/*
+
+// Ork
+
+
+
+/obj/item/clothing/suit/armor/orkarmor/snazzy
+	name = "Snazzy Shoota Armor"
+	desc = "Snazzy Armor of em ranged shoota boy types. Gud all rounda. Wat eva dat wurd means..."
+	icon_state = "snazzya"
+	item_state = "snazzya"
+	armor = list(melee = 8, bullet = 39, laser = 35, energy = 25, bomb = 50, bio = 0, rad = 0)
+
+/obj/item/clothing/suit/armor/orkarmor/freeb
+	name = "Freeboota Coat"
+	desc = "Freeboota Coat of em ranged merc boy types. Gud all rounda. Wat eva dat wurd means..."
+	icon_state = "freeboota"
+	item_state = "freeboota"
+	armor = list(melee = 8, bullet = 35, laser = 39, energy = 25, bomb = 50, bio = 0, rad = 0)
+
+/obj/item/clothing/suit/armor/orkarmor/snazzy/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.1
+
+/obj/item/clothing/suit/armor/orkarmor/skullza
+	name = "Orky Boy Skull Armor"
+	desc = "Da armor of a real lova of humie skullz'. Dis Boy 'oves gettin' in klose kombat, it's defeenses help loads in da maylays!"
+	icon_state = "ork_skullza"
+	item_state = "ork_skullza"
+	armor = list(melee = 12, bullet = 35, laser = 35, energy = 25, bomb = 50, bio = 0, rad = 0)
+
+/obj/item/clothing/suit/armor/orkarmor/skullza/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.1
+
+/obj/item/clothing/suit/armor/orkarmor/zog
+	name = "Zogging Ork Boy Armor"
+	desc = "Da buttom of de barrel, dis one. Won't protek ya much. Betta dun nuffin, me guesses..."
+	icon_state = "zoga"
+	item_state = "zoga"
+	armor = list(melee = 8, bullet = 35, laser = 35, energy = 25, bomb = 50, bio = 0, rad = 0)
+
+/obj/item/clothing/suit/armor/orkarmor/zog/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.1
+
+/obj/item/clothing/suit/armor/orkarmor/warboss
+	name = "War Boss Arma'"
+	desc = "DA BOSS WEARS THIS!"
+	icon_state = "ork_m_armor"
+	item_state = "ork_m_armor"
+	armor = list(melee = 12, bullet = 45, laser = 45, energy = 25, bomb = 50, bio = 0, rad = 0)
+
+/obj/item/clothing/suit/armor/orkarmor/warboss/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+// NOBLES & SERVANTS
+/obj/item/clothing/suit/armor/rtcloak
+	name = "Rogue Trader's Cloak"
+	desc = "The distinguished cloak of a Rogue Trader"
+	icon_state = "lccoat"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 5, bullet = 38, laser = 38, energy = 25, bomb = 40, bio = 20, rad = 20) //Hidden armoured plates
+	sales_price = 0
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS |ARMS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/rtcloak2
+	name = "Rogue Trader's Armor"
+	desc = "The distinguished armor of a Rogue Trader"
+	icon_state = "rtarm"
+	item_state = "rtarm"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 5, bullet = 38, laser = 38, energy = 25, bomb = 40, bio = 20, rad = 20)
+	sales_price = 0
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS |ARMS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/rtcloak/mechanicus
+	name = "Rogue Trader's Cloak(M)"
+	desc = "The distinguished cloak of a Rogue Trader, improved by the Mechanicus."
+	armor = list(melee = 7, bullet = 39, laser = 41, energy = 25, bomb = 40, bio = 20, rad = 20) //Hidden armoured plates
+
+/obj/item/clothing/suit/armor/governor
+	name = "Planetary Governor's Mantle"
+	desc = "The extra, extra, extra large exotic mantle of the Governor of Messina. Custom tailor made for his superb frame. It is interwoven into his flesh and unremovable"
+	icon_state = "taxstomach"
+	item_state = "taxstomach"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 7, bullet = 39, laser = 41, energy = 25, bomb = 40, bio = 20, rad = 20) //Hidden armoured plates
+	sales_price = 30
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+
+/obj/item/clothing/suit/armor/governor/mechanicus
+	name = "Planetary Governor's Mantle(M)"
+	desc = "The extra, extra, extra large exotic mantle of the Governor of Messina, improved by the Mechanicus. Custom tailor made for his superb frame. It is interwoven into his flesh and unremovable"
+	armor = list(melee = 8, bullet = 41, laser = 43, energy = 25, bomb = 60, bio = 20, rad = 20) //Hidden armoured plates
+
+/obj/item/clothing/suit/armor/rtdrip
+	name = "Rogue Trader's Fancy Robes"
+	desc = "The stylish robes of a Rogue Trader"
+	icon_state = "rtdrip"
+	item_state = "rtdrip"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 7, bullet = 39, laser = 41, energy = 25, bomb = 40, bio = 20, rad = 20) //Hidden armoured plates
+	sales_price = 5
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/slanclothing/femaleslan
+	name = "Noble Red Dress"
+	desc = "Elegant, fashionable, lavish!"
+	icon_state = "baroness"
+	item_state = "baroness"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun,/obj/item/melee/whip/lashoftorment,)
+	armor = list(melee = 5, bullet = 15, laser = 15, energy = 15, bomb = 10, bio = 10, rad = 10)
+	sales_price = 5
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+
+/obj/item/clothing/suit/storage/senkhalat
+	name = "ornate khalat"
+	desc = "The ornate khalat of the Steward. It is made from the finest fabrics this side of the galaxy and interwoven with real gold. Very fancy and well armored."
+	icon_state = "senkhalat"
+	item_state = "senkhalat"
+	armor = list(melee = 4, bullet = 30, laser = 35, energy = 0, bomb = 50, bio = 15, rad = 15)
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 40
+
+/obj/item/clothing/suit/storage/traderpirate
+	name = "rugged and regal trader coat"
+	desc = "A rugged, regal, trader coat. It is dyed with the finest of dyes and made from durable and armored fabric. For when you need to plunder and pillage the galactic seas."
+	icon_state = "traderpirate"
+	item_state = "traderpirate"
+	armor = list(melee = 5, bullet = 35, laser = 35, energy = 20, bomb = 40, bio = 15, rad = 15)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 30
+
+/obj/item/clothing/suit/armor/vest/leather/tailcoat
+	name = "tailcoat"
+	desc = "A fancy tailcoat to make your suit seem even more lavish."
+	icon_state = "tailcoat"
+	item_state = "tailcoat"
+	armor = list(melee = 2, BULLET = 20, LASER = 30, ENERGY = 10, BOMB = 15, BIO = 0, FIRE = 20, ACID = 15)
+//	pocket_storage_component_path = /datum/component/storage/concrete/pockets/tailcoat
+
+/obj/item/clothing/suit/armor/vest/leather/tailcoat/ladycoat
+	name = "lady coat"
+	desc = "Fancy lady coat."
+	icon = 'icons/mob/onmob/suit.dmi'
+	icon_state = "tailcoatgirlblack"
+	item_state = "tailcoatgirlblack"
+	armor = list(melee = 5, BULLET = 30, LASER = 22, energy = 30, BOMB = 15, BIO = 0, FIRE = 10, ACID = 5)
+
+/obj/item/clothing/suit/armor/vest/leather/tailcoat/ladycoat/red
+	icon_state = "tailcoatladiesred"
+	item_state = "tailcoatladiesred"
+
+/obj/item/clothing/suit/armor/vest/leather/tailcoat/black
+	icon_state = "tailcoatb"
+	item_state = "tailcoatb"
+
+/obj/item/clothing/suit/armor/vest/leather/tailcoat/ladycoat/grey
+	icon_state = "ladiesvictoriancoatg"
+	item_state = "ladiesvictoriancoatg"
+
+
+/obj/item/clothing/suit/storage/hooded/miner
+	name = "Mining Robes"
+	desc = "Black mining robes commonly worn by the nascent workers of underhives."
+	icon_state = "mortician"
+	item_state = "mortician"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun, /obj/item/pickaxe)
+	armor = list(melee = 7, bullet = 25, laser = 25, energy = 30, bomb = 0, bio = 0, rad = 0)
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	action_button_name = "Toggle Hood"
+	hoodtype = /obj/item/clothing/head/mininghood
+
+/obj/item/clothing/suit/armor/slanclothing/maleslan
+	name = "Studded Coat"
+	desc = "An ellegant studded coat worn by the illustrious servants of noble courts."
+	icon_state = "castellan"
+	item_state = "castellan"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun,/obj/item/melee/whip/lashoftorment,)
+	armor = list(melee = 8, bullet = 28, laser = 20, energy = 30, bomb = 10, bio = 10, rad = 10)
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/militia
+	name = "Heavy Overcoat"
+	desc = "A durable and heavy overcoat designed to protect against indirect blast and small arms fire."
+	icon_state = "bluecoat"
+	item_state = "bluecoat"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun,/obj/item/melee/whip/lashoftorment,)
+	armor = list(melee = 8, bullet = 20, laser = 28, energy = 30, bomb = 10, bio = 10, rad = 10)
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/cloak
+	name = "Mysterious Cloak"
+	desc = "A tough black cloak made from animal leather."
+	icon_state = "bluecoat_sniper"
+	item_state = "bluecoat_sniper"
+	armor = list(melee = 8, bullet = 20, laser = 28, energy = 30, bomb = 10, bio = 10, rad = 10)
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+
+
+
+// NEW ARMORS
+
+/obj/item/clothing/suit/armor/heavyflaksuit
+	name = "Heavy Flak Suit"
+	desc = "A custom made flak suit used for close quarters fighting, it's restrictive nature is made up by it's excessive protection from small arms and explosive damage."
+	icon_state = "meister"
+	item_state = "meister"
+	armor = list(melee = 9, bullet = 34, laser = 34, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 28
+/obj/item/clothing/suit/armor/heavyflaksuit/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+/obj/item/clothing/suit/armor/fraterisarmor
+	name = "Frateris Robes"
+	desc = "Robes of the faithful concealing aged flak plates stitched into the front and back."
+	icon_state = "syndievest"
+	item_state = "syndievest"
+	armor = list(melee = 9, bullet = 30, laser = 30, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/witch
+	name = "Witch Hunter's Gambeson"
+	desc = "The gambeson chosen by the fanatical Frateris Witch Hunters of the Ecclesiarchy"
+	icon_state = "preacherarmor"
+	item_state = "preacherarmor"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 11, bullet = 32, laser = 32, energy = 30, bomb = 40, bio = 30, rad = 30)
+	sales_price = 5
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/trinet
+	name = "Iron Cuirass"
+	desc = "An iron-alloy breastplate forged by local hands, it's craftsmanship is questionable but the exotic alloy is remarkbly unique to Messina."
+	icon_state = "trinet"
+	item_state = "trinet"
+	armor = list(melee = 11, bullet = 25, laser = 25, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/trinet/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.2
+
+/obj/item/clothing/suit/armor/breastplate
+	name = "Iron Breastplate"
+	desc = "An iron-alloy breastplate forged by local hands, it's craftsmanship is questionable but the exotic alloy is remarkbly unique to Messina."
+	icon_state = "bmerc2"
+	item_state = "bmerc2"
+	armor = list(melee = 11, bullet = 25, laser = 25, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/heavyduster
+	name = "Mysterious Duster"
+	desc = "This strange duster fits snugly against your back, heavily padded and made of fire-retardent materials."
+	icon_state = "chemsis"
+	item_state = "chemsis"
+	armor = list(melee = 8, bullet = 28, laser = 28, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/iplate
+	name = "Heavy Plate Cuirass"
+	desc = "An iron-alloy heavy plate cuirass forged by local hands, it's craftsmanship is remarkable and benefits from the exotic alloy unique to Messina."
+	icon_state = "iplate"
+	item_state = "iplate"
+	armor = list(melee = 11, bullet = 27, laser = 27, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/iplate/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+/obj/item/clothing/suit/armor/templar
+	name = "Full Plate Armor"
+	desc = "An iron-alloy heavy plate cuirass forged by local hands, it's craftsmanship is remarkable and benefits from the exotic alloy unique to Messina."
+	icon_state = "templar"
+	item_state = "templar"
+	armor = list(melee = 11, bullet = 27, laser = 27, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/templar/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+/obj/item/clothing/suit/armor/knighthosp
+	name = "Frateris Plate"
+	desc = "An iron-alloy heavy plate cuirass forged by local hands, it's craftsmanship is remarkable and benefits from the exotic alloy unique to Messina."
+	icon_state = "knight_hospitaller"
+	item_state = "knight_hospitaller"
+	armor = list(melee = 11, bullet = 27, laser = 27, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/knighthosp/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+/obj/item/clothing/suit/armor/hauberk
+	name = "Hauberk"
+	desc = "A light chain hauberk worn over padded cloth, it's comfortable and protects against slashes."
+	icon_state = "hauberk"
+	item_state = "hauberk"
+	armor = list(melee = 8, bullet = 25, laser = 25, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/hauberk/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.2
+
+/obj/item/clothing/suit/armor/slaverobe
+	name = "Serf Robes"
+	desc = "Disgusting filthy robes worn by gutter trash like you."
+	icon_state = "slaverobe"
+	item_state = "slaverobe"
+	armor = list(melee = 8, bullet = 29, laser = 29, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/slaverobe/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = -0.1
+
+/obj/item/clothing/suit/armor/armoredtrench
+	name = "Armored Trenchcoat"
+	desc = "A heavy armored trenchcoat with carapace plates inserted into the front and back. Attached also are iron-alloy chausses and pauldrons, a true masterwork of Messina."
+	icon_state = "towntrench_heavy"
+	item_state = "towntrench_heavy"
+	armor = list(melee = 8, bullet = 32, laser = 32, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/armoredtrench/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.2
+
+/obj/item/clothing/suit/armor/vanpa
+	name = "Van Saar Power Armor"
+	desc = "A heavy set of Necromundan Power Armor manufactured by the House of Van Saar, the quality despite it's status as technical power armor is quite poor."
+	icon_state = "lightpa2"
+	item_state = "lightpa2"
+	armor = list(melee = 9, bullet = 38, laser = 38, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 70
+/obj/item/clothing/suit/armor/vanpa/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.7
+
+/obj/item/clothing/suit/armor/berserker
+	name = "Berserker Power Armor"
+	desc = "A heavy set of Berserker Power Armor manufactured by unknown smiths of ruinous origin, it radiates with incredible energy and a wrath that infests your very soul. The touch of fire has no effect on you."
+	icon_state = "berserker"
+	item_state = "berserker"
+	armor = list(melee = 12, bullet = 40, laser = 40, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	sales_price = 0
+/obj/item/clothing/suit/armor/berserker/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.8
+
+/obj/item/clothing/suit/armor/goliathplate
+	name = "Barbarian Plate"
+	desc = "A heavy set of Goliath Plate manufactured by the Goliath House of Necromunda, the quality is terrible but is forged of rare metals from the Necromunda smelteries."
+	icon_state = "paladin"
+	item_state = "paladin"
+	armor = list(melee = 9, bullet = 32, laser = 32, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 10
+/obj/item/clothing/suit/armor/goliathplate/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.3
+
+/obj/item/clothing/suit/armor/goliatharmor
+	name = "Raider Cuirass"
+	desc = "A light set of Goliath armor manufactured by the Goliath House of Necromunda, the quality is terrible but is forged of rare metals from the Necromunda smelteries."
+	icon_state = "venator"
+	item_state = "venator"
+	armor = list(melee = 8, bullet = 30, laser = 30, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/goliatharmor/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.2
+
+/obj/item/clothing/suit/armor/sniper
+	name = "Ghillie Suit"
+	desc = "A strange ghillie suit uniquely lacking in any camoflauge that would hide you on an ice-world."
+	icon_state = "fox"
+	item_state = "fox"
+	armor = list(melee = 5, bullet = 34, laser = 34, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/seolarmor
+	name = "Seolite Robes"
+	desc = "Armored Robes of the xenos species of Seol. It seems the protective layers are designed to prevent lasburns or... even worse."
+	icon_state = "scribe"
+	item_state = "scribe"
+	armor = list(melee = 5, bullet = 31, laser = 39, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 10
+
+/obj/item/clothing/suit/armor/seolsuit
+	name = "Seolite Anomaly Suit"
+	desc = "Forged by the strange xenos of this barren ice-world, it seeems to have an advanced protective field wrapping around it."
+	icon_state = "spacer"
+	item_state = "spacer"
+	armor = list(melee = 11, bullet = 34, laser = 39, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET|HEAD
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	sales_price = 60
+/obj/item/clothing/suit/armor/seolsuit/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.8
+
+/obj/item/clothing/suit/armor/flak1
+	name = "Necromundan Flak Armor"
+	desc = "Unmarked flak armor manufactured by the underhives of Necromunda."
+	icon_state = "flak1"
+	item_state = "flak1"
+	armor = list(melee = 5, bullet = 31, laser = 31, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 9
+/obj/item/clothing/suit/armor/flak1/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.2
+
+/obj/item/clothing/suit/armor/flak2
+	name = "Necromundan Flak Vest" // Protects chest only.
+	desc = "Unmarked flak vest manufactured by the underhives of Necromunda."
+	icon_state = "flak2"
+	item_state = "flak2"
+	armor = list(melee = 4, bullet = 28, laser = 28, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 7
+
+/obj/item/clothing/suit/armor/carapace2
+	name = "Necromundan Carapace Armor"
+	desc = "Unmarked carapace armor manufactured by the underhives of Necromunda."
+	icon_state = "carapace2"
+	item_state = "carapace2"
+	armor = list(melee = 7, bullet = 33, laser = 33, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 25
+/obj/item/clothing/suit/armor/carapace2/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.3
+
+/obj/item/clothing/suit/armor/carapace3
+	name = "Necromundan Carapace Armor"
+	desc = "Unmarked carapace armor manufactured by the underhives of Necromunda."
+	icon_state = "carapace3"
+	item_state = "carapace3"
+	armor = list(melee = 7, bullet = 33, laser = 33, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 25
+/obj/item/clothing/suit/armor/carapace3/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.3
+
+/obj/item/clothing/suit/armor/carapace4
+	name = "Heavy Carapace Armor"
+	desc = "Unmarked carapace armor manufactured by the underhives of Necromunda."
+	icon_state = "carapace4"
+	item_state = "carapace4"
+	armor = list(melee = 8, bullet = 35, laser = 35, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 35
+/obj/item/clothing/suit/armor/carapace4/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+/obj/item/clothing/suit/armor/goliath2
+	name = "Goliath Flak Armor"
+	desc = "Shoddy flak armor worn by members of House Goliath, it seems unlikely to protect you from much more then a blade."
+	icon_state = "raider_combat"
+	item_state = "raider_combat"
+	armor = list(melee = 7, bullet = 31, laser = 31, energy = 25, bomb = 30, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 15
+/obj/item/clothing/suit/armor/goliath2/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.2
+
+/obj/item/clothing/suit/armor/greypa
+	name = "Mechanicus Power Armour"
+	desc = "Mechanicus power armour, forged by the Tech-priest of Mars and blessed with runes of blankness, a potent tool against the great enemy."
+	icon_state = "knight_grey"
+	item_state = "knight_grey"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 10, bullet = 38, laser = 38, energy = 30, bomb = 60, bio = 60, rad = 90)
+	sales_price = 90
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+/obj/item/clothing/suit/armor/greypa/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+/obj/item/clothing/suit/armor/rpowerarmor
+	name = "Renegade Power Armour"
+	desc = "Masterwork power armor forged and used by the renegade navigator houses."
+	icon_state = "t51bgs"
+	item_state = "t51bgs"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 9, bullet = 40, laser = 40, energy = 30, bomb = 40, bio = 30, rad = 30)
+	sales_price = 85
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+/obj/item/clothing/suit/armor/rpowerarmor/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+/obj/item/clothing/suit/armor/scum2
+	name = "Mysterious Garb"
+	desc = "These clothes belong to the most mystical of folk."
+	icon_state = "gothcoat"
+	item_state = "gothcoat"
+	armor = list(melee = 8, bullet = 28, laser = 28, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/leather
+	name = "Leather Armor"
+	desc = "Shoddy armor sewn from shafra leather, it protects you more from the cold then anything else."
+	icon_state = "leatherarmor"
+	item_state = "leatherarmor"
+	armor = list(melee = 8, bullet = 27, laser = 27, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/hjacket
+	name = "Heavy Jacket"
+	desc = "A heavy leather jacket."
+	icon_state = "wornmfp"
+	item_state = "wornmfp"
+	armor = list(melee = 8, bullet = 27, laser = 27, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/hjacket2
+	name = "Cool Jacket"
+	desc = "A light jacket worn by gangers."
+	icon_state = "biker_jacket"
+	item_state = "biker_jacket"
+	armor = list(melee = 5, bullet = 27, laser = 31, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/slumcoat
+	name = "Slum Coat"
+	desc = "A heavy leather coat made of a strange leather, it's incredibly durable."
+	icon_state = "ghostechoe"
+	item_state = "ghostechoe"
+	armor = list(melee = 8, bullet = 27, laser = 27, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/towntrench
+	name = "Trench Coat"
+	desc = "A trench coat underpiece to wear with your trench coat!"
+	icon_state = "towntrench_special"
+	item_state = "towntrench_special"
+	armor = list(melee = 8, bullet = 27, laser = 27, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/vessor
+	name = "Vessorine Carapace"
+	desc = "A light bodysuit with carapace plates overlayn like an exterior scale-mail, the suit appears to be powered."
+	icon_state = "uegarmor"
+	item_state = "uegarmor"
+	armor = list(melee = 9, bullet = 34, laser = 33, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 40
+
+/obj/item/clothing/suit/armor/exile
+	name = "Vessorine Armor"
+	desc = "Ritual combat armor worn by the natives of Vessor."
+	icon_state = "exile"
+	item_state = "exile"
+	armor = list(melee = 11, bullet = 28, laser = 28, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/exile/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = -0.3
+
+/obj/item/clothing/suit/armor/tribalarmor
+	name = "Tribal Armor"
+	desc = "Ritual combat armor worn by the nomadic clansmen predating the colony."
+	icon_state = "tribal_armor"
+	item_state = "tribal_armor"
+	armor = list(melee = 9, bullet = 27, laser = 27, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/bonearmor
+	name = "Boneplate Armor"
+	desc = "Shoddy bone armor constructed from the gigantic bones of a local beast, the materials are surprisingly durable."
+	icon_state = "bonearmor"
+	item_state = "bonearmor"
+	armor = list(melee = 10, bullet = 29, laser = 29, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/bonearmor/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+/obj/item/clothing/suit/armor/brigandine
+	name = "Brigandine"
+	desc = "A heavy set of plated leather overlayn to protect against the sturdiest of thrown rocks."
+	icon_state = "brigandine"
+	item_state = "brigandine"
+	armor = list(melee = 9, bullet = 29, laser = 29, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/brigandine/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.3
+
+/obj/item/clothing/suit/armor/brigandine/palace
+	name = "Honour Guard Cuirass"
+	desc = "A heavy set of fine plat with carapace inserts to protect against even the most unconventional of weapons. Worn by the Honour Guard of Messina."
+	icon_state = "templar"
+	item_state = "templar"
+	color = "#ad9b30"
+	armor = list(melee = 8, bullet = 31, laser = 31, energy = 30, bomb = 40, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/armor/brigandine/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.3
+
+/obj/item/clothing/suit/armor/kasrkin
+	name = "Kasrkin Carapace"
+	desc = "The Carapace Armor of an Elite Kasrkin, a reliable stormtrooper armor."
+	icon_state = "kasrkinarmor"
+	item_state = "kasrkinarmor"
+	armor = list(melee = 9, bullet = 38, laser = 38, energy = 30, bomb = 40, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 40
+
+/obj/item/clothing/suit/armor/royalguard
+	name = "Captain's Carapace"
+	desc = "The Carapace Armor of the local Messian Captain."
+	icon_state = "royalgc"
+	item_state = "royalgc"
+	armor = list(melee = 9, bullet = 38, laser = 38, energy = 30, bomb = 40, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 60
+
+/obj/item/clothing/suit/armor/pdfcapt
+	name = "Captain's Carapace"
+	desc = "The Carapace Armor of the local Messian Captain."
+	icon_state = "PDF-CaptainT"
+	item_state = "PDF-CaptainT"
+	armor = list(melee = 9, bullet = 38, laser = 38, energy = 30, bomb = 40, bio = 30, rad = 50)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 60
+
+/obj/item/clothing/suit/armor/tduster
+	name = "Armored Duster"
+	desc = "A duster with a flak plate insert, sewn together with shafra leather."
+	icon_state = "talon_duster"
+	item_state = "talon_duster"
+	armor = list(melee = 7, bullet = 29, laser = 29, energy = 25, bomb = 30, bio = 30, rad = 20)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/carapaceduster
+	name = "Armored Duster"
+	desc = "A duster with carapace plate inserts, sewn together with shafra leather."
+	icon_state = "ranger"
+	item_state = "ranger"
+	armor = list(melee = 7, bullet = 32, laser = 32, energy = 25, bomb = 38, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+// ARMORS PHASE TWO
+
+/obj/item/clothing/suit/armor/necromundaflak1
+	name = "Heavy Flak Armor"
+	desc = "Unmarked heavy flak armor manufactured by the underhives of Necromunda."
+	icon_state = "necromundaflak"
+	item_state = "necromundaflak"
+	armor = list(melee = 8, bullet = 31, laser = 31, energy = 25, bomb = 38, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 15
+/obj/item/clothing/suit/armor/necromundaflak1/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+/obj/item/clothing/suit/armor/necromundacarapace1
+	name = "Heavy Carapace Armor"
+	desc = "Unmarked heavy carapace armor manufactured by the underhives of Necromunda."
+	icon_state = "necromundacarapace"
+	item_state = "necromundacarapace"
+	armor = list(melee = 7, bullet = 33, laser = 33, energy = 25, bomb = 38, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 31
+/obj/item/clothing/suit/armor/necromundacarapace1/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+/obj/item/clothing/suit/armor/ranger2
+	name = "Colonial Duster"
+	desc = "A duster with a flak plate insert, sewn together with grox leather."
+	icon_state = "ranger2"
+	item_state = "ranger2"
+	armor = list(melee = 7, bullet = 31, laser = 31, energy = 31, bomb = 38, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/ranger3
+	name = "Ganger Duster"
+	desc = "A duster with a flak plate insert, sewn together with grox leather."
+	icon_state = "ranger3"
+	item_state = "ranger3"
+	armor = list(melee = 7, bullet = 32, laser = 32, energy = 32, bomb = 38, bio = 30, rad = 30)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/bondsman
+	name = "Mechanicus Hazard Suit"
+	desc = "A heavy protective suit made from chemically treated fabrics that protect the wearer from toxic death world environment, this particular set is fitted with carapace pauldrons and plate to protect it's wearer from dangers only the Cogboys seem wise enough to prepare for."
+	icon_state = "MineWorkerS"
+	item_state = "MineWorkerS"
+	armor = list(melee = 8, bullet = 34, laser = 31, energy = 31, bomb = 45, bio = 70, rad = 79)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/armor/bondsman/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.4
+
+// admeme only
+
+/obj/item/clothing/suit/armor/ogryn1 // only give this to ogryns. it cannot be removed and has head protection.
+	name = "Ogryn Armor"
+	desc = "Protects ya stomach from dem flashie stingy things."
+	icon_state = "ogryn1"
+	item_state = "ogryn1"
+	armor = list(melee = 8, bullet = 31, laser = 31, energy = 31, bomb = 30, bio = 30, rad = 20)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|HANDS|FEET|HEAD
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 0
+	canremove = 0
+
+/obj/item/clothing/suit/armor/ogryn2
+	name = "Ogryn Armor"
+	desc = "Protects ya stomach from dem flashie stingy things."
+	icon_state = "ogryn2"
+	item_state = "ogryn2"
+	armor = list(melee = 10, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 30, rad = 20)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|HANDS|FEET|HEAD
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 0
+	canremove = 0
+
+/obj/item/clothing/suit/armor/shadowbeast // ADMIN ONLY DONT FUKKIN GIVE ANYONE THIS.
+	name = "Beastly garb."
+	desc = "DO YOU SEE ME."
+	icon_state = "shadow"
+	item_state = "shadow"
+	armor = list(melee = 12, bullet = 49, laser = 49, energy = 39, bomb = 50, bio = 100, rad = 100)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|HANDS|FEET|HEAD
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	sales_price = 0
+/obj/item/clothing/suit/armor/shadowbeast/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = -1
+
+/obj/item/clothing/suit/armor/vindicare
+	name = "Vindicare armour"
+	desc = "The armoured bodysuit of a Vindicare assassin."
+	armor = list(melee = 12, bullet = 46, laser = 46, energy = 35, bomb = 20, bio = 100, rad = 100)
+	icon_state = "s-ninja"
+	item_state = "s-ninja"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	str_requirement = 18
+	canremove = 0
+	siemens_coefficient = 0
+	sales_price = 250
+/obj/item/clothing/suit/armor/vindicare/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = -0.5
+
+/obj/item/clothing/suit/armor/thallax
+	name = "Thallax Armour"
+	desc = "Heavy armour which makes up the main body of a Thallax Warrior"
+	icon_state = "lightpa2"
+	item_state = "lightpa2"
+	armor = list(melee = 12, bullet = 46, laser = 46, energy = 34, bomb = 20, bio = 100, rad = 100)
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	canremove = 0
+
+obj/item/clothing/suit/armor/scion
+	name = "Tempestus Scion Carapace"
+	desc = "Solid Carapace armour, belonging to the elite forces of the Tempestus Scions."
+	icon_state = "ScionArmour"
+	item_state = "ScionArmour"
+	armor = list(melee = 9, bullet = 39, laser = 39, energy = 39, bomb = 40, bio = 100, rad = 90)
+	allowed = list(/obj/item/gun/energy,/obj/item/device/radio,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs)
+	cold_protection = UPPER_TORSO|LOWER_TORSO
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+
+obj/item/clothing/suit/armor/scion/trooper
+	name = "Stormtrooper Carapace"
+	desc = "Solid Carapace armour, belonging to the inquisitorial stormtrooper."
+	icon_state = "i-Stormtrooper Armor"
+	item_state = "i-Stormtrooper Armor"
+
+
+/obj/item/clothing/suit/armor/grot // only give this to gretchin, tiny sprite
+	name = "Tiny plate armor"
+	desc = "A scavenged metal plate made for the training of local children now worn by a grot."
+	icon_state = "Grotarmor"
+	item_state = "Grotarmor"
+	armor = list(melee = 5, bullet = 20, laser = 18, energy = 20, bomb = 30, bio = 30, rad = 20)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+
+
+/obj/item/clothing/suit/armor/grot/grccooat
+	name = "GRC Coat"
+	desc = "A coat worn by the leaders of the GRC rising up against their ork opressors."
+	icon_state = "GRCcoat"
+	item_state = "GRCcoat"
+
+/obj/item/clothing/suit/armor/grot/grcplate
+	name = "GRC Plate armor"
+	desc = "Suit of a true freedom fighter, fight with your fellow GRC members against your greenskin opressors."
+	icon_state = "GRCarmor"
+	item_state = "GRCarmor"
+
+/obj/item/clothing/suit/armor/necron
+	name = "Necron Armour"
+	desc = "The main armoured body of a Necron."
+	armor = list(melee = 12, bullet = 49, laser = 49, energy = 49, bomb = 20, bio = 100, rad = 100)
+	icon_state = null
+	item_state = null
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	canremove = 0
+	unacidable = 1
+	siemens_coefficient = 0
+	species_restricted = list(SPECIES_NECRON)
+
+/obj/item/clothing/suit/storage/hooded/inquisitor/chronos
+	name = "Ordo Chronos Armour"
+	desc = "Mysterious armour belonging to the strange Inquisitors of the ordo Chronos, this suit seems to warp space around it."
+	icon_state = "inqarmor"
+	item_state = "inqarmor"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 100, bio = 100, rad = 100) //Ordo Chronos bullshit, and it's event armour.
+	sales_price = 0
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS | HEAD| FACE | EYES
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	action_button_name = "Toggle Hood"
+	hoodtype = /obj/item/clothing/head/inqhood
+
+/obj/item/clothing/suit/storage/hooded/inquisitor/chronos/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = -0.5
+
+
+/obj/item/clothing/suit/storage/hooded/inquisitor/chronos/Initialize()
+	. = ..()
+
+
+/obj/item/clothing/suit/storage/hooded/inquisitor/chronos/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
+	if(istype(damage_source, /obj/item/projectile))
+		var/obj/item/projectile/P = damage_source
+		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
+		spark_system.set_up(5, 0, user.loc)
+		spark_system.start()
+		playsound(user.loc, "sparks", 50, 1)
+		user.visible_message("<span class='danger'>[user]'s shields deflect [attack_text] in a shower of sparks!</span>")
+		START_PROCESSING(SSobj, src)
+		del(P)
+	else
+		user.visible_message("<span class='danger'>\The [user]'s temporal field warps the [attack_text] around them!</span>")
+		return 100
+
+
+/obj/item/clothing/suit/storage/hooded/inquisitor/chronos/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/clothing/suit/storage/hooded/inquisitor/chronos/Process()
+	return ..()
+
+/obj/item/clothing/suit/storage/hooded/inquisitor/chronos
+	name = "Ordo Chronos Armour"
+	desc = "Mysterious armour belonging to the strange Inquisitors of the ordo Chronos, this suit seems to warp space around it."
+	icon_state = "inqarmor"
+	item_state = "inqarmor"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 100, bio = 100, rad = 100) //Ordo Chronos bullshit, and it's event armour.
+	sales_price = 0
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS | HEAD| FACE | EYES
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	action_button_name = "Toggle Hood"
+	hoodtype = /obj/item/clothing/head/inqhood
+
+/obj/item/clothing/suit/storage/hooded/inquisitor/chronos/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = -0.5
+
+
+/obj/item/clothing/suit/storage/hooded/inquisitor/chronos/Initialize()
+	. = ..()
+
+
+/obj/item/clothing/suit/storage/hooded/archeotech
+	name = "Archeotech Armour"
+	desc = "This armour is clearly antique, seemingly predating the Imperium entirely."
+	icon_state = "military_rig_sealed"
+	item_state = "military_rig_sealed"
+	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/cell,/obj/item/gun/energy/las/lasgun)
+	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 100, bio = 100, rad = 100) //Archeotech, and it's event armour.
+	sales_price = 0
+	canremove = 0
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS | HEAD| FACE | EYES
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
+	action_button_name = "Toggle Helmet"
+	hoodtype = /obj/item/clothing/head/helmet/archoetech
+	var/displaced = 0
+
+/obj/item/clothing/suit/storage/hooded/archeotech/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = -0.5
+
+/obj/item/clothing/suit/storage/hooded/archeotech/update_icon()
+	if(suittoggled)
+		icon_state = "military_rig_sealed"
+	else
+		icon_state = "military_rig_sealed"
+
+
+/obj/item/clothing/suit/storage/hooded/archeotech/Initialize()
+	. = ..()
+
+/obj/item/clothing/suit/storage/hooded/archeotech/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
+	if(istype(damage_source, /obj/item/projectile))
+		var/obj/item/projectile/P = damage_source
+		user.visible_message("<span class='danger'>[attack_text] splashes harmlessly against [user]'s armour!</span>")
+		START_PROCESSING(SSobj, src)
+		del(P)
+	else
+		user.visible_message("<span class='danger'>\The [attack_text] splashes harmlessly against [user]'s armour!</span>")
+		return 100
+
+
+/obj/item/clothing/suit/storage/hooded/archeotech/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/clothing/suit/storage/hooded/archeotech/Process()
+	return ..()
+
+/obj/item/clothing/suit/storage/hooded/archeotech/verb/activaterifle()
+	set name = "Activate Archeotech Rifle"
+	set category = "Weapons"
+	set src in usr
+	if(!usr.canmove || usr.stat || usr.restrained())
+		return
+	else
+		to_chat(usr,"You activate your integrated Storm Bolter.")
+		usr.put_in_hands(new /obj/item/gun/energy/archeotech/integrated(usr))
+
+/obj/item/clothing/head/helmet/archoetech
+	name = "Archeotech Helmet"
+	desc = "An ancient looking helmet."
+	icon_state = "military_rig"
+	item_state = "military_rig"
+	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 100, bio = 100, rad = 100)
+	siemens_coefficient = 0
+	canremove = 0
+	siemens_coefficient = 0
+	unacidable = 1
+	body_parts_covered = HEAD|FACE|EYES
+
+/obj/item/clothing/suit/storage/hooded/archeotech/verb/temporaldisplace()
+	set name = "Toggle Temporal Displacement"
+	set category = "Abilities"
+	set src in usr
+	if(displaced == 0)
+		usr.transforming = 1 //protects the mob from being transformed (replaced) midjaunt and getting stuck in bluespace
+		if(usr.buckled)
+			usr.buckled.unbuckle_mob()
+		spawn(0)
+			var/mobloc = get_turf(usr.loc)
+			var/obj/effect/dummy/spell_jaunt/holder = new /obj/effect/dummy/spell_jaunt( mobloc )
+			var/atom/movable/overlay/animation = new /atom/movable/overlay( mobloc )
+			animation.SetName("water")
+			animation.set_density(0)
+			animation.anchored = 1
+			animation.icon = 'icons/mob/mob.dmi'
+			animation.layer = 5
+			animation.master = holder
+			if(usr.buckled)
+				usr.buckled = null
+			displace_disappear(animation, usr)
+			usr.loc = holder
+			usr.transforming=0 //mob is safely inside holder now, no need for protection.
+			to_chat(usr, "<span class='notice'>You seperate yourself from the timestream, displacing yourself a fraction out of time.</span>")
+			displaced = 1
+	else
+		var/mobloc = get_turf(usr.loc)
+		var/obj/effect/dummy/spell_jaunt/holder = new /obj/effect/dummy/spell_jaunt( mobloc )
+		var/atom/movable/overlay/animation = new /atom/movable/overlay( mobloc )
+		mobloc = holder.last_valid_turf
+		animation.loc = mobloc
+		usr.canmove = 0
+		holder.reappearing = 1
+		//sleep(20)
+		displace_reappear(animation, usr)
+		sleep(5)
+		if(!usr.forceMove(mobloc))
+			for(var/direction in list(1,2,4,8,5,6,9,10))
+				var/turf/T = get_step(mobloc, direction)
+				if(T)
+					if(usr.forceMove(T))
+						break
+		usr.canmove = 1
+		usr.client.eye = usr
+		to_chat(usr, "<span class='notice'>You return yourself to normal time.</span>")
+		displaced = 0
+		qdel(animation)
+		qdel(holder)
+
+
+
+/obj/item/clothing/suit/storage/hooded/archeotech/proc/displace_disappear(var/atom/movable/overlay/animation, usr)
+	animation.icon_state = "liquify"
+	flick("liquify",animation)
+
+/obj/item/clothing/suit/storage/hooded/archeotech/proc/displace_reappear(var/atom/movable/overlay/animation, usr)
+	flick("reappear",animation)
+
+/obj/item/clothing/suit/storage/hooded/archeotech/verb/archeocloak(mob/user)
+	set name = "Toggle Photonic Distortion Field"
+	set category = "Abilities"
+	set src in usr
+	if(user.alpha == 255)
+		var/mobloc = get_turf(user.loc)
+		var/obj/effect/dummy/spell_jaunt/holder = new /obj/effect/dummy/spell_jaunt( mobloc )
+		var/atom/movable/overlay/animation = new /atom/movable/overlay( mobloc )
+		mobloc = holder.last_valid_turf
+		animation.loc = mobloc
+		to_chat(user, "<span class='notice'>You activate the Photonic Distortion Field.</span>")
+		user.alpha = 0
+		animation.icon_state = "cloak"
+		flick("liquify",animation)
+	else
+		var/mobloc = get_turf(user.loc)
+		var/obj/effect/dummy/spell_jaunt/holder = new /obj/effect/dummy/spell_jaunt( mobloc )
+		var/atom/movable/overlay/animation = new /atom/movable/overlay( mobloc )
+		mobloc = holder.last_valid_turf
+		animation.loc = mobloc
+		to_chat(user, "<span class='notice'>You disable the Photonic Distortion Field.</span>")
+		user.alpha = 255
+		animation.icon_state = "uncloak"
+		flick("liquify",animation)
+
+/obj/item/storage/backpack/ert
+	name = "Archeotech Backpack"
+	desc = "An ancient looking backpack."
+	icon_state = "ert_commander"
+	item_state_slots = list(
+		slot_l_hand_str = "securitypack",
+		slot_r_hand_str = "securitypack",
+		)
+	canremove = 0
+	max_storage_space = 36
+
+
+*/

--- a/code/modules/clothing/under/accessories/_accessory.dm
+++ b/code/modules/clothing/under/accessories/_accessory.dm
@@ -85,10 +85,13 @@
 /obj/item/clothing/accessory/proc/on_attached(obj/item/clothing/S, mob/user)
 	if(!istype(S))
 		return
+	if (equip_delay > 0)
+		equip_delay_before(user, S)
+		sleep(equip_delay)
+		equip_delay_after(user, S)
 	parent = S
 	forceMove(parent)
 	parent.AddOverlays(get_inv_overlay())
-
 	if(user)
 		to_chat(user, SPAN_NOTICE("You attach \the [src] to \the [parent]."))
 		src.add_fingerprint(user)

--- a/code/modules/clothing/under/accessories/_accessory.dm
+++ b/code/modules/clothing/under/accessories/_accessory.dm
@@ -9,6 +9,7 @@
 	item_state = ""	//no inhands
 	slot_flags = SLOT_TIE
 	w_class = ITEM_SIZE_SMALL
+	equip_delay = 2 SECONDS
 	var/accessory_flags = ACCESSORY_DEFAULT_FLAGS
 	var/slot = ACCESSORY_SLOT_DECOR
 	var/body_location = UPPER_TORSO //most accessories are here
@@ -101,6 +102,10 @@
 	if(!parent)
 		return
 	parent.CutOverlays(get_inv_overlay())
+	if (equip_delay > 0)
+		equip_delay_before(user)
+		sleep(equip_delay)
+		equip_delay_after(user)
 	parent = null
 	if(user)
 		usr.put_in_hands(src)

--- a/code/modules/clothing/under/accessories/armor_plate.dm
+++ b/code/modules/clothing/under/accessories/armor_plate.dm
@@ -10,7 +10,7 @@
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-20
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+200
 	slowdown = 0.05
-	equip_delay = 2.5 SECONDS
+	equip_delay = 3.5 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-1,
 		bullet = ARMOR_BALLISTIC_FLAK-2,
@@ -30,7 +30,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-30
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
-	equip_delay = 3 SECONDS
+	equip_delay = 4 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_FLAK,
 		bullet = ARMOR_BALLISTIC_FLAK+1,
@@ -115,7 +115,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-400
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
-	equip_delay = 3.5 SECONDS
+	equip_delay = 4.5 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_FLAK+1,
 		bullet = ARMOR_BALLISTIC_FLAK+2,

--- a/code/modules/clothing/under/accessories/armor_plate.dm
+++ b/code/modules/clothing/under/accessories/armor_plate.dm
@@ -6,9 +6,11 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	heat_protection = UPPER_TORSO|LOWER_TORSO
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-20
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+200
 	slowdown = 0.05
+	equip_delay = 2.5 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_FLAK-1,
 		bullet = ARMOR_BALLISTIC_FLAK-2,
@@ -28,6 +30,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-30
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+300
+	equip_delay = 3 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_FLAK,
 		bullet = ARMOR_BALLISTIC_FLAK+1,
@@ -39,6 +42,72 @@
 		)
 	slowdown = 0.06
 
+/obj/item/clothing/accessory/armor_plate/nurgle
+	name = "nurgle plates"
+	desc = "A disgusting plague infused plating, providing enhanced protection against ballistic impacts and energy discharge. It writhes as if the metal were alive."
+	icon_state = "armor_medium"
+	color = COLOR_PAKISTAN_GREEN
+	item_flags = ITEM_FLAG_THICKMATERIAL
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	cold_protection = FULL_BODY // CHAOS PROTECTION
+	heat_protection = FULL_BODY
+	equip_delay = 15 SECONDS
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK+1,
+		laser = ARMOR_LASER_FLAK+1,
+		energy = ARMOR_ENERGY_MINOR+1,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED,
+		bomb = ARMOR_BOMB_MINOR+2
+		)
+	slowdown = 0.07
+
+/obj/item/clothing/accessory/armor_plate/nurgleheavy
+	name = "heavy nurgle plates"
+	desc = "A disgusting plague infused plating, providing enhanced protection against ballistic impacts and energy discharge. It writhes as if the metal were alive."
+	icon_state = "armor_medium"
+	color = COLOR_PAKISTAN_GREEN
+	item_flags = ITEM_FLAG_THICKMATERIAL
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	cold_protection = FULL_BODY // CHAOS PROTECTION
+	heat_protection = FULL_BODY
+	equip_delay = 17 SECONDS
+	armor = list(
+		melee = ARMOR_MELEE_FLAK+1,
+		bullet = ARMOR_BALLISTIC_FLAK+2,
+		laser = ARMOR_LASER_FLAK+2,
+		energy = ARMOR_ENERGY_MINOR+1,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED,
+		bomb = ARMOR_BOMB_MINOR+12
+		)
+	slowdown = 0.085
+
+/obj/item/clothing/accessory/armor_plate/tzeentch
+	name = "exotic plates"
+	desc = "A beautiful alien plating, providing enhanced protection against ballistic impacts and energy discharge. It writhes with constant sparks of chaos magic."
+	icon_state = "armor_medium"
+	color = COLOR_PALE_PURPLE_GRAY
+	item_flags = ITEM_FLAG_THICKMATERIAL
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	cold_protection = FULL_BODY // CHAOS PROTECTION
+	heat_protection = FULL_BODY
+	equip_delay = 16 SECONDS
+	armor = list(
+		melee = ARMOR_MELEE_FLAK+1,
+		bullet = ARMOR_BALLISTIC_FLAK+3,
+		laser = ARMOR_LASER_FLAK+3,
+		energy = ARMOR_ENERGY_MINOR+1,
+		bio = ARMOR_BIO_MINOR+20,
+		rad = ARMOR_RAD_MINOR+30,
+		bomb = ARMOR_BOMB_MINOR+20
+		)
+	slowdown = 0.07
+
 /obj/item/clothing/accessory/armor_plate/flakheavy
 	name = "heavy flak plates"
 	desc = "A plasteel-reinforced flak plate, providing enhanced protection against ballistic impacts and energy discharge."
@@ -46,6 +115,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-400
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	equip_delay = 3.5 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_FLAK+1,
 		bullet = ARMOR_BALLISTIC_FLAK+2,
@@ -64,6 +134,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-45
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+450
+	equip_delay = 7 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_FLAK,
 		bullet = ARMOR_BALLISTIC_FLAK-1,
@@ -83,6 +154,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-50
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+500
+	equip_delay = 4 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE,
 		bullet = ARMOR_BALLISTIC_CARAPACE+1,
@@ -102,6 +174,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-60
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+600
+	equip_delay = 4 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE+1,
 		bullet = ARMOR_BALLISTIC_CARAPACE+2,
@@ -121,6 +194,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-65
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+650
+	equip_delay = 5 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_CARAPACE+1,
 		bullet = ARMOR_BALLISTIC_CARAPACE+2,
@@ -141,11 +215,13 @@
 	icon_state = "helmcover_green"
 	color = COLOR_BEASTY_BROWN
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	equip_delay = 7 SECONDS // Basically ripping out the lining.
+	max_pressure_protection = null
 	slowdown = 0.02
 	armor = list(
 		melee = ARMOR_MELEE_PRIMAL-1,
 		bullet = ARMOR_BALLISTIC_PRIMAL,
-		laser = ARMOR_LASER_PRIMAL,
+		laser = ARMOR_LASER_PRIMAL-1,
 		energy = ARMOR_ENERGY_MINOR-4,
 		bio = ARMOR_BIO_MINOR-6,
 		rad = ARMOR_RAD_MINOR,
@@ -160,13 +236,15 @@
 	color = COLOR_BEASTY_BROWN
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	max_pressure_protection = null
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-35
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+350
+	equip_delay = 9 SECONDS // Basically ripping out the lining.
 	slowdown = 0.03
 	armor = list(
 		melee = ARMOR_MELEE_PRIMAL,
-		bullet = ARMOR_BALLISTIC_PRIMAL+1,
-		laser = ARMOR_LASER_PRIMAL+1,
+		bullet = ARMOR_BALLISTIC_PRIMAL+1, // Heavy padding is better for bullets then las.
+		laser = ARMOR_LASER_PRIMAL,
 		energy = ARMOR_ENERGY_MINOR-3,
 		bio = ARMOR_BIO_MINOR,
 		rad = ARMOR_RAD_MINOR+10,
@@ -180,9 +258,11 @@
 	icon_state = "helmcover_green"
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-40
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+400
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	color = COLOR_BEASTY_BROWN
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	equip_delay = 10 SECONDS
 	slowdown = 0.03
 	armor = list(
 		melee = ARMOR_MELEE_PRIMAL-1,
@@ -200,11 +280,13 @@
 	icon = 'icons/obj/clothing/obj_suit.dmi'
 	icon_state = "helmcover_green"
 	item_flags = ITEM_FLAG_THICKMATERIAL
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	color = COLOR_BEASTY_BROWN
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-55
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+550
 	slowdown = 0.05
+	equip_delay = 12 SECONDS
 	armor = list(
 		melee = ARMOR_MELEE_PRIMAL,
 		bullet = ARMOR_BALLISTIC_PRIMAL+1,
@@ -223,8 +305,10 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	color = COLOR_BEASTY_BROWN
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-70
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+700
+	equip_delay = 18 SECONDS
 	slowdown = 0.08
 	armor = list(
 		melee = ARMOR_MELEE_FLAK,
@@ -234,6 +318,29 @@
 		rad = ARMOR_RAD_RESISTANT+48,
 		bio = ARMOR_BIO_RESISTANT+48,
 		bomb = ARMOR_BOMB_MINOR+10
+		)
+
+/obj/item/clothing/accessory/armor_plate/mechplatemagos
+	name = "special hazard plating"
+	desc = "A special tech hazard plating used primarily by mechanicus tech priests -- it's been ripped out..."
+	icon = 'icons/obj/clothing/obj_suit.dmi'
+	icon_state = "helmcover_green"
+	item_flags = ITEM_FLAG_THICKMATERIAL
+	color = COLOR_BEASTY_BROWN
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-70
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+700
+	equip_delay = 18 SECONDS
+	slowdown = 0.095
+	armor = list(
+		melee = ARMOR_MELEE_FLAK+1,
+		bullet = ARMOR_BALLISTIC_CARAPACE+2,
+		laser = ARMOR_LASER_CARAPACE+2,
+		energy = ARMOR_ENERGY_MINOR+30,
+		rad = ARMOR_RAD_RESISTANT+60,
+		bio = ARMOR_BIO_RESISTANT+60,
+		bomb = ARMOR_BOMB_MINOR+20
 		)
 
 /obj/item/clothing/accessory/armor_plate/bodyglovebio
@@ -255,6 +362,7 @@
 	blood_overlay_type = "armor" // Bodygloves use base armor_plate temp protection.
 	icon_state = "robotics"
 	item_state = "robotics_s"
+	equip_delay = 3 SECONDS
 	slowdown = 0.03
 	flags_inv = null
 	armor = list(
@@ -280,12 +388,14 @@
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+50
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	slot_flags = SLOT_OCLOTHING //can wear in suit slot as well
 	slot = ACCESSORY_SLOT_UTILITY // Worn alongside a carrier plate.
 	w_class = ITEM_SIZE_NORMAL
 	blood_overlay_type = "armor"
 	icon_state = "robotics"
 	item_state = "robotics_s"
+	equip_delay = 3.5 SECONDS
 	slowdown = 0.04
 	flags_inv = null
 	armor = list(
@@ -299,7 +409,7 @@
 		)
 
 /obj/item/clothing/accessory/armor_plate/bodyglove
-	name = "low-profile bodyglove"
+	name = "undersuit bodyglove"
 	desc = "Composed of layered polymer fibers, attached to a uniform, this low-profile bodyglove offers lightweight and flexible protection, suitable for minimizing bulk without sacrificing defense."
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-10
@@ -316,6 +426,7 @@
 	icon_state = "jensen_s"
 	item_state = "jensen_s"
 	slowdown = 0.03 // Almost the same as Mech but lighter and offers no decent bio/rad prot.
+	equip_delay = 2 SECONDS
 	flags_inv = null
 	armor = list(
 		melee = 0,
@@ -328,7 +439,7 @@
 		)
 
 /obj/item/clothing/accessory/armor_plate/bodyglove2
-	name = "low-profile bodyglove"
+	name = "armoured bodyglove"
 	desc = "Made from tech polymers, attached to a uniform, this experimental bodyglove balances flexibility with advanced defensive capabilities, providing enhanced protection at the cost of more cumbersome movement."
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE-30
@@ -340,11 +451,13 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	slot_flags = SLOT_OCLOTHING
 	slot = ACCESSORY_SLOT_UTILITY // Attaches to uniform or can be worn as exosuit.
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	w_class = ITEM_SIZE_NORMAL
 	blood_overlay_type = "armor"
 	icon_state = "robotics"
 	item_state = "robotics_s"
 	slowdown = 0.07 // This item is super OP if stacked with power armor. It can be the difference between a lasgun critting you or just causing an injury.
+	equip_delay = 3 SECONDS
 	flags_inv = null
 	armor = list(
 		melee = 1,
@@ -373,6 +486,7 @@
 	blood_overlay_type = "armor"
 	icon_state = "catacomm" // Bulletproof pants and shirt.
 	item_state = "catacomm_s"
+	equip_delay = 0.5 SECONDS
 	slowdown = 0.05 // better bodyglove since it doesn't protect arms and offers no melee protection. Catachan design since their weakness is only ranged fighting and rad/bio.
 	flags_inv = null
 	armor = list(


### PR DESCRIPTION
Added pilgrimarmor.dm and retinuearmor.dm to clothing/suits.

Edited some melee weapons to have better attack cooldowns.

Edited hardhat code to have weaker lights.

Added equip_delay to accessories so they now take time to insert and remove inserts.

Edited armor_plate to have equip_delay, with things like padding, hazard lining and anything especially mechanicus related having the longest delays. While simple flak plates and bodygloves are easier to attach.

Edited contamination code so that your clothes are no longer contaminated with chemicals after 100 seconds. I really don't want the maps to require washing machines.

Under darkarmor.dm added; tau and eldar armors.

Under grimarmor.dm added; mechanicus suits, hoods and skitarii exoskeletons.

Under pilgrimarmor.dm added; cult/heretic armors, ecclesiarchy and sister suits, merc and pilgrim armors.

Under retinuearmor.dm added; ordos armors, hood and an ork armor. Alongside the unfinished code for all unported armors remaining.