### PR TITLE
RogueTrader - V1.0.5.0 - Jobs/Armor

### DIFF
--- a/code/__defines/guns.dm
+++ b/code/__defines/guns.dm
@@ -5,7 +5,6 @@
 #define CALIBER_SLUG_ANTIQUE	"~10mm"
 
 #define CALIBER_AUTOGUN			"8mm AR"
-#define CALIBER_AUTOGUN_TECH  "6.8mm AR"
 #define CALIBER_AUTOGUN_HEAVY		"10mm AR"
 #define CALIBER_SNIPER    "15mmR"
 

--- a/code/game/gamemodes/cult/manifest.dm
+++ b/code/game/gamemodes/cult/manifest.dm
@@ -1,8 +1,8 @@
 /datum/species/human/cult
 	name = "Cult"
 	spawn_flags = SPECIES_IS_RESTRICTED
-	brute_mod = 2
-	burn_mod = 2
+	brute_mod = 1
+	burn_mod = 1
 	species_flags = SPECIES_FLAG_NO_SCAN
 	force_cultural_info = list(
 		TAG_CULTURE =   CULTURE_CULTIST,

--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -94,11 +94,6 @@
 		if (src.Move(T))
 			return
 
-/mob/living/carbon/airlock_crush(crush_damage)
-	..()
-	if (can_feel_pain())
-		emote("scream")
-
 /mob/living/silicon/robot/airlock_crush(crush_damage)
 	..(round(crush_damage / CYBORG_AIRLOCKCRUSH_RESISTANCE)) //TODO implement robot melee armour and remove this.
 

--- a/code/game/objects/items/weapons/material/warhammer.dm
+++ b/code/game/objects/items/weapons/material/warhammer.dm
@@ -130,7 +130,7 @@ All weapons should use twohanded/warhammer -- otherwise it will break.
 	base_parry_chance = 30
 	melee_accuracy_bonus = 5
 
-/obj/item/material/twohanded/ravenor/sword/cutro
+/obj/item/material/twohanded/ravenor/sword/cutro/adamantine
 	name = "adamantine cutro"
 	desc = "A lightweight adamantium blade with near perfect balance."
 	color = "#848484"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -598,12 +598,48 @@
 	desc = "A heavy rucksack."
 	icon_state = "warfare_satchel"
 	max_storage_space = DEFAULT_BACKPACK_STORAGE+3
-	slowdown_general = 0.05
+	slowdown_general = 0.04
 
 /obj/item/storage/backpack/satchel/warfare
 	name = "light satchel"
 	desc = "Fit for war, and not much else."
 	icon_state = "warfare_satchel"
+	max_storage_space = DEFAULT_BACKPACK_STORAGE
+	slowdown_general = 0.015
+
+/obj/item/storage/backpack/satchel/krieger
+	desc = "Field ready kit, tried and tested through countless encounters."
+	icon_state = "kriegpack"
+	item_state = "kriegpack"
+	max_storage_space = DEFAULT_BACKPACK_STORAGE+2
+	slowdown_general = 0.035
+
+/obj/item/storage/backpack/satchel/krieger/grenadier
+	desc = "An assembled kit for air filtration, weapon power supply, and basic storage. Perfect to bring with you into no man's land."
+	icon_state = "grenpack"
+	item_state = "grenpack"
+	max_storage_space = DEFAULT_BACKPACK_STORAGE
+	slowdown_general = 0.015
+
+/obj/item/storage/backpack/satchel/maccabian
+	desc = "Field ready kit, tried and tested through countless encounters."
+	icon_state = "M_Backpack-Icon"
+	item_state = "M_Backpack-Icon"
+	max_storage_space = DEFAULT_BACKPACK_STORAGE
+	slowdown_general = 0.015
+
+/obj/item/storage/backpack/satchel/maccabian/sergeant
+	desc = "Field ready kit, tried and tested through countless encounters."
+	icon_state = "M_SBackpack-Icon"
+	item_state = "M_SBackpack-Icon"
+	max_storage_space = DEFAULT_BACKPACK_STORAGE
+	slowdown_general = 0.015
+
+/obj/item/storage/backpack/satchel/ordinate
+	name = "Administratum Ink Pack"
+	desc = "Burocracy on the go"
+	icon_state = "ordinate"
+	item_state = "ordinate"
 
 /obj/item/storage/backpack/satchel/warfare/techpriest
 	desc = "BZZZRRRRT."
@@ -738,35 +774,6 @@
 		usr.put_in_hands(new /obj/item/melee/energy/powersword/claw/integrated(usr))
 
 
-/obj/item/storage/backpack/warfare
-	desc = "Holds more than a satchel, but can't open it on your back."
-	icon_state = "warfare_backpack"
 
-/obj/item/storage/backpack/satchel/krieger
-	desc = "Field ready kit, tried and tested through countless encounters."
-	icon_state = "kriegpack"
-	item_state = "kriegpack"
-
-/obj/item/storage/backpack/satchel/krieger/grenadier
-	desc = "An assembled kit for air filtration, weapon power supply, and basic storage. Perfect to bring with you into no man's land."
-	icon_state = "grenpack"
-	item_state = "grenpack"
-
-/obj/item/storage/backpack/satchel/maccabian
-	desc = "Field ready kit, tried and tested through countless encounters."
-	icon_state = "M_Backpack-Icon"
-	item_state = "M_Backpack-Icon"
-
-/obj/item/storage/backpack/satchel/maccabian/sergeant
-	desc = "Field ready kit, tried and tested through countless encounters."
-	icon_state = "M_SBackpack-Icon"
-	item_state = "M_SBackpack-Icon"
-
-
-/obj/item/storage/backpack/satchel/ordinate
-	name = "Administratum Ink Pack"
-	desc = "Burocracy on the go"
-	icon_state = "ordinate"
-	item_state = "ordinate"
 
 */

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1413,7 +1413,7 @@ GLOBAL_LIST_INIT(random_backpacks, list(
 /obj/random/backpack
 	name = "random backpack"
 	desc = "This is a random backpack."
-	icon = 'icons/obj/clothing/obj_backpacks.dmi'
+	icon = 'icons/obj/storage.dmi'
 	icon_state = "backpack"
 
 /obj/random/backpack/spawn_choices()

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -382,6 +382,21 @@
 	icon_state = "nvg_avi_on"
 	off_state = "avi_off"
 	item_state = "nvg_avi_on"
+	darkness_view = 14
+
+/obj/item/clothing/glasses/night/aviators/catachan
+	name = "tech aviators"
+	desc = "Night-vision glasses integrated into a pair of aviator sunglasses. It does little to protect against the sun, but it sure looks cool."
+	icon_state = "nvg_avi_on"
+	off_state = "avi_off"
+	item_state = "nvg_avi_on"
+	darkness_view = 13
+	see_invisible = SEE_INVISIBLE_NOLIGHTING
+	body_parts_covered = EYES
+	siemens_coefficient = 0.9
+	unacidable = 1
+	flash_protection =  FLASH_PROTECTION_MODERATE
+	vision_flags = SEE_TURFS|SEE_MOBS
 
 /obj/item/clothing/glasses/scion
 	name = "Omnishield Visor"

--- a/code/modules/clothing/head/grimhelm.dm
+++ b/code/modules/clothing/head/grimhelm.dm
@@ -218,7 +218,7 @@
 	desc = "Unlike the more common Cadian-pattern, the Mark IX is made out of durable plasteel, giving it higher defensive capabilities though at the cost of weight and production."
 	icon_state = "krieghelm"
 	item_state = "krieghelm"
-	flags_inv = HIDEMASK|HIDEEARS|BLOCKHAIR
+	flags_inv = HIDEEARS|BLOCKHAIR
 	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	body_parts_covered = FACE|EYES|HEAD
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+100
@@ -240,7 +240,7 @@
 	icon_state = "krieghelm"
 	item_state = "krieghelm"
 
-/obj/item/clothing/head/helmet/flak/krieg/sergeant
+/obj/item/clothing/head/helmet/flak/krieg/officer
 	name = "Krieg IX carapace helmet"
 	desc = "Unlike the more common Cadian-pattern, the Mark IX is made out of durable plasteel, giving it higher defensive capabilities though at the cost of weight and production."
 	icon_state = "WatchHelm"
@@ -281,7 +281,7 @@
 	desc = "Unlike the more common Cadian-pattern, the Mark IX is made out of durable plasteel, giving it higher defensive capabilities though at the cost of weight and production."
 	icon_state = "M_Helmet-Icon"
 	item_state = "M_Helmet-Icon"
-	flags_inv = HIDEMASK|HIDEEARS|BLOCKHAIR
+	flags_inv = HIDEEARS|BLOCKHAIR
 	body_parts_covered = FACE|EYES|HEAD
 	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+200
@@ -340,7 +340,7 @@
 	name = "kasrkin carapace helmet"
 	desc = "A carapace helmet belonging to the elite stormtroopers of the Kasrkin. Cadia may not be intact, but your brain will when in combat with this on."
 	icon_state = "kasrkinhelmet"
-	flags_inv = HIDEMASK|HIDEEARS|BLOCKHAIR
+	flags_inv = HIDEEARS|BLOCKHAIR
 	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+550
 	slowdown_general = 0.012

--- a/code/modules/clothing/head/pilgrimhelm.dm
+++ b/code/modules/clothing/head/pilgrimhelm.dm
@@ -257,7 +257,7 @@
 	desc = "an armoured flak-lamellar recon hood."
 	icon_state = "reconhood"
 	item_state = "reconhood"
-	flags_inv = HIDEMASK|HIDEEARS|BLOCKHEADHAIR
+	flags_inv = HIDEEARS|BLOCKHEADHAIR
 	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	slowdown_general = 0.008
 	disorientation = 0.5

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -325,12 +325,6 @@
 	icon_state = "jackboots"
 	item_state = "jackboots"
 
-/obj/item/clothing/shoes/jackboots/catachan
-	name = "combat boots"
-	desc = "Astra Militarum's common combat boots, found worn by most Imperial Agencies and Astra Militarum."
-	icon_state = "jackboots"
-	item_state = "jackboots"
-
 /obj/item/clothing/shoes/jackboots/krieg
 	name = "combat boots"
 	desc = "The Krieg Regiment, unlike most of the Astra Militarum, prefer their less protective but more mobile boots over the standard Mars Pattern used by the Munitorium."
@@ -593,12 +587,30 @@
 	icon_state = "noble-boots"
 	item_state = "noble-boots"
 	item_flags = ITEM_FLAG_NOSLIP
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_TEN,
+		bio = ARMOR_BIO_THIRTY+25,
+		rad = ARMOR_RAD_THIRTY+75,
+		bomb = ARMOR_BOMB_TEN+25
+	)
 
 /obj/item/clothing/shoes/jackboots/noble
 	name = "noble boots"
 	desc = "A pair of high quality black leather boots for kicking the filthy peasants and participating in questionable hedonistic activities at the chambers."
 	icon_state = "noble-boots"
 	item_state = "noble-boots"
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-1,
+		energy = ARMOR_ENERGY_TEN,
+		bio = ARMOR_BIO_THIRTY+5,
+		rad = ARMOR_RAD_THIRTY+55,
+		bomb = ARMOR_BOMB_TEN+10
+	)
 
 /obj/item/clothing/shoes/jackboots/mordian
 	name = "Mordian Dress Boots"
@@ -611,14 +623,30 @@
 	desc = "A pair of high quality black leather boots for kicking the filthy peasants and participating in questionable hedonistic activities at the chambers."
 	icon_state = "Boots"
 	item_state = "Boots"
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_TEN,
+		bio = ARMOR_BIO_THIRTY+25,
+		rad = ARMOR_RAD_THIRTY+75,
+		bomb = ARMOR_BOMB_TEN+25
+	)
 
 /obj/item/clothing/shoes/scion
 	name = "Tempestus Scion Boots"
 	desc = "Armoured boots belonging to the elite Tempestus Scions."
 	icon_state = "ScionBoots"
 	item_state = "ScionBoots"
-	force = 5
-	armor = list(melee = 10, bullet = 20, laser = 20,energy = 25, bomb = 50, bio = 100, rad = 0)
+	armor = list(
+		melee = ARMOR_MELEE_FLAK,
+		bullet = ARMOR_BALLISTIC_FLAK,
+		laser = ARMOR_LASER_FLAK,
+		energy = ARMOR_ENERGY_TEN,
+		bio = ARMOR_BIO_THIRTY+25,
+		rad = ARMOR_RAD_THIRTY+75,
+		bomb = ARMOR_BOMB_TEN+25
+	)
 	item_flags = ITEM_FLAG_NOSLIP
 	siemens_coefficient = 0.6
 
@@ -645,7 +673,15 @@
 	siemens_coefficient = 0
 	unacidable = 1
 	canremove = 0
-	armor = list(melee = 25, bullet = 25, laser = 25,energy = 25, bomb = 50, bio = 100, rad = 100)
+	armor = list(
+		melee = ARMOR_MELEE_FLAK-1,
+		bullet = ARMOR_BALLISTIC_FLAK-1,
+		laser = ARMOR_LASER_FLAK-1,
+		energy = ARMOR_ENERGY_TEN,
+		bio = ARMOR_BIO_THIRTY+5,
+		rad = ARMOR_RAD_THIRTY+55,
+		bomb = ARMOR_BOMB_TEN+10
+	)
 
 
 /*

--- a/code/modules/clothing/suits/grimarmor.dm
+++ b/code/modules/clothing/suits/grimarmor.dm
@@ -216,9 +216,9 @@
 		bomb = ARMOR_BOMB_TEN+10
 	)
 
-/obj/item/clothing/suit/armor/grim/krieger/sergeant
-	name = "krieg watchmaster's overcoat"
-	desc = "The reinforced carapace overcoat of a Krieg Watchmaster, offering additional protection against hazardous environments and combat damage."
+/obj/item/clothing/suit/armor/grim/krieger/officer
+	name = "krieg officer's overcoat"
+	desc = "The reinforced carapace overcoat of a Krieg Officer, offering additional protection against hazardous environments and combat damage."
 	icon_state = "kriegcoat"
 	item_state = "kriegcoat"
 	body_parts_covered = LEGS|ARMS
@@ -325,7 +325,7 @@
 	icon_state = "mvalarmor"
 	item_state = "mvalarmor"
 
-/obj/item/clothing/suit/armor/grim/valhallan/captain
+/obj/item/clothing/suit/armor/grim/valhallan/officer
 	name = "valhalan carapace overcoat"
 	desc = "A Valhallan overcoat with additional markings and improved protection, worn by Officers."
 	accessories = list(/obj/item/clothing/accessory/armor_plate/carapace)
@@ -485,7 +485,7 @@
 	icon_state = "ScionArmour"
 	item_state = "ScionArmour"
 
-/obj/item/clothing/suit/armor/grim/cadian/officer
+/obj/item/clothing/suit/armor/grim/cadian/officer_formal
 	name = "militarum officer's coat"
 	desc = "A formal coat worn by command staff of the Imperial Guard, reinforced with integrated carapace and armourplas plates. It has an insignia spear belonging to that of the general staff for the local Lord General Militant."
 	icon_state = "officertanjacket"

--- a/code/modules/clothing/under/warhammer.dm
+++ b/code/modules/clothing/under/warhammer.dm
@@ -7,9 +7,7 @@
 	icon_state = "maccabian"
 	item_state = "maccabian"
 	worn_state = "maccabian"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60, rad = 0)
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/under/rank/maccabian/medic
 	desc = "These durable undersuit are used to represent the zealous, smells like holy oils and other aromatics. This one is the Medicae Variant"
@@ -29,9 +27,7 @@
 	icon_state = "krieg"
 	item_state = "krieg"
 	worn_state = "krieg"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60, rad = 0)
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/under/cadian_uniform
 	name = "guard uniform"
@@ -39,7 +35,6 @@
 	icon_state = "guard"
 	item_state = "guard"
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/under/rank/valhallan_uniform
 	name = "valhallan uniform"
@@ -48,14 +43,12 @@
 	item_state = "krieg"
 	worn_state = "krieg"
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/under/casual_pants/catachan
 	name = "catachan shorts"
 	desc = "Catachan fear no heat, no boltguns, no lasguns. They don't need shirts, They're Catachan Jungle Hunters."
 	icon_state = "camopants"
 	cold_protection = LOWER_TORSO | LEGS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/under/rank/krieg_uniform/commissar
 	name = "commissar's Dress Uniform"
@@ -78,7 +71,6 @@
 	desc = "The bodysuit worn by Astartes underneath their Power Armour."
 	icon_state = "swatunder"
 	worn_state = "swatunder"
-	armor = list(melee = 1, bullet = 5, laser = 5,energy = 5, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 
 // Adepta Sororitas
@@ -86,28 +78,21 @@
 /obj/item/clothing/under/guard/uniform/sisterofbattle
 	name = "Adepta Sororitas Bodysuit"
 	desc = "The bodysuit worn by Adepta Sororitas underneath their Power Armour."
-	armor = list(melee = 1, bullet = 5, laser = 5,energy = 5, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
-	species_restricted = list(SPECIES_HUMAN)
-
 
 /obj/item/clothing/under/guard/uniform/sisterofbattle/repentia
 	name = "Faith of the Repentia"
 	desc = "When there is no armor to defend from heretics, the Emperor protects."
-	armor = list(melee = 1, bullet = 5, laser = 5,energy = 5, bomb = 0, bio = 0, rad = 0)
 	icon_state = "repentia_nude"
 	worn_state = "repentia_nude"
 	siemens_coefficient = 0.9
-	species_restricted = list(SPECIES_HUMAN)
 
 /obj/item/clothing/under/guard/uniform/sisterofbattle/zealot
 	name = "Robes of the Faithful"
 	desc = "When you're blessed there's no need for a helmet, the Emperor protects."
-	armor = list(melee = 1, bullet = 5, laser = 5,energy = 5, bomb = 0, bio = 0, rad = 0)
 	icon_state = "zealot"
 	worn_state = "zealot"
 	siemens_coefficient = 0.9
-	species_restricted = list(SPECIES_HUMAN)
 
 /obj/item/clothing/under/administratum
 	name = "administratum underlayers"
@@ -115,19 +100,15 @@
 	icon_state = "combat"
 	item_state = "bl_suit"
 	worn_state = "combat"
-	armor = list(melee = 1, bullet = 5, laser = 5,energy = 5, bomb = 5, bio = 5, rad = 50)
-	has_sensor = SUIT_HAS_SENSORS
 
 /obj/item/clothing/under/necron
 	name = "Necrodermis Skin"
 	desc = "A thin layer of Necrodermis making up the skin of a Necron."
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 5, bomb = 0, bio = 100, rad = 100)
 	icon_state = "golem"
 	worn_state = "golem"
 	siemens_coefficient = 0.1
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	unacidable = 1
 	canremove = 0
 
@@ -148,7 +129,6 @@
 	item_state = "scoutoutfit"
 	worn_state = "scoutoutfit"
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/under/rank/skitarii
 	desc = "Heavily-augmented body, reinforced to fit the Mechanicus purposes."
@@ -159,7 +139,6 @@
 	canremove = 0
 	unacidable = 1
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/under/rank/ork // only using this one atm
 	desc = "Tattered and torn from a life of battle and strife."
@@ -169,7 +148,6 @@
 	worn_state = "ork_clothes"
 
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/under/rank/ork/two
 	icon_state = "orkpants"
@@ -189,7 +167,6 @@
 	item_state = "vest"
 	worn_state = "vest"
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/under/rank/victorian/blred
 	icon_state = "vestblred"
@@ -256,7 +233,6 @@
 	item_icons = list(slot_w_uniform_str = 'icons/mob/32x40/uniforms.dmi')
 	icon_state = "ogryn_full"
 	worn_state = "ogryn_full"
-	armor = list(melee = 1, bullet = 1, laser = 1,energy = 30, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 
 
@@ -279,7 +255,6 @@
 	icon_state = "guard"
 	item_state = "guard"
 	worn_state = "guard"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 
 /obj/item/clothing/under/guard/renegadeuniform
@@ -293,9 +268,7 @@
 	desc = "A standardised armoured undersuit worn by Tempestus Scions"
 	icon_state = "ScionUndersuit"
 	item_state = "scionundersuit"
-	armor = list(melee = 1, bullet = 1, laser = 1, energy = 20, bomb = 20, bio = 20, rad = 0)
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
 
 /obj/item/clothing/under/grot
@@ -303,11 +276,9 @@
 	desc = "What a fool"
 	icon_state = "Grotrags"
 	item_state = "Grotrags"
-	slowdown_general = -20
 
 /obj/item/clothing/under/grot/grc
 	name = "Expensive revolutionary suit"
 	desc = "A true revolutionist"
 	icon_state = "GRCrags"
 	item_state = "GRCrags"
-	slowdown_general = -20

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -158,6 +158,18 @@
 	throwforce = 7.0
 	w_class = ITEM_SIZE_SMALL
 
+/obj/item/shovel/krieg
+	name = "krieg shovel"
+	desc = "A small tool for digging and moving dirt."
+	icon = 'icons/obj/tools.dmi'
+	icon_state = "entrenching_tool"
+	item_state = "trench"
+	force = 24
+	sharp = 1
+	armor_penetration = 6
+	throwforce = 20
+	w_class = ITEM_SIZE_NORMAL
+
 // Flags.
 /obj/item/stack/flag
 	name = "beacon"

--- a/code/modules/mob/living/carbon/human/corpse.dm
+++ b/code/modules/mob/living/carbon/human/corpse.dm
@@ -169,7 +169,7 @@
 
 
 /obj/landmark/corpse/bridgeofficer
-	name = "Bridge Officer"
+	name = ""
 	corpse_outfits = list(/singleton/hierarchy/outfit/nanotrasen/officer)
 
 /obj/landmark/corpse/commander

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -127,13 +127,16 @@ var/global/list/sparring_attack_cache = list()
 /datum/unarmed_attack/bite
 	attack_verb = list("bit")
 	attack_sound = 'sound/weapons/bite.ogg'
-	damage = 19
+	damage = 17
 	attack_name = "bite"
 
 /datum/unarmed_attack/bite/sharp
 	attack_verb = list("bit", "chomped")
 	sharp = TRUE
 	edge = TRUE
+
+/datum/unarmed_attack/bite/sharp/strong
+	damage = 19
 
 /datum/unarmed_attack/bite/is_usable(mob/living/carbon/human/user, mob/living/carbon/human/target, zone)
 
@@ -151,7 +154,7 @@ var/global/list/sparring_attack_cache = list()
 	attack_noun = list("fist")
 	eye_attack_text = "fingers"
 	eye_attack_text_victim = "digits"
-	damage = 17
+	damage = 16
 	attack_name = "punch"
 
 /datum/unarmed_attack/punch/show_attack(mob/living/carbon/human/user, mob/living/carbon/human/target, zone, attack_damage)
@@ -197,11 +200,14 @@ var/global/list/sparring_attack_cache = list()
 	else
 		user.visible_message(SPAN_CLASS("danger", "[user] [pick("punched", "threw a punch at", "struck", "slammed their [pick(attack_noun)] into")] [target]'s [organ]!")) //why do we have a separate set of verbs for lying targets?
 
+/datum/unarmed_attack/punch/strong
+	damage = 19
+
 /datum/unarmed_attack/kick
 	attack_verb = list("kicked", "kicked", "kicked", "kneed")
 	attack_noun = list("kick", "kick", "kick", "knee strike")
 	attack_sound = "swing_hit"
-	damage = 23
+	damage = 17
 	attack_name = "kick"
 
 /datum/unarmed_attack/kick/is_usable(mob/living/carbon/human/user, mob/living/carbon/human/target, zone)
@@ -235,6 +241,9 @@ var/global/list/sparring_attack_cache = list()
 		if(1 to 2)	user.visible_message(SPAN_DANGER("\The [user] threw \the [target] a glancing [pick(attack_noun)] to \the [organ]!")) //it's not that they're kicking lightly, it's that the kick didn't quite connect
 		if(3 to 4)	user.visible_message(SPAN_DANGER("\The [user] [pick(attack_verb)] \the [target] in [target_pronouns.his] [organ]!"))
 		if(5)		user.visible_message(SPAN_DANGER("\The [user] landed a strong [pick(attack_noun)] against \the [target]'s [organ]!"))
+
+/datum/unarmed_attack/kick/strong
+	damage = 19
 
 /datum/unarmed_attack/stomp
 	attack_verb = list("stomped on")
@@ -282,6 +291,9 @@ var/global/list/sparring_attack_cache = list()
 			user.visible_message(pick(
 				SPAN_CLASS("danger", "\The [user] stomped down hard onto \the [target]'s [organ][pick("", "with their [shoe_text]")]!"),
 				SPAN_DANGER("\The [user] slammed [user_pronouns.his] [shoe_text] down onto \the [target]'s [organ]!")))
+
+/datum/unarmed_attack/stomp/strong
+	damage = 12
 
 /datum/unarmed_attack/light_strike
 	deal_halloss = 3

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -34,8 +34,8 @@
 			if (armor_pen >= 200)
 				continue
 
-			// Full block if armor value is much higher than armor_pen + 10
-			if (armor_value > armor_pen + 10)
+			// Full block if armor value is much higher than armor_pen + 15. Shouldn't activate unless someone fires a pea shooter at power armor.
+			if (armor_value > armor_pen + 15)
 			{
 				show_message("<span class='warning'>Your armor protects you!</span>")
 				playsound(src, "sound/weapons/armorblockheavy[rand(1,3)].ogg", 50, 1, 1)
@@ -44,7 +44,7 @@
 			// If armor penetration exceeds armor value, continue without blocking
 			if (armor_pen >= armor_value)
 				continue
-			var damage_breakthrough = ((armor_value - armor_pen) / 15) * 100
+			var damage_breakthrough = (((armor_value * (rand(70, 110) / 100)) - armor_pen) / 15) * 100
 			if (damage_breakthrough < 0)
 				damage_breakthrough = 0
 			// Show message and sound if partial block occurs

--- a/code/modules/mob/living/simple_animal/hostile/robotic/robots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/robotic/robots.dm
@@ -115,7 +115,7 @@
 	muzzle_type = /obj/projectile/laser/pulse/muzzle
 	tracer_type = /obj/projectile/laser/pulse/tracer
 	impact_type = /obj/projectile/laser/pulse/impact
-	penetration_modifier = 1.5
+	rupture_artery = 1.5
 
 /obj/item/projectile/beam/bunkerbuster/check_penetrate(atom/A)
 	..()
@@ -123,7 +123,7 @@
 	var/chance = damage
 	var/datum/extension/penetration/P = get_extension(A, /datum/extension/penetration)
 	if(P)
-		chance = min(100, P.PenetrationProbability(chance, damage, damage_type) * penetration_modifier)
+		chance = min(100, P.PenetrationProbability(chance, damage, damage_type) * rupture_artery)
 
 	if(prob(chance))
 		if(A.opacity)

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -117,7 +117,7 @@
 	verbs |= /obj/item/organ/internal/eyes/proc/change_eye_color
 	update_colour()
 	flash_mod = 1
-	darksight_range = 2
+	darksight_range = 3
 	darksight_tint = DARKTINT_NONE
 	status = ORGAN_ROBOTIC
 

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -345,7 +345,7 @@
 	name = "magazine (8mm)"
 	icon_state = "5556"
 	mag_type = MAGAZINE
-	caliber = "autogun"
+	caliber = CALIBER_AUTOGUN
 	matter = list(DEFAULT_WALL_MATERIAL = 1800)
 	ammo_type = /obj/item/ammo_casing/autogun
 	max_ammo = 33
@@ -368,7 +368,7 @@
 	icon_state = "5556"
 	color = COLOR_DARK_GUNMETAL
 	mag_type = MAGAZINE
-	caliber = "autogun"
+	caliber = CALIBER_AUTOGUN
 	matter = list(DEFAULT_WALL_MATERIAL = 1800)
 	ammo_type = /obj/item/ammo_casing/autogun/militarum
 	max_ammo = 37
@@ -748,7 +748,7 @@
 	icon_state = "bullpup"
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
-	caliber = CALIBER_AUTOGUN_TECH
+	caliber = CALIBER_AUTOGUN
 	matter = list(MATERIAL_STEEL = 1800)
 	ammo_type = /obj/item/ammo_casing/rifle/military
 	max_ammo = 18

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -163,7 +163,7 @@
 
 /obj/item/ammo_casing/autogun/militarum
 	desc = "A 6.8mm slug casing."
-	caliber = CALIBER_AUTOGUN_TECH
+	caliber = CALIBER_AUTOGUN
 	projectile_type = /obj/item/projectile/bullet/rifle/militarum
 	icon_state = "rifle-casing"
 	spent_icon = "rifle-casing-spent"
@@ -395,7 +395,7 @@
 
 /obj/item/ammo_casing/rifle/military
 	desc = "A military rifle slug casing."
-	caliber = CALIBER_AUTOGUN_TECH
+	caliber = CALIBER_AUTOGUN
 	icon_state = "rifle_mil"
 	spent_icon = "rifle_mil-spent"
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -270,7 +270,7 @@
 	sales_price = 20
 	firemodes = list(
 		list(mode_name="single", projectile_type=/obj/item/projectile/beam/lasgun/weak, charge_cost=31, burst=1, burst_delay=2, fire_delay=4),
-		list(mode_name="overcharge", projectile_type=/obj/item/projectile/beam/lasgun, charge_cost=41, burst=3, burst_delay=2, fire_delay=4.7),
+		list(mode_name="overcharge", projectile_type=/obj/item/projectile/beam/lasgun, charge_cost=41, burst=1, burst_delay=2, fire_delay=4.7),
 		)
 
 /obj/item/gun/energy/lasgun/laspistol/militarum/bloodpact
@@ -281,7 +281,7 @@
 	charge_cost = 33
 	firemodes = list(
 		list(mode_name="single", projectile_type=/obj/item/projectile/beam/lasgun/weak, charge_cost=33, burst=1, burst_delay=2, fire_delay=4),
-		list(mode_name="overcharge", projectile_type=/obj/item/projectile/beam/lasgun, charge_cost=43, burst=3, burst_delay=2, fire_delay=4.7),
+		list(mode_name="overcharge", projectile_type=/obj/item/projectile/beam/lasgun, charge_cost=43, burst=1, burst_delay=2, fire_delay=4.7),
 		)
 
 /obj/item/gun/energy/lasgun/laspistol/lucius
@@ -296,7 +296,7 @@
 
 	firemodes = list(
 		list(mode_name="single", projectile_type=/obj/item/projectile/beam/lasgun, charge_cost=38, burst=1, burst_delay=2.2, fire_delay=4.5),
-		list(mode_name="overcharge", projectile_type=/obj/item/projectile/beam/lasgun/overcharge, charge_cost=48, burst=3, burst_delay=2.2, fire_delay=5.5),
+		list(mode_name="overcharge", projectile_type=/obj/item/projectile/beam/lasgun/overcharge, charge_cost=48, burst=1, burst_delay=2.2, fire_delay=5.5),
 		)
 
 /obj/item/gun/energy/lasgun/laspistol/accatran

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -196,7 +196,7 @@
 	item_state = "z8carbine"
 	w_class = ITEM_SIZE_HUGE
 	force = 10
-	caliber = CALIBER_AUTOGUN_TECH
+	caliber = CALIBER_AUTOGUN
 	origin_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 3)
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
@@ -397,7 +397,7 @@
 	item_state = null
 	w_class = ITEM_SIZE_HUGE
 	force = 12
-	caliber = CALIBER_AUTOGUN_TECH
+	caliber = CALIBER_AUTOGUN
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 1, TECH_ESOTERIC = 5)
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE

--- a/code/modules/projectiles/guns/projectile/eisenhorn.dm
+++ b/code/modules/projectiles/guns/projectile/eisenhorn.dm
@@ -18,17 +18,6 @@
 	mag_insert_sound 	= 'sound/warhammer/guns/interact/rev_magin.ogg'
 	load_sound = 'sound/warhammer/guns/interact/rev_magin.ogg'
 
-/obj/item/gun/projectile/revolver/imperial/on_update_icon()
-	..()
-	if(ammo_magazine)
-		icon_state = "snubby"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-	else
-		icon_state = "snubby-e"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-
 /obj/item/gun/projectile/revolver/imperial/holdout
 	name = "Holdout Revolver"
 	desc = "A concealed-carry revolver that is more compact at the cost of additional recoil. It fires small 7mm tech rounds"
@@ -43,17 +32,6 @@
 	fire_delay = 3.2
 	max_shells = 9
 
-/obj/item/gun/projectile/revolver/imperial/holdout/on_update_icon()
-	..()
-	if(ammo_magazine)
-		icon_state = "mervex"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-	else
-		icon_state = "mervex"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-
 /obj/item/gun/projectile/revolver/imperial/heavy
 	name = "Heavy Slug Revolver"
 	desc = "A heavy slug revolver chambered in 15mm, standard issue to Guard Officers and Magistratum Enforcers."
@@ -66,18 +44,6 @@
 	fire_delay = 3.5
 	max_shells = 7
 
-/obj/item/gun/projectile/revolver/imperial/heavy/on_update_icon()
-	..()
-	if(ammo_magazine)
-		icon_state = "slug_revolver"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-	else
-		icon_state = "slug_revolver"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-
-
 /obj/item/gun/projectile/revolver/imperial/heavy/mateba
 	name = "Heavy Slug Revolver"
 	desc = "A custom made mateba slug revolver -- clearly forged by a talented of gunsmith, it's makers mark signifying it's origins beyond the Ghoul Stars."
@@ -87,17 +53,6 @@
 	fire_delay= 3.3
 	max_shells = 8
 
-/obj/item/gun/projectile/revolver/imperial/heavy/mateba/on_update_icon()
-	..()
-	if(ammo_magazine)
-		icon_state = "goldmateba"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-	else
-		icon_state = "goldmateba-e"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-
 /obj/item/gun/projectile/revolver/imperial/heavy/necros
 	name = "Heavy Slug Revolver"
 	desc = "A necromundan slug revolver -- a favorite among bounty hunters due to it's supreme accuracy at a distance."
@@ -105,17 +60,6 @@
 	accuracy = 0.6
 	fire_delay= 3.5
 	max_shells = 7
-
-/obj/item/gun/projectile/revolver/imperial/heavy/necros/on_update_icon()
-	..()
-	if(ammo_magazine)
-		icon_state = "necros"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-	else
-		icon_state = "necros"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
 
 /obj/item/gun/projectile/revolver/imperial/heavy/custom
 	name = "Custom Slug Revolver"
@@ -126,48 +70,8 @@
 	max_shells = 8
 	ammo_type = /obj/item/ammo_casing/autogun/militarum
 	caliber = list(
-    CALIBER_AUTOGUN_TECH
+	CALIBER_AUTOGUN
 )
-
-/obj/item/gun/projectile/revolver/imperial/heavy/custom/on_update_icon()
-	..()
-	if(ammo_magazine)
-		icon_state = "hunting_revolver"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-	else
-		icon_state = "hunting_revolver"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-
-/obj/item/gun/projectile/revolver/imperial/heavy/officer
-	name = "Heavy Slug Revolver"
-	desc = "This slug revolver is custom forged to fire heavy shotgun shells and slug rounds. The recoil is punishing and it can only hold four shells at a time."
-	icon_state = "mrevolver"
-	item_state = "crevolver"
-	caliber = "shotgun"
-	handle_casings = CYCLE_CASINGS
-	max_shells = 4
-	force = 15
-	accuracy = -0.5
-	fire_delay= 3.7
-	ammo_type = /obj/item/ammo_casing/shotgun
-	caliber = list(
-    CALIBER_SHOTGUN
-)
-	fire_sound = 'sound/warhammer/guns/fire/revolver_fire.ogg'
-
-/obj/item/gun/projectile/revolver/imperial/heavy/custom/on_update_icon()
-	..()
-	if(ammo_magazine)
-		icon_state = "mrevolver"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-	else
-		icon_state = "mrevolver-e"
-		item_state = "crevolver"
-		wielded_item_state = "crevolver"
-
 
 /obj/item/gun/projectile/pistol/slug // Do not get the calibers mixed up. Slug pistols use caliber_slug_magnum.
 	name = "Slug Pistol"
@@ -183,7 +87,7 @@
 	one_hand_penalty = 0
 	fire_delay = 3.7
 	caliber = list(
-    CALIBER_SLUG_MAGNUM
+	CALIBER_SLUG_MAGNUM
 )
 	accuracy = -0.5
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
@@ -212,8 +116,8 @@
 	accuracy = -1 // Fires both Antique and Magnum rounds. Not accurate.
 	sales_price = 15
 	caliber = list(
-    CALIBER_SLUG_MAGNUM,
-    CALIBER_SLUG_ANTIQUE
+	CALIBER_SLUG_MAGNUM,
+	CALIBER_SLUG_ANTIQUE
 )
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 
@@ -228,6 +132,34 @@
 		item_state = "pistol"
 		wielded_item_state = "pistol"
 
+/obj/item/gun/projectile/pistol/slug/shotgun
+	name = "Maccabian Slug Pistol"
+	desc = "This slug pistol is custom forged to fire heavy 16mm slugs with a magazine insert for standard shotshell holders. The recoil is punishing and it can only hold eight shells at a time."
+	icon_state = "mrevolver"
+	item_state = "crevolver"
+	caliber = "shotgun"
+	force = 15
+	accuracy = -0.5
+	fire_delay= 3.7
+	allowed_magazines = /obj/item/ammo_magazine/shotholder
+	magazine_type = /obj/item/ammo_magazine/shotholder/flechette
+	ammo_type = /obj/item/ammo_casing/shotgun
+	caliber = list(
+	CALIBER_SHOTGUN
+)
+	fire_sound = 'sound/warhammer/guns/fire/revolver_fire.ogg'
+
+/obj/item/gun/projectile/pistol/slug/shotgun/on_update_icon()
+	..()
+	if(ammo_magazine)
+		icon_state = "mrevolver"
+		item_state = "crevolver"
+		wielded_item_state = "crevolver"
+	else
+		icon_state = "mrevolver-e"
+		item_state = "crevolver"
+		wielded_item_state = "crevolver"
+
 /obj/item/gun/projectile/pistol/stub
 	name = "Kieji stub pistol"
 	desc = "A standard pattern 10mm stub pistol, on the side is the makers mark of it's forger -- this pistol has history."
@@ -238,8 +170,8 @@
 	allowed_magazines = /obj/item/ammo_magazine/pistol
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	caliber = list(
-    CALIBER_SLUG,
-    CALIBER_SLUG_ANTIQUE
+	CALIBER_SLUG,
+	CALIBER_SLUG_ANTIQUE
 )
 	sales_price = 8
 	accuracy = 0.3
@@ -305,7 +237,7 @@
 	icon_state = "talon"
 	fire_delay = 2.5
 	caliber = list(
-    CALIBER_SLUG_SMALL
+	CALIBER_SLUG_SMALL
 )
 	magazine_type = /obj/item/ammo_magazine/pistol/small/ap
 	allowed_magazines = /obj/item/ammo_magazine/pistol/small

--- a/code/modules/projectiles/guns/projectile/ravenor.dm
+++ b/code/modules/projectiles/guns/projectile/ravenor.dm
@@ -203,8 +203,7 @@
 	fire_delay = 3.5
 	sales_price = 8
 	caliber = list(
-    CALIBER_AUTOGUN,
-    CALIBER_AUTOGUN_TECH
+	CALIBER_AUTOGUN
 )
 	fire_sound = 'sound/warhammer/guns/fire/smg_fire.ogg' // reminder sounds are under warhammer/
 	ammo_type = /obj/item/ammo_casing/autogun
@@ -433,7 +432,7 @@
 	accuracy = 0
 	fire_delay = 3.5
 	sales_price = 20
-	caliber = CALIBER_AUTOGUN_TECH
+	caliber = CALIBER_AUTOGUN
 	fire_sound = 'sound/warhammer/gunshot/auto2.ogg'
 	ammo_type = /obj/item/ammo_casing/autogun/militarum
 	magazine_type = /obj/item/ammo_magazine/autogunheavy
@@ -472,7 +471,7 @@
 	accuracy = 0.5
 	fire_delay = 3.4
 	sales_price = 25
-	caliber = CALIBER_AUTOGUN_TECH
+	caliber = CALIBER_AUTOGUN
 	fire_sound = 'sound/warhammer/gunshot/auto2.ogg'
 	ammo_type = /obj/item/ammo_casing/autogun/militarum
 	magazine_type = /obj/item/ammo_magazine/autogunheavy/ap
@@ -771,48 +770,7 @@
 	slowdown_per_slot[slot_r_hand] = 0.4
 	slowdown_per_slot[slot_l_hand] = 0.4
 
-/obj/item/gun/projectile/automatic/radcarbine/radpistol/update_icon()
-	..()
-	if(ammo_magazine)
-		icon_state = "pulserifle"
-		item_state = "pulserifle"
-		wielded_item_state = "pulserifle-wielded"
-	else
-		icon_state = "pulserifle"
-		item_state = "pulserifle"
-		wielded_item_state = "pulserifle-wielded"
-
-// KRUMPIN TIME
-
-/obj/item/gun/projectile/automatic/gaussrifle
-	name ="Gauss Rifle"
-	desc = "A strange alien weapon which hums with resonant frequencies alien to mankind."
-	icon = 'icons/map_project/port/ds13.dmi'
-	fire_sound = 'sound/warhammer/ds/pulse_shot.ogg'
-	caliber = "pmag"
-	max_shells = 40
-	one_hand_penalty = 3.5
-	accuracy = 0
-	fire_delay = 1.5
-	slot_flags = SLOT_BACK
-	magazine_type = /obj/item/ammo_magazine/pulsemag
-	allowed_magazines = list(/obj/item/ammo_magazine/pulsemag)
-	w_class = ITEM_SIZE_HUGE
-
-	firemodes = list(
-		list(mode_name="semi-automatic", burst=1, fire_delay=1.2, burst_accuracy=null, dispersion=null, automatic = 0),
-		list(mode_name="5-round bursts", burst=5, fire_delay=4, burst_accuracy=list(0,-1,-1), dispersion=null, automatic = 0),
-		)
-
-/obj/item/gun/projectile/automatic/gaussrifle/New()
-	..()
-	slowdown_per_slot[slot_back] = 0.15 // Wear slowdown is higher due to Xenos tech not being designed for human bodies.
-	slowdown_per_slot[slot_belt] = 0.25
-	slowdown_per_slot[slot_wear_suit] = 0.25
-	slowdown_per_slot[slot_r_hand] = 0.4
-	slowdown_per_slot[slot_l_hand] = 0.4
-
-/obj/item/gun/projectile/automatic/radcarbine/radpistol/update_icon()
+/obj/item/gun/projectile/automatic/gaussrifle/update_icon()
 	..()
 	if(ammo_magazine)
 		icon_state = "pulserifle"

--- a/code/modules/projectiles/guns/projectile/zipgun.dm
+++ b/code/modules/projectiles/guns/projectile/zipgun.dm
@@ -36,7 +36,7 @@
 		fire_sound = 'sound/weapons/gunshot/shotgun.ogg'
 	if(caliber == CALIBER_SLUG)
 		fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
-	if(caliber == CALIBER_AUTOGUN || caliber == CALIBER_AUTOGUN_TECH)
+	if(caliber == CALIBER_AUTOGUN || caliber == CALIBER_AUTOGUN)
 		fire_sound = 'sound/weapons/gunshot/gunshot3.ogg'
 	. = ..()
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -57,7 +57,7 @@
 	var/drowsy = 0
 	var/agony = 0
 	var/embed = FALSE // whether or not the projectile can embed itself in the mob
-	var/penetration_modifier = 0.2 //How likely this projectile is to embed or rupture artery
+	var/rupture_artery = 0.2 //How likely this projectile is to embed or rupture artery
 	var/space_knockback = 0	//whether or not it will knock things back in space
 
 	var/hitscan = FALSE		// whether the projectile should be hitscan
@@ -524,7 +524,7 @@
 	if(!can_embed() || (organ.species.species_flags & SPECIES_FLAG_NO_EMBED))
 		return
 	//Embed or sever artery
-	var/damage_prob = 0.5 * wound.damage * penetration_modifier
+	var/damage_prob = 0.5 * wound.damage * rupture_artery
 	if(prob(damage_prob))
 		var/obj/item/shrapnel = get_shrapnel()
 		if(shrapnel)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -13,7 +13,7 @@
 	eyeblur = 4
 	hitscan = TRUE
 	invisibility = INVISIBILITY_ABSTRACT	//beam projectiles are invisible as they are rendered by the effect engine
-	penetration_modifier = 0.3
+	rupture_artery = 0.3
 	distance_falloff = 1.5
 	damage_falloff = TRUE
 	var/mob_passthrough_checker = 0
@@ -74,7 +74,7 @@
 
 /obj/item/projectile/beam/midlaser
 	damage = 40
-	armor_penetration = 20
+	armor_penetration = 22
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(6, 0.98),
@@ -85,8 +85,8 @@
 	icon_state = "laser"
 	fire_sound = 'sound/warhammer/gunshot/lasgun2.ogg'
 	damage = 45
-	penetration_modifier = 0.4
-	armor_penetration = 24
+	rupture_artery = 0.4
+	armor_penetration = 25
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(6, 0.98),
@@ -97,8 +97,8 @@
 	icon_state = "laser"
 	fire_sound = 'sound/warhammer/gunshot/lasgun1.ogg'
 	damage = 38
-	armor_penetration = 22
-	penetration_modifier = 0.2
+	armor_penetration = 23
+	rupture_artery = 0.2
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(6, 0.98),
@@ -109,8 +109,8 @@
 	icon_state = "heavylaser"
 	fire_sound = 'sound/warhammer/gunshot/lasgun3.ogg'
 	damage = 50
-	armor_penetration = 28
-	penetration_modifier = 0.5
+	armor_penetration = 29
+	rupture_artery = 0.5
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(6, 0.98),
@@ -121,8 +121,8 @@
 	icon_state = "laser"
 	fire_sound = 'sound/warhammer/gunshot/lasgun2.ogg'
 	damage = 48
-	armor_penetration = 26
-	penetration_modifier = 0.5
+	armor_penetration = 27
+	rupture_artery = 0.5
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(6, 0.98),
@@ -133,8 +133,8 @@
 	icon_state = "laser"
 	fire_sound = 'sound/warhammer/gunshot/lasgun2.ogg'
 	damage = 53
-	armor_penetration = 30
-	penetration_modifier = 0.6
+	armor_penetration = 31
+	rupture_artery = 0.6
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(6, 0.98),
@@ -145,8 +145,8 @@
 	icon_state = "heavylaser"
 	fire_sound = 'sound/warhammer/gunshot/lasgun3.ogg'
 	damage = 50
-	armor_penetration = 28
-	penetration_modifier = 0.5
+	armor_penetration = 29
+	rupture_artery = 0.5
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(6, 0.98),
@@ -157,8 +157,8 @@
 	icon_state = "heavylaser"
 	fire_sound = 'sound/warhammer/gunshot/lasgun3.ogg'
 	damage = 54
-	armor_penetration = 32
-	penetration_modifier = 0.6
+	armor_penetration = 33
+	rupture_artery = 0.6
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(6, 0.98),
@@ -169,8 +169,8 @@
 	icon_state = "heavylaser"
 	fire_sound = 'sound/warhammer/gunshot/lasgun3.ogg'
 	damage = 58
-	armor_penetration = 32 // AP can't be too high or else it'll ignore power armor.
-	penetration_modifier = 0.8
+	armor_penetration = 33 // AP can't be too high or else it'll ignore power armor.
+	rupture_artery = 0.8
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(6, 0.98),
@@ -180,8 +180,8 @@
 	icon_state = "heavylaser"
 	fire_sound = 'sound/warhammer/gunshot/lasgun3.ogg'
 	damage = 62
-	armor_penetration = 36
-	penetration_modifier = 0.9
+	armor_penetration = 37
+	rupture_artery = 0.9
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(6, 0.98),
@@ -196,9 +196,9 @@
 	agony = 8
 	eyeblur = 8
 	damage_flags = 0
-	penetration_modifier = 0.3 // Volkite sets you on fire. Lasbeams explode chunks off you. So less arterial bleed.
+	rupture_artery = 0.3 // Volkite sets you on fire. Lasbeams explode chunks off you. So less arterial bleed.
 	life_span = 5
-	armor_penetration = 34
+	armor_penetration = 35
 	damage_falloff_list = list(
 		list(3, 0.90), // Distance, Damage Multiplier. E.G. Distance of 3 or more means 0.90 damage mult.
 		list(5, 0.80),
@@ -222,9 +222,9 @@
 	icon_state = "heavylaser"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 	damage = 66
-	armor_penetration = 28
+	armor_penetration = 29
 	distance_falloff = 0.5
-	penetration_modifier = 0.5
+	rupture_artery = 0.5
 	damage_falloff_list = list(
 		list(6, 0.97),
 		list(9, 0.94),
@@ -240,7 +240,7 @@
 	icon_state = "xray"
 	fire_sound = 'sound/weapons/laser3.ogg'
 	damage = 37
-	armor_penetration = 28
+	armor_penetration = 29
 	distance_falloff = 1.5
 	damage_falloff_list = list(
 		list(3, 0.95),
@@ -267,7 +267,7 @@
 	icon_state = "u_laser"
 	fire_sound='sound/weapons/pulse.ogg'
 	damage = 25 //lower damage, but fires in bursts
-	armor_penetration = 22
+	armor_penetration = 23
 	distance_falloff = 1.5
 	damage_falloff_list = list(
 		list(3, 0.95),
@@ -281,7 +281,7 @@
 
 /obj/item/projectile/beam/pulse/mid
 	damage = 35
-	armor_penetration = 24
+	armor_penetration = 25
 	distance_falloff = 1
 	damage_falloff_list = list(
 		list(4, 0.96),
@@ -291,7 +291,7 @@
 
 /obj/item/projectile/beam/pulse/heavy
 	damage = 35
-	armor_penetration = 26
+	armor_penetration = 27
 	distance_falloff = 0.5
 	damage_falloff_list = list(
 		list(6, 0.97),
@@ -389,7 +389,7 @@
 	icon_state = "xray"
 	fire_sound = 'sound/weapons/marauder.ogg'
 	damage = 53
-	penetration_modifier = 0.5
+	rupture_artery = 0.5
 	armor_penetration = 29
 	damage_falloff_list = null
 
@@ -506,7 +506,7 @@
 	damage_flags = 0
 	damage_type = DAMAGE_STUN
 	life_span = 3
-	penetration_modifier = 0.4
+	rupture_artery = 0.4
 	var/potency_min = 4
 	var/potency_max = 6
 
@@ -535,13 +535,13 @@
 	muzzle_type = /obj/projectile/laser_particle/muzzle
 	tracer_type = /obj/projectile/laser_particle/tracer
 	impact_type = /obj/projectile/laser_particle/impact
-	penetration_modifier = 0.8
+	rupture_artery = 0.8
 
 /obj/item/projectile/beam/particle/small
 	name = "particle beam"
 	damage = 40
 	armor_penetration = 24
-	penetration_modifier = 0.6
+	rupture_artery = 0.6
 
 /obj/item/projectile/beam/darkmatter
 	name = "dark matter bolt"
@@ -568,7 +568,7 @@
 	name = "point defense salvo"
 	icon_state = "laser"
 	damage = 15
-	armor_penetration = 20
+	armor_penetration = 22
 	damage_type = DAMAGE_BURN //You should be safe inside a voidsuit
 	sharp = FALSE //"Wide" spectrum beam
 	muzzle_type = /obj/projectile/pointdefense/muzzle

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -3,11 +3,11 @@
 	icon_state = "bullet"
 	fire_sound = null
 	damage = 30
-	armor_penetration = 16
+	armor_penetration = 21
 	damage_type = DAMAGE_BRUTE
 	damage_flags = DAMAGE_FLAG_BULLET | DAMAGE_FLAG_SHARP
 	embed = TRUE
-	penetration_modifier = 0.4
+	rupture_artery = 0.4
 	space_knockback = 1
 	var/mob_passthrough_check = 0
 	var/is_pellet = FALSE
@@ -127,53 +127,53 @@
 
 /obj/item/projectile/bullet/pistol
 	damage = 35
-	armor_penetration = 20
+	armor_penetration = 21
 	distance_falloff = 3
 
 /obj/item/projectile/bullet/pistol/ap
-	armor_penetration = 22 // +2
+	armor_penetration = 23 // +2
 
 /obj/item/projectile/bullet/pistol/kp
 	damage = 38 // +3 damage.
-	armor_penetration = 24 // +2 added with AP. So +4 total from standard.
+	armor_penetration = 25 // +2 added with AP. So +4 total from standard.
 
 /obj/item/projectile/bullet/pistol/ms
 	damage = 43 // MS rounds are +5 damage -2 AP to all rounds
-	armor_penetration = 18
+	armor_penetration = 19
 
 /obj/item/projectile/bullet/pistol/holdout // Higher quality penetrative slugs
 	damage = 32
-	armor_penetration = 21
-	penetration_modifier = 0.5
+	armor_penetration = 22
+	rupture_artery = 0.5
 	distance_falloff = 4
 
 /obj/item/projectile/bullet/pistol/holdout/ap
-	armor_penetration = 23
+	armor_penetration = 24
 
 /obj/item/projectile/bullet/pistol/holdout/kp
 	damage = 35
-	armor_penetration = 25
+	armor_penetration = 26
 
 /obj/item/projectile/bullet/pistol/holdout/ms
 	damage = 40
-	armor_penetration = 21
+	armor_penetration = 20
 
 /obj/item/projectile/bullet/magnum
 	damage = 38
-	penetration_modifier = 0.5
+	rupture_artery = 0.5
 	distance_falloff = 2 // Heavy slug.
-	armor_penetration = 22
+	armor_penetration = 24
 
 /obj/item/projectile/bullet/magnum/ap
-	armor_penetration = 24
+	armor_penetration = 26
 
 /obj/item/projectile/bullet/magnum/kp
 	damage = 41
-	armor_penetration = 26
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/magnum/ms
 	damage = 46
-	armor_penetration = 20
+	armor_penetration = 22
 
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
@@ -195,7 +195,7 @@
 /obj/item/projectile/bullet/flechette
 	damage = 35
 	penetrating = 1
-	armor_penetration = 23
+	armor_penetration = 25
 	embed = FALSE
 	distance_falloff = 2
 
@@ -204,19 +204,19 @@
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	damage = 65
-	armor_penetration = 22
+	armor_penetration = 24
 	distance_falloff = 4
 
 /obj/item/projectile/bullet/shotgun/ap
-	armor_penetration = 25
+	armor_penetration = 27
 
 /obj/item/projectile/bullet/shotgun/kp
 	damage = 68
-	armor_penetration = 27 // special rounds scale better on big slugs.
+	armor_penetration = 29 // special rounds scale better on big slugs.
 
 /obj/item/projectile/bullet/shotgun/ms
 	damage = 70
-	armor_penetration = 21
+	armor_penetration = 24
 
 /obj/item/projectile/bullet/shotgun/beanbag
 	name = "beanbag"
@@ -243,75 +243,75 @@
 	name = "flechette"
 	icon_state = "flechette"
 	damage = 18 // Tigher spread and higher AP. On paper this thing blows regular pellets out of the water when dealing with flak.
-	armor_penetration = 21
+	armor_penetration = 23
 	pellets = 6
 	range_step = 3
 	base_spread = 99
 	spread_step = 15
-	penetration_modifier = 0.4
+	rupture_artery = 0.4
 
 /* "Rifle" rounds */
 
 /obj/item/projectile/bullet/rifle // 8mm slug round. Ideal for soft targets and light armour.
 	damage = 38
-	armor_penetration = 22
+	armor_penetration = 25
 	distance_falloff = 1
 
 /obj/item/projectile/bullet/rifle/ap
-	armor_penetration = 24
+	armor_penetration = 27
 
 /obj/item/projectile/bullet/rifle/kp
 	damage = 41
-	armor_penetration = 26
+	armor_penetration = 29
 
 /obj/item/projectile/bullet/rifle/ms
 	damage = 43
-	armor_penetration = 20
+	armor_penetration = 23
 
 /obj/item/projectile/bullet/rifle/heavy // 10mm heavy rifle slug. Big recoil.
 	damage = 43
-	armor_penetration = 24
+	armor_penetration = 26
 
 /obj/item/projectile/bullet/rifle/heavy/ap
-	armor_penetration = 26
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/rifle/heavy/kp
 	damage = 46
-	armor_penetration = 28
+	armor_penetration = 30
 
 /obj/item/projectile/bullet/rifle/heavy/ms
 	damage = 51
-	armor_penetration = 20
+	armor_penetration = 26
 
 /obj/item/projectile/bullet/rifle/militarum // 6.8 Militarum. Higher AP, less damage to 8mm.
 	damage = 36
-	armor_penetration = 24
+	armor_penetration = 26
 
 /obj/item/projectile/bullet/rifle/militarum/ap
-	armor_penetration = 26
+	armor_penetration = 28
 
 /obj/item/projectile/bullet/rifle/militarum/kp
 	damage = 39
-	armor_penetration = 28
+	armor_penetration = 30
 
 /obj/item/projectile/bullet/rifle/militarum/ms
 	damage = 41
-	armor_penetration = 22
+	armor_penetration = 24
 
 /obj/item/projectile/bullet/rifle/sniper // 12.7mm Battle Round
 	damage = 58
-	armor_penetration = 32
+	armor_penetration = 33
 
 /obj/item/projectile/bullet/rifle/sniper/ap
-	armor_penetration = 34
+	armor_penetration = 35
 
 /obj/item/projectile/bullet/rifle/sniper/kp
 	damage = 61
-	armor_penetration = 36
+	armor_penetration = 37
 
 /obj/item/projectile/bullet/rifle/sniper/ms
 	damage = 63
-	armor_penetration = 30
+	armor_penetration = 31
 
 /obj/item/projectile/bullet/rifle/shell // 12.7mm Tech Round
 	damage = 85
@@ -319,7 +319,7 @@
 	weaken = 2
 	penetrating = 3
 	armor_penetration = 34
-	penetration_modifier = 1
+	rupture_artery = 1
 	distance_falloff = 0.5
 
 /obj/item/projectile/bullet/rifle/shell/apds
@@ -327,17 +327,17 @@
 
 /obj/item/projectile/bullet/rifle/shell/apds/rail
 	damage = 110
-	armor_penetration = 32 // Not a penetrative slug -- just hot metal being fired by a xenos magnetic rail device.
+	armor_penetration = 33 // Not a penetrative slug -- just hot metal being fired by a xenos magnetic rail device.
 
 /obj/item/projectile/bullet/rifle/shell/rend // Special tech shredder round. Loses wall_pen ability for huge damage.
 	damage = 100
 	penetrating = 0
-	armor_penetration = 32
+	armor_penetration = 33
 
 /obj/item/projectile/bullet/rifle/shell/knockout // Round for putting space marines and xenos to sleep for capture or killing.
 	damage = 40
 	penetrating = 0
-	armor_penetration = 32
+	armor_penetration = 33
 	paralyze = 3
 	drowsy = 20
 	stun = 3

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -200,7 +200,7 @@
 	armor_penetration = 30
 	damage_type = DAMAGE_BRUTE
 	vacuum_traversal = 0
-	penetration_modifier = 0.2
+	rupture_artery = 0.2
 	penetrating = 1
 	min_dizziness_amt = 10
 	med_dizziness_amt = 60

--- a/code/modules/projectiles/projectile/magnetic.dm
+++ b/code/modules/projectiles/projectile/magnetic.dm
@@ -5,7 +5,7 @@
 	damage = 75
 	penetrating = 5
 	armor_penetration = 28
-	penetration_modifier = 1.1
+	rupture_artery = 1.1
 	fire_sound = 'sound/weapons/railgun.ogg'
 	distance_falloff = 1
 

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -35,13 +35,13 @@
 	base_color  = RANDOM_RGB
 
 	//Combat stats
-	total_health = round(total_health * Frand(0.8, 1.2), 0.1)
-	brute_mod = round(brute_mod * Frand(0.5, 1.5), 0.1)
-	burn_mod = round(burn_mod * Frand(0.8, 1.2), 0.1)
-	oxy_mod = round(oxy_mod * Frand(0.5, 1.5), 0.1)
-	toxins_mod = round(toxins_mod * Frand(0, 2), 0.1)
-	radiation_mod = round(radiation_mod * Frand(0, 2), 0.1)
-	flash_mod = round(flash_mod * Frand(0.5, 1.5), 0.1)
+	total_health = round(total_health * Frand(0.9, 1.4), 0.1)
+	brute_mod = round(brute_mod * Frand(0.5, 1), 0.1)
+	burn_mod = round(burn_mod * Frand(0.5, 1), 0.1)
+	oxy_mod = round(oxy_mod * Frand(0.5, 1), 0.1)
+	toxins_mod = round(toxins_mod * Frand(0, 1), 0.1)
+	radiation_mod = round(radiation_mod * Frand(0, 1), 0.1)
+	flash_mod = round(flash_mod * Frand(0.5, 1), 0.1)
 
 	if(brute_mod < 1 && prob(40))
 		species_flags |= SPECIES_FLAG_NO_MINOR_CUT

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -102,8 +102,8 @@
 	hunger_factor = 0
 	breath_type = null
 
-	burn_mod = 10
-	brute_mod = 0
+	burn_mod = 1
+	brute_mod = 0.2
 	oxy_mod = 0
 	toxins_mod = 0
 	radiation_mod = 0

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -42,12 +42,12 @@
 
 	min_age = 1
 	max_age = 100
-	brute_mod = 0.9 // Vunerable to Brute.
-	burn_mod = 0.75 // Resistance to Burn.
-	stun_mod = 0.8 // Resistant to concussion
-	weaken_mod = 0.8 // Advanced health systems.
-	paralysis_mod = 0.8
-	toxins_mod = 0.8
+	brute_mod = 0.75 // Vunerable to Brute.
+	burn_mod = 0.55 // Resistance to Burn.
+	stun_mod = 0.7 // Resistant to concussion
+	weaken_mod = 0.7 // Advanced health systems.
+	paralysis_mod = 0.7
+	toxins_mod = 0.7
 
 	gluttonous = GLUT_TINY|GLUT_ITEM_NORMAL
 	stomach_capacity = 12

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -55,8 +55,8 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_SCAN
 	spawn_flags = SPECIES_IS_RESTRICTED
 	vision_flags = SEE_SELF | SEE_MOBS
-	brute_mod = 1.0
-	burn_mod = 1.5 //Vulnerable to fire
+	brute_mod = 0.5
+	burn_mod = 0.5
 	oxy_mod = 0.0
 	stun_mod = 0.2
 	weaken_mod = 0.3

--- a/code/modules/species/station/human_subspecies.dm
+++ b/code/modules/species/station/human_subspecies.dm
@@ -13,7 +13,7 @@
 	oxy_mod =       0.6
 	breath_pressure = 17
 	radiation_mod = 1
-	brute_mod =     0.9
+	brute_mod =     0.7
 	strength = STR_HIGH
 
 	descriptors = list(
@@ -32,12 +32,11 @@
 	icobase =     'icons/mob/human_races/species/human/subspecies/spacer_body.dmi'
 	preview_icon= 'icons/mob/human_races/species/human/subspecies/spacer_preview.dmi'
 
-	oxy_mod =   0.4
-	breath_pressure = 15
-	toxins_mod =   0.9
-	brute_mod = 1.05
-	radiation_mod = 0.8
-	darksight_range = 5
+	oxy_mod =   0.35
+	toxins_mod =   0.7
+	brute_mod = 0.8
+	radiation_mod = 0.6
+	darksight_range = 4
 	darksight_tint = DARKTINT_MODERATE
 
 	descriptors = list(
@@ -69,7 +68,7 @@
 	icobase =     'icons/mob/human_races/species/human/subspecies/vatgrown_body.dmi'
 	preview_icon= 'icons/mob/human_races/species/human/subspecies/vatgrown_preview.dmi'
 
-	toxins_mod =   1.1
+	toxins_mod =   0.75
 	has_organ = list(
 		BP_HEART =    /obj/item/organ/internal/heart,
 		BP_STOMACH =  /obj/item/organ/internal/stomach,
@@ -101,9 +100,9 @@
 	slowdown = 1
 
 	oxy_mod =             0.5
-	brute_mod =           0.8
-	toxins_mod =          1.15
-	radiation_mod =       1.15
+	brute_mod =           0.75
+	toxins_mod =          1
+	radiation_mod =       0.75
 	body_temperature =    302
 	water_soothe_amount = 5
 
@@ -146,13 +145,12 @@
 	preview_icon= 'icons/mob/human_races/species/human/subspecies/mule_preview.dmi'
 
 	spawn_flags =   SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_FBP_CHARGEN | SPECIES_NO_ROBOTIC_INTERNAL_ORGANS
-	brute_mod =     0.9
-	burn_mod =      0.9
-	oxy_mod =       0.6
-	toxins_mod =    0.8
-	radiation_mod = 0.9
-	flash_mod =     1.1
-	blood_volume =  SPECIES_BLOOD_DEFAULT * 0.85
+	brute_mod =     0.65
+	burn_mod =      0.65
+	oxy_mod =       0.5
+	toxins_mod =    0.7
+	radiation_mod = 0.6
+	flash_mod =     1.2
 	min_age =       18
 	max_age =       500
 

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -19,10 +19,11 @@
 	strength = STR_HIGH
 	breath_pressure = 12
 	slowdown = -0.4
-	brute_mod = 0.8
-	burn_mod = 0.7
+	brute_mod = 0.55
+	burn_mod = 0.65
 	flash_mod = 1.2
 	toxins_mod = 0.5
+	radiation_mod = 0.4
 	blood_volume = 800
 
 	health_hud_intensity = 2

--- a/code/modules/species/station/lizard_subspecies.dm
+++ b/code/modules/species/station/lizard_subspecies.dm
@@ -9,8 +9,6 @@
 	darksight_range = 5
 	darksight_tint = DARKTINT_GOOD
 	slowdown = 0.4
-	brute_mod = 0.85
-	flash_mod = 1.4
 	blood_volume = 700
 	water_soothe_amount = 5
 	species_flags = SPECIES_IS_RESTRICTED

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -31,8 +31,8 @@
 
 	rarity_value = 0.1
 	total_health = 150
-	brute_mod = 1.5
-	burn_mod = 1.5
+	brute_mod = 0.65
+	burn_mod = 0.8
 
 	spawn_flags = SPECIES_IS_RESTRICTED
 

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -47,8 +47,8 @@
 	hud_type = /datum/hud_data/nabber
 
 	total_health = 200
-	brute_mod = 0.9
-	burn_mod =  1.35
+	brute_mod = 0.65
+	burn_mod =  0.75
 	natural_armour_values = list(
 		melee = ARMOR_MELEE_FLAK,
 		bullet = ARMOR_BALLISTIC_BASIC,

--- a/code/modules/species/station/prometheans.dm
+++ b/code/modules/species/station/prometheans.dm
@@ -35,7 +35,7 @@ var/global/datum/species/shapeshifter/promethean/prometheans
 	min_age =             1
 	max_age =             5
 	brute_mod =           0.5
-	burn_mod =            2
+	burn_mod =            0.8
 	oxy_mod =             0
 	total_health =        240
 	siemens_coefficient = -1

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -78,10 +78,8 @@
 	min_age = 19
 	max_age = 190
 
-	burn_mod = 0.9
-	oxy_mod = 0.4
-	flash_mod = 1.1
-	toxins_mod = 1.1
+	burn_mod = 0.8
+	oxy_mod = 0.7
 	siemens_coefficient = 1.3
 	warning_low_pressure = WARNING_LOW_PRESSURE
 	hazard_low_pressure = HAZARD_LOW_PRESSURE
@@ -218,7 +216,7 @@
 	assisted_langs = list(LANGUAGE_NABBER)
 	spawns_with_stack = 0
 	health_hud_intensity = 2
-	hunger_factor = 3
+	hunger_factor = 1
 	thirst_factor = 0.01
 
 	min_age = 1

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -46,12 +46,15 @@
 
 /datum/job/rogue_trader/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
-	if (!selected_title)
-		selected_title = title
-	H.fully_replace_character_name("[selected_title] [current_name]")
-	captain_announcement.Announce("All crew, [selected_title] [current_name] has arrived...")
-	to_chat(H, "<span class='notice'><b><font size=2>You are the [selected_title], commander of the Dauntless, an Imperial corvette exploratory vessel. Tasked with navigating the uncharted terror -- the Ghoul Stars, you lead a diverse retinue representing many factions, each serving a crucial role aboard your ship. While you hold ultimate authority, you work closely with your Magos Explorator, whose resources and personnel are vital to your survival in this cursed region. Rely on your officers to manage the deck scum, explore forgotten worlds, and broker alliances or hostilities with the human, alien, and worse. The emperor protects...</font></b></span>")
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
+	H.fully_replace_character_name("[current_title] [current_name]")
+	captain_announcement.Announce("All crew, [current_title] [current_name] has arrived...")
+	to_chat(H, "<span class='notice'><b><font size=2>You are the [current_title], commander of the Dauntless, an Imperial corvette exploratory vessel. Tasked with navigating the uncharted terror -- the Ghoul Stars, you lead a diverse retinue representing many factions, each serving a crucial role aboard your ship. While you hold ultimate authority, you work closely with your Magos Explorator, whose resources and personnel are vital to your survival in this cursed region. Rely on your officers to manage the deck scum, explore forgotten worlds, and broker alliances or hostilities with the human, alien, and worse. The emperor protects...</font></b></span>")
 	return ..()
 
 /datum/job/seneschal
@@ -121,11 +124,14 @@
 
 /datum/job/seneschal/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
-	if (!selected_title)
-		selected_title = title
-	H.fully_replace_character_name("[selected_title] [current_name]")
-	to_chat(H, "<span class='notice'><b><font size=2>You are the [selected_title], the trusted advisor and chief administrator aboard the Dauntless. Your duties involve managing the vast wealth, resources, and trade networks of the Rogue Trader, ensuring colonies, contracts, and logistics run smoothly. You oversee the ship’s operations, handling everything from diplomacy to the darker dealings of the trade empire. While the Rogue Trader focuses on larger ventures, you maintain the foundations that keep the dynasty profitable and in control.</font></b></span>")
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
+	H.fully_replace_character_name("[current_title] [current_name]")
+	to_chat(H, "<span class='notice'><b><font size=2>You are the [current_title], the trusted advisor and chief administrator aboard the Dauntless. Your duties involve managing the vast wealth, resources, and trade networks of the Rogue Trader, ensuring colonies, contracts, and logistics run smoothly. You oversee the ship’s operations, handling everything from diplomacy to the darker dealings of the trade empire. While the Rogue Trader focuses on larger ventures, you maintain the foundations that keep the dynasty profitable and in control.</font></b></span>")
 	return ..()
 
 /datum/job/mercenary
@@ -212,6 +218,54 @@
 /datum/job/rd/get_description_blurb()
 	return "You are the Chief Science Officer. You are responsible for the research department. You handle the science aspects of the project and liase with the imperial interests of the Explorator Organisation. Make sure science gets done, do some yourself, and get your scientists on away missions to find things to benefit the project. Advise the CO on science matters."
 
+/datum/job/void_officer
+	title = "Void Officer"
+	department = "Support"
+	department_flag = SPT
+	total_positions = 3
+	spawn_positions = 3
+	supervisors = "the Commanding Officer and heads of staff"
+	selection_color = "#2f2f7f"
+	minimal_player_age = 0
+	economic_power = 8
+	minimum_character_age = list(SPECIES_HUMAN = 22)
+	ideal_character_age = 24
+	outfit_type = /singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer
+	allowed_branches = list(
+		/datum/mil_branch/civilian
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/civ
+	)
+	skill_points = 26
+	min_skill = list( // 5 points
+		SKILL_BUREAUCRACY = SKILL_BASIC, // 1 point
+		SKILL_PILOT = SKILL_TRAINED // 4 points
+	)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
+
+
+	access = list(
+		access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
+		access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
+		access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
+		access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter,
+		access_torch_fax, access_torch_helm, access_radio_comm, access_radio_eng, access_radio_exp, access_radio_serv, access_radio_sci, access_radio_sup
+	)
+
+	software_on_spawn = list(/datum/computer_file/program/comm,
+							 /datum/computer_file/program/suit_sensors,
+							 /datum/computer_file/program/power_monitor,
+							 /datum/computer_file/program/supermatter_monitor,
+							 /datum/computer_file/program/alarm_monitor,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/shields_monitor,
+							 /datum/computer_file/program/reports,
+							 /datum/computer_file/program/deck_management)
+
+/datum/job/void_officer/get_description_blurb()
+	return "You are a . You are a very junior officer. You do not give orders of your own. You are subordinate to all of command. You handle matters on the bridge and report directly to the CO and XO. You take The Dauntless's helm and pilot the Aquila if needed. You monitor bridge cogitator programs and communications and report relevant information to command."
 
 /datum/job/sea
 	title = "Senior Enlisted Advisor"
@@ -261,52 +315,3 @@
 
 /datum/job/sea/get_description_blurb()
 	return "You are the Senior Enlisted Advisor. You are the highest enlisted person on the ship. You are directly subordinate to the CO. You advise them on enlisted concerns and provide expertise and advice to officers. You are responsible for ensuring discipline and good conduct among enlisted, as well as notifying officers of any issues and \"advising\" them on mistakes they make. You also handle various duties on behalf of the CO and XO. You are an experienced enlisted person, very likely equal only in experience to the CO and XO. You know the regulations better than anyone."
-
-/datum/job/void_officer
-	title = "Bridge Officer"
-	department = "Support"
-	department_flag = SPT
-	total_positions = 3
-	spawn_positions = 3
-	supervisors = "the Commanding Officer and heads of staff"
-	selection_color = "#2f2f7f"
-	minimal_player_age = 0
-	economic_power = 8
-	minimum_character_age = list(SPECIES_HUMAN = 22)
-	ideal_character_age = 24
-	outfit_type = /singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer
-	allowed_branches = list(
-		/datum/mil_branch/civilian
-	)
-	allowed_ranks = list(
-		/datum/mil_rank/civ/civ
-	)
-	skill_points = 26
-	min_skill = list( // 5 points
-		SKILL_BUREAUCRACY = SKILL_BASIC, // 1 point
-		SKILL_PILOT = SKILL_TRAINED // 4 points
-	)
-
-	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
-
-
-	access = list(
-		access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
-		access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
-		access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
-		access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter,
-		access_torch_fax, access_torch_helm, access_radio_comm, access_radio_eng, access_radio_exp, access_radio_serv, access_radio_sci, access_radio_sup
-	)
-
-	software_on_spawn = list(/datum/computer_file/program/comm,
-							 /datum/computer_file/program/suit_sensors,
-							 /datum/computer_file/program/power_monitor,
-							 /datum/computer_file/program/supermatter_monitor,
-							 /datum/computer_file/program/alarm_monitor,
-							 /datum/computer_file/program/camera_monitor,
-							 /datum/computer_file/program/shields_monitor,
-							 /datum/computer_file/program/reports,
-							 /datum/computer_file/program/deck_management)
-
-/datum/job/void_officer/get_description_blurb()
-	return "You are a Bridge Officer. You are a very junior officer. You do not give orders of your own. You are subordinate to all of command. You handle matters on the bridge and report directly to the CO and XO. You take The Dauntless's helm and pilot the Aquila if needed. You monitor bridge cogitator programs and communications and report relevant information to command."

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -75,10 +75,15 @@
 
 /datum/job/magos_explorator/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
 	H.fully_replace_character_name("Magos Explorator [current_name]")
 	H.say(":e Memory cache integrity at 87%... Motive force appeased. Security apparatis functional. Non organics uncorrupted.")
-	to_chat(H, "<span class='notice'><b><font size=2>As the [selected_title], you manage the technology and exploration efforts aboard The Dauntless, working in partnership with the Rogue Trader. Your duties are divided between maintaining the sacred machinery of the ship and pursuing the discovery of lost knowledge and power across the stars. Overseeing tech-priests, bondsmen, menials, slaves, and Skitarii, you ensure their work serves the dual purpose of keeping the ship operational and advancing the Mechanicum’s quest for knowledge, all while respecting the Rogue Trader’s command.</font></b></span>")
+	to_chat(H, "<span class='notice'><b><font size=2>As the [current_title], you manage the technology and exploration efforts aboard The Dauntless, working in partnership with the Rogue Trader. Your duties are divided between maintaining the sacred machinery of the ship and pursuing the discovery of lost knowledge and power across the stars. Overseeing tech-priests, bondsmen, menials, slaves, and Skitarii, you ensure their work serves the dual purpose of keeping the ship operational and advancing the Mechanicum’s quest for knowledge, all while respecting the Rogue Trader’s command.</font></b></span>")
 	return ..()
 
 /datum/job/magos_explorator/get_description_blurb()
@@ -161,10 +166,13 @@
 
 /datum/job/data_smith/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
-	if (!selected_title)
-		selected_title = title
-	H.fully_replace_character_name("[selected_title] [current_name]")
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
+	H.fully_replace_character_name("[current_title] [current_name]")
 	H.say(":e OMVISS1@H &(47*TECHNICA)B(ADMECH)... transponder signal active.")
 	to_chat(H, "<span class='notice'><b><font size=2>As a member of the mechanicus aboard The Dauntless, your role centers on the pursuit of knowledge and the preservation of ancient technologies. Focused on research and data analysis, you delve into the mysteries of the machine, whether through the study of archives, the recovery of lost information, or the understanding of sacred technology. Overseeing tech-acolytes and other personnel, your purpose is to advance the Mechanicus' quest for knowledge while safeguarding the ship's technological sanctity.</font></b></span>")
 	return ..()
@@ -233,10 +241,13 @@
 
 /datum/job/tech_priest/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
-	if (!selected_title)
-		selected_title = title
-	H.fully_replace_character_name("[selected_title] [current_name]")
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
+	H.fully_replace_character_name("[current_title] [current_name]")
 	H.say(":e OMVISS1@H &(47*TECHNICA)B(ADMECH)... transponder signal active.")
 	to_chat(H, "<span class='notice'><b><font size=2>As a member of the Mechanicus aboard The Dauntless, your role is dedicated to maintaining the sacred machinery that keeps the ship operational. Focused on engineering, repairs, and the appeasement of machine spirits, you oversee the function of essential systems. Whether guiding tech-acolytes or directly addressing mechanical issues, your purpose is to ensure the smooth operation of the ship’s technology, preserving its sanctity and efficiency for the Omnissiah.</font></b></span>")
 	return ..()
@@ -305,12 +316,15 @@
 
 /datum/job/bondsman/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
-	if (!selected_title)
-		selected_title = title
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
 	H.fully_replace_character_name("[current_name]")
 	H.say(":e OMVISS1@H &(47*INDENTURED)B(X1HK)... transponder signal active.")
-	to_chat(H, "<span class='notice'><b><font size=2>You are a [selected_title] under the service of the Mechanicus aboard the Rogue Trader’s vessel, lifebonded to the Magos Explorator and likely a descendant of gang-pressed families taken from their homeworlds. Tasked with menial yet vital technical work, your duties include maintaining ship systems, assisting with resource extraction, and performing hazardous tasks in the ship's more dangerous zones.</font></b></span>")
+	to_chat(H, "<span class='notice'><b><font size=2>You are a [current_title] under the service of the Mechanicus aboard the Rogue Trader’s vessel, lifebonded to the Magos Explorator and likely a descendant of gang-pressed families taken from their homeworlds. Tasked with menial yet vital technical work, your duties include maintaining ship systems, assisting with resource extraction, and performing hazardous tasks in the ship's more dangerous zones.</font></b></span>")
 	return ..()
 
 /datum/job/roboticist

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -64,10 +64,15 @@
 
 /datum/job/data_smith/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
 	H.fully_replace_character_name("Magos Biologis [current_name]")
 	H.say(":e OMVISS1@H &(47*TECHNICA)B(ADMECH)... transponder signal active.")
-	to_chat(H, "<span class='notice'><b><font size=2>As the [selected_title], you are part of the Rogue Trader's retinue, operating beyond the constraints of the Mechanicus. You manage the biological research and medical efforts aboard the vessel, overseeing Skitarii and Medicae personnel alike. Your duty is to ensure your medicae staff are prepared for surgery, treatment, and field response, and that every biological specimen or anomaly is studied with ruthless efficiency. You are expected to lead in matters of biology and medicine, stepping in as surgeon or advisor when necessary, always furthering the quest for knowledge and mastery over the flesh.</font></b></span>")
+	to_chat(H, "<span class='notice'><b><font size=2>As the [current_title], you are part of the Rogue Trader's retinue, operating beyond the constraints of the Mechanicus. You manage the biological research and medical efforts aboard the vessel, overseeing Skitarii and Medicae personnel alike. Your duty is to ensure your medicae staff are prepared for surgery, treatment, and field response, and that every biological specimen or anomaly is studied with ruthless efficiency. You are expected to lead in matters of biology and medicine, stepping in as surgeon or advisor when necessary, always furthering the quest for knowledge and mastery over the flesh.</font></b></span>")
 	return ..()
 
 /datum/job/sister_hospitaller
@@ -121,11 +126,14 @@
 
 /datum/job/sister_hospitaller/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
-	if (!selected_title)
-		selected_title = title
-	H.fully_replace_character_name("[selected_title] [current_name]")
-	to_chat(H, "<span class='notice'><b><font size=2>As the [selected_title], you are responsible for overseeing the health and medical training of the crew. A guiding hand for novitiates, you impart the knowledge and faith required to heal both body and soul, embodying the sacred duty of the Orders Hospitaller. Your care extends beyond the physical, offering spiritual solace to those in need, ensuring that the crew remains steadfast in both their service and devotion.</font></b></span>")
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
+	H.fully_replace_character_name("[current_title] [current_name]")
+	to_chat(H, "<span class='notice'><b><font size=2>As the [current_title], you are responsible for overseeing the health and medical training of the crew. A guiding hand for novitiates, you impart the knowledge and faith required to heal both body and soul, embodying the sacred duty of the Orders Hospitaller. Your care extends beyond the physical, offering spiritual solace to those in need, ensuring that the crew remains steadfast in both their service and devotion.</font></b></span>")
 	return ..()
 
 /datum/job/pharmacologis
@@ -171,11 +179,14 @@
 
 /datum/job/pharmacologis/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
-	if (!selected_title)
-		selected_title = title
-	H.fully_replace_character_name("[selected_title] [current_name]")
-	to_chat(H, "<span class='notice'><b><font size=2>As the [selected_title], you serve alongside the Medicae and Sister Hospitaller, wielding your knowledge of chemistry and biological science to support their sacred work. You are responsible for the formulation of complex medicines, compounds, and stimulants, as well as assisting in advanced surgical procedures when required. Though you are not tasked with direct patient care, your role is critical—ensuring the crew can fight, endure, and survive in the Emperor’s name. Your work stands at the intersection of science and duty, safeguarding the vitality of those who serve the Imperium.</font></b></span>")
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
+	H.fully_replace_character_name("[current_title] [current_name]")
+	to_chat(H, "<span class='notice'><b><font size=2>As the [current_title], you serve alongside the Medicae and Sister Hospitaller, wielding your knowledge of chemistry and biological science to support their sacred work. You are responsible for the formulation of complex medicines, compounds, and stimulants, as well as assisting in advanced surgical procedures when required. Though you are not tasked with direct patient care, your role is critical—ensuring the crew can fight, endure, and survive in the Emperor’s name. Your work stands at the intersection of science and duty, safeguarding the vitality of those who serve the Imperium.</font></b></span>")
 	return ..()
 
 /datum/job/medicae
@@ -225,11 +236,14 @@
 
 /datum/job/medicae/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
-	if (!selected_title)
-		selected_title = title
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
 	H.fully_replace_character_name("[current_name]")
-	to_chat(H, "<span class='notice'><b><font size=2>You are a [selected_title] aboard the Rogue Trader’s vessel, trained to deal with the harsh and unforgiving conditions of both space and hive cities. Your responsibilities include treating battlefield injuries, performing surgeries, and managing the health of the crew. Whether responding to emergencies or ensuring long-term health, your experience in crowded, under-equipped environments has honed your ability to handle crises with efficiency and precision, making you indispensable in the chaos of the void.</font></b></span>")
+	to_chat(H, "<span class='notice'><b><font size=2>You are a [current_title] aboard the Rogue Trader’s vessel, trained to deal with the harsh and unforgiving conditions of both space and hive cities. Your responsibilities include treating battlefield injuries, performing surgeries, and managing the health of the crew. Whether responding to emergencies or ensuring long-term health, your experience in crowded, under-equipped environments has honed your ability to handle crises with efficiency and precision, making you indispensable in the chaos of the void.</font></b></span>")
 	return ..()
 
 /datum/job/novitiate
@@ -278,11 +292,14 @@
 
 /datum/job/novitiate/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
-	if (!selected_title)
-		selected_title = title
-	H.fully_replace_character_name("[selected_title] [current_name]")
-	to_chat(H, "<span class='notice'><b><font size=2>As a [selected_title] aboard the vessel, you are in the early stages of rigorous training under the Sister Hospitaller and Chaplain Militant. Your education spans both spiritual teachings and practical disciplines, preparing you for a future role within the Imperium.</font></b></span>")
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
+	H.fully_replace_character_name("[current_title] [current_name]")
+	to_chat(H, "<span class='notice'><b><font size=2>As a [current_title] aboard the vessel, you are in the early stages of rigorous training under the Sister Hospitaller and Chaplain Militant. Your education spans both spiritual teachings and practical disciplines, preparing you for a future role within the Imperium.</font></b></span>")
 	return ..()
 
 

--- a/maps/torch/job/outfits/command_outfits.dm
+++ b/maps/torch/job/outfits/command_outfits.dm
@@ -93,8 +93,8 @@
 	gloves = /obj/item/clothing/gloves/thick/swat/cadian
 	id_types = list(/obj/item/card/id/torch/silver/security)
 	pda_type = /obj/item/modular_computer/pda/heads/hos
-	back = /obj/item/storage/backpack/satchel/warfare/heavy
-	backpack_contents = list(/obj/item/pen = 1, /obj/item/cell/device/high/mechanicus = 1, /obj/item/cell/device/high/laspack = 1, /obj/item/device/flashlight/flare = 1)
+	back = /obj/item/storage/backpack/satchel/warfare
+	backpack_contents = list(/obj/item/pen = 1, /obj/item/material/twohanded/ravenor/knife/trench = 1, /obj/item/cell/device/high/mechanicus = 1, /obj/item/cell/device/high/laspack = 1, /obj/item/device/flashlight/flare = 1)
 
 /singleton/hierarchy/outfit/job/torch/crew/command/valhallan_captain
 	name = OUTFIT_JOB_NAME("Valhallan Captain")
@@ -102,45 +102,80 @@
 	mask = /obj/item/clothing/mask/gas/explorer
 	glasses = /obj/item/clothing/glasses/cadiangoggles/elite
 	belt = /obj/item/storage/belt/holster/security
-	suit = /obj/item/clothing/suit/armor/grim/valhallan/captain
+	suit = /obj/item/clothing/suit/armor/grim/valhallan/officer
 	shoes = /obj/item/clothing/shoes/jackboots/cadian
 	uniform = /obj/item/clothing/under/cadian_uniform
 	r_pocket = null
 	l_ear = /obj/item/device/radio/headset/heads/cos
 	l_hand = /obj/item/gun/projectile/automatic/boltrifle/lockebolter/drusian
-	r_hand = /obj/item/gun/projectile/revolver/imperial/heavy
+	r_hand = /obj/item/gun/projectile/revolver/imperial/heavy/mateba
 	gloves = /obj/item/clothing/gloves/thick/swat/cadian
 	id_types = list(/obj/item/card/id/torch/silver/security)
 	pda_type = /obj/item/modular_computer/pda/heads/hos
 	back = /obj/item/storage/backpack/satchel/warfare/heavy
-	backpack_contents = list(/obj/item/pen = 1, /obj/item/ammo_magazine/bolt_rifle_magazine = 1, /obj/item/ammo_magazine/speedloader/revolver = 2, /obj/item/device/flashlight/flare = 1)
+	backpack_contents = list(/obj/item/pen = 1, /obj/item/material/twohanded/ravenor/knife/trench = 1, /obj/item/ammo_magazine/bolt_rifle_magazine = 1, /obj/item/ammo_magazine/speedloader/revolver = 2, /obj/item/device/flashlight/flare = 1)
+
+/singleton/hierarchy/outfit/job/torch/crew/command/krieg_captain
+	name = OUTFIT_JOB_NAME("Krieg Captain")
+	head = /obj/item/clothing/head/helmet/flak/krieg/officer
+	mask = /obj/item/clothing/mask/gas/krieg
+	glasses = /obj/item/clothing/glasses/night
+	belt = /obj/item/storage/belt/holster/security
+	suit = /obj/item/clothing/suit/armor/grim/krieger/officer
+	shoes = /obj/item/clothing/shoes/jackboots/cadian
+	uniform = /obj/item/clothing/under/cadian_uniform
+	r_pocket = null
+	l_ear = /obj/item/device/radio/headset/heads/cos
+	l_hand = /obj/item/gun/energy/lasgun/hotshot/krieg
+	r_hand = /obj/item/gun/energy/lasgun/laspistol/lucius
+	gloves = /obj/item/clothing/gloves/thick/swat/cadian
+	id_types = list(/obj/item/card/id/torch/silver/security)
+	pda_type = /obj/item/modular_computer/pda/heads/hos
+	back = /obj/item/storage/backpack/satchel/krieger
+	backpack_contents = list(/obj/item/shovel/krieg = 1, /obj/item/material/twohanded/ravenor/knife/trench = 1, /obj/item/cell/device/high/laspack/hotshot = 2)
+
 
 /singleton/hierarchy/outfit/job/torch/crew/command/catachan_sergeant
 	name = OUTFIT_JOB_NAME("Catachan Sergeant")
+	head = /obj/item/clothing/head/helmet/guardcap/catachan
+	mask = /obj/item/clothing/mask/gas/explorer
+	glasses = /obj/item/clothing/glasses/night/aviators/catachan // They can see mobs through walls...
+	belt = /obj/item/material/twohanded/ravenor/knife/catachan
+	suit = /obj/item/clothing/suit/armor/grim/catachan/sergeant
+	shoes = /obj/item/clothing/shoes/jackboots/cadian
+	uniform = /obj/item/clothing/under/cadian_uniform
+	r_pocket = null
 	l_ear = /obj/item/device/radio/headset/heads/cos
-	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/security
-	shoes = /obj/item/clothing/shoes/dutyboots
+	l_hand = /obj/item/gun/projectile/pistol/bolt_pistol/drusian
+	r_hand = /obj/item/gun/energy/lasgun/catachan
+	gloves = /obj/item/clothing/gloves/thick/swat/cadian
 	id_types = list(/obj/item/card/id/torch/silver/security)
 	pda_type = /obj/item/modular_computer/pda/heads/hos
+	back = /obj/item/storage/backpack/satchel/warfare
+	backpack_contents = list(/obj/item/pen = 1, /obj/item/ammo_magazine/bolt_pistol_magazine/ms = 2, /obj/item/cell/device/high/laspack = 1, /obj/item/device/flashlight/flare = 2)
+
 
 /singleton/hierarchy/outfit/job/torch/crew/command/maccabian_captain
 	name = OUTFIT_JOB_NAME("Maccabian Sergeant")
+	head = /obj/item/clothing/head/helmet/flak/maccabian/sergeant
+	mask = /obj/item/clothing/mask/gas/maccabian/sergeant
+	glasses = /obj/item/clothing/glasses/scion // Can see mobs through walls.
+	belt = /obj/item/material/twohanded/ravenor/sword/cutro/adamantine
+	suit = /obj/item/clothing/suit/armor/grim/maccabian/sergeant
+	shoes = /obj/item/clothing/shoes/jackboots/maccabian
+	uniform = /obj/item/clothing/under/rank/maccabian/sergeant
+	r_pocket = null
 	l_ear = /obj/item/device/radio/headset/heads/cos
-	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/security
-	shoes = /obj/item/clothing/shoes/dutyboots
+	l_hand = /obj/item/gun/projectile/pistol/slug/shotgun // shotgun pistol
+	r_hand = /obj/item/gun/projectile/automatic/slugrifle
+	gloves = /obj/item/clothing/gloves/thick/swat/cadian
 	id_types = list(/obj/item/card/id/torch/silver/security)
 	pda_type = /obj/item/modular_computer/pda/heads/hos
-
-/singleton/hierarchy/outfit/job/torch/crew/command/mordian_captain
-	name = OUTFIT_JOB_NAME("Mordian Captain")
-	l_ear = /obj/item/device/radio/headset/heads/cos
-	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/security
-	shoes = /obj/item/clothing/shoes/dutyboots
-	id_types = list(/obj/item/card/id/torch/silver/security)
-	pda_type = /obj/item/modular_computer/pda/heads/hos
+	back = /obj/item/storage/backpack/satchel/maccabian
+	backpack_contents = list(/obj/item/pen = 1, /obj/item/material/twohanded/ravenor/knife/glaive = 1, /obj/item/ammo_magazine/shotholder/flechette = 1, /obj/item/ammo_magazine/heavy = 2)
 
 /singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer
-	name = OUTFIT_JOB_NAME("Bridge Officer")
+	name = OUTFIT_JOB_NAME("Void Officer")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/command
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_types = list(/obj/item/card/id/torch/crew/bridgeofficer)
@@ -170,7 +205,7 @@
 
 
 /singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer/fleet
-	name = OUTFIT_JOB_NAME("Bridge Officer - Fleet")
+	name = OUTFIT_JOB_NAME(" - Fleet")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/command
 	shoes = /obj/item/clothing/shoes/dutyboots
 

--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -3,19 +3,18 @@
 	supervisors = "the Commanding Officer and the Executive Officer"
 	economic_power = 10
 	minimal_player_age = 14
-	department = "Command"
-	department_flag = COM
+	department = "Security"
+	department_flag = SEC
 	minimum_character_age = list(SPECIES_HUMAN = 25)
 	ideal_character_age = 35
 	outfit_type = /singleton/hierarchy/outfit/job/torch/crew/command/cadian_captain
 	total_positions = 1
 	spawn_positions = 1
 	alt_titles = list(
-		"Krieg Captain",
-		"Valhallan Captain",
-		"Catachan Sergeant ", // Catachan's aren't cool if they're officers.
-		"Maccabian Sergeant",
-		"Mordian Captain"
+		"Krieg Captain" = /singleton/hierarchy/outfit/job/torch/crew/command/krieg_captain,
+		"Valhallan Captain" = /singleton/hierarchy/outfit/job/torch/crew/command/valhallan_captain,
+		"Catachan Sergeant " = /singleton/hierarchy/outfit/job/torch/crew/command/catachan_sergeant, // Catachan's aren't cool if they're officers.
+		"Maccabian Sergeant" = /singleton/hierarchy/outfit/job/torch/crew/command/maccabian_captain,
 	)
 	allowed_branches = list(
 		/datum/mil_branch/civilian
@@ -23,17 +22,15 @@
 	allowed_ranks = list(
 		/datum/mil_rank/civ/civ
 	)
-	skill_points = 34
-	min_skill = list(
-		SKILL_VIGOR = SKILL_EXPERIENCED,
-		SKILL_MEDICAL = SKILL_TRAINED,
-		SKILL_DEVICES = SKILL_BASIC,
-		SKILL_COMBAT = SKILL_EXPERIENCED,
-		SKILL_GUNS = SKILL_EXPERIENCED,
-		SKILL_MECH = SKILL_TRAINED,
-		SKILL_EVA = SKILL_TRAINED
-	)
-
+	skill_points = 9
+	min_skill = list(SKILL_VIGOR = SKILL_EXPERIENCED,
+					SKILL_MEDICAL = SKILL_TRAINED,
+					SKILL_DEVICES = SKILL_BASIC,
+					SKILL_COMBAT = SKILL_EXPERIENCED,
+					SKILL_GUNS = SKILL_EXPERIENCED,
+					SKILL_MECH = SKILL_TRAINED,
+					SKILL_EVA = SKILL_TRAINED
+				)
 	max_skill = list(	SKILL_VIGOR = SKILL_MASTER,
 						SKILL_GUNS = SKILL_PRIMARIS,
 						SKILL_COMBAT = SKILL_LEGEND)
@@ -57,24 +54,61 @@
 
 /datum/job/guard_captain/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
-	var/selected_title = alt_titles[H.mind.role_alt_title]
-	switch(title) //DO NOT TOUCH THIS, IT PROBABLY WORKS
-		if("Cadian Captain" || "Valhallan Captain" || "Catachan Sergeant" || "Krieg Captain" || "Maccabian Sergeant" || "Mordian Captain")
-			if(title == "Catachan Sergeant")
-				H.fully_replace_character_name("Sergeant [current_name]")
-			if(title == "Cadian Captain")
-				H.fully_replace_character_name("Captain [current_name]")
-			if(title == "Maccabian Sergeant")
-				H.fully_replace_character_name("Sergeant [current_name]")
-			if(title == "Krieg Captain")
-				H.fully_replace_character_name("Captain [current_name]")
-			if(title == "Valhallan Captain")
-				H.fully_replace_character_name("Captain [current_name]")
-			if(title == "Mordian Captain")
-				H.fully_replace_character_name("Captain [current_name]")
-	to_chat(H, "<span class='notice'><b><font size=2>As the [selected_title], you command the ship's security forces, leading personnel in maintaining order and protecting the vessel. You oversee security training, manage defensive operations, and embark on critical missions alongside the Deck Sergeant and Seneschal. Your leadership keeps the crew ready for any threat, aboard the ship or beyond.</font></b></span>")
+	var/current_title = trimtext(H.mind.role_alt_title)
+	H.voice_in_head(pick(GLOB.lone_thoughts))
+	H.species.unarmed_types = list(
+		/datum/unarmed_attack/stomp/strong,
+		/datum/unarmed_attack/kick/strong,
+		/datum/unarmed_attack/punch/strong,
+		/datum/unarmed_attack/bite/sharp/strong
+	)
+	if(current_title && (H.mind.role_alt_title in alt_titles))
+		current_title = trimtext(H.mind.role_alt_title) // Use alt_title if selected
+	else
+		current_title = title // use default title
+	if(current_title == "Cadian Captain" || current_title == "Valhallan Captain" || current_title == "Catachan Sergeant" || current_title == "Krieg Captain" || current_title == "Maccabian Sergeant")
+		if(current_title == "Catachan Sergeant")
+			H.fully_replace_character_name("Sergeant [current_name]")
+			H.species.brute_mod = 0.64
+			H.species.weaken_mod = 0.77
+			H.species.stun_mod = 0.77
+			H.species.burn_mod = 0.68
+			H.species.toxins_mod = 0.7
+			H.species.hunger_factor = DEFAULT_HUNGER_FACTOR * 1.5
+			H.species.species_flags = SPECIES_FLAG_LOW_GRAV_ADAPTED
+		else if(current_title == "Cadian Captain")
+			H.fully_replace_character_name("Captain [current_name]")
+			H.species.brute_mod = 0.67
+			H.species.weaken_mod = 0.71
+			H.species.stun_mod = 0.71
+			H.species.slowdown = -0.5
+		else if(current_title == "Maccabian Sergeant")
+			H.fully_replace_character_name("Sergeant [current_name]")
+			H.species.weaken_mod = 0.73
+			H.species.stun_mod = 0.73
+			H.species.slowdown = -0.3
+		else if(current_title == "Krieg Captain")
+			H.fully_replace_character_name("Captain [current_name]")
+			H.species.toxins_mod = 0.65
+			H.species.radiation_mod = 0.45
+			H.species.darksight_range = 4
+			H.species.hunger_factor = DEFAULT_HUNGER_FACTOR * 0.75
+			H.species.species_flags = SPECIES_FLAG_NO_PAIN
+		else if(current_title == "Valhallan Captain")
+			H.fully_replace_character_name("Captain [current_name]")
+			H.species.stun_mod = 0.8
+			H.species.weaken_mod = 0.73 // Ice-worlders got that whim hoff circulatory / nervous system control. Resist stuns and thermal damage.
+			H.species.paralysis_mod = 0.73
+			H.species.cold_level_1 = 180 // Amazing at cold. Terrible with heat.
+			H.species.cold_level_2 = 100
+			H.species.cold_level_3 = 20
+			H.species.heat_level_1 = 330
+			H.species.heat_level_2 = 360
+			H.species.heat_level_3 = 800
+	to_chat(H, "<span class='notice'><b><font size=2>As the [current_title], you command the ship's security forces, leading personnel in maintaining order and protecting the vessel. You oversee security training, manage defensive operations, and embark on critical missions alongside the Deck Sergeant and Seneschal. Your leadership keeps the crew ready for any threat, aboard the ship or beyond.</font></b></span>")
 	to_chat(H, "<span class='notice'><b><font size=2>   The Astra Militarum, also known as the Imperial Guard in colloquial Low Gothic, is the largest coherent fighting force in the galaxy. They serve as the Imperium of Man's primary combat force and first line of defence from the myriad threats which endanger the existence of the Human race in the 41st Millennium. </font></b></span>")
 	return ..()
+
 
 
 /datum/job/enforcer_sergeant
@@ -197,3 +231,21 @@
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/camera_monitor)
+
+/mob/proc/voice_in_head(message)
+	to_chat(src, "<i>...[message]</i>")
+
+GLOBAL_LIST_INIT(lone_thoughts, list(
+		"Subdue the regret. Dust yourself off. Proceed. You'll get it in the next life. Do what you can with this one.",
+		"You do have something better to do. Stay strong. You don't need to keep doing this to yourself.",
+		"This is somewhere to be. This is all you have, but it's still something. Streets and sodium lights. The sky, the world. You're still alive.",
+		"The road to healing will be a long one. Stay the course. You will make it. Someday.",
+		"Just remember that you've made it this far. And it's just a bit farther now. Let's finish this.",
+		"Your heart is broken, bratushka. And it cannot be mended. Believe me, I've tried.",
+		"A hug a day keeps the bourgeoisie away.",
+		"Your mangled brain would like you to know there is a boxer called Contact Mike.",
+		"A tremendous loneliness comes over you. Everybody in the world is doing something without you.",
+		"All the gifts your parents gave you, all the love and patience of your friends, you drowned in a neurotoxin. You let misery win. And it will keep on winning till you die -- or overcome it.",
+		"You are a violent and irrepressible miracle. The vacuum of cosmos and the stars burning in it are afraid of you. Given enough time you would wipe us all out and replace us with nothing -- just by accident.",
+		"There is a giant ball there. And evil apes. And the evil apes are dukin' it out on the ball. You're one of them. It's basically all just evil apes dukin' it out on a giant ball.",
+		"I hope the Inquisitor doesn't find my Eldar Mommy fan-fiction",))


### PR DESCRIPTION
Fixed autogun_tech code define messing up guns.

Fixed typo on cutro adamantine.

Edited damage modifiers for many species, generally lowering them, esp for radiation.

Added more job-gear, helmets, backpacks, etc.

Lowered unarmed attack damage, also added a new /strong variant of all unarmed's for powerful characters like Militarum/Enforcers.

Edited living defense to incorporate some RNG into armor calculations. Ranging from 70-110 percent of the original armor value when calculating each time you are hit. Also raised full block to +15 instead of +10 so pistols don't deal 0 damage to carapace.

Changed the penetration_modifier var to rupture_artery since it was confusing people on what it actually did.

Fixed some burst issues with laspistols.

Fixed the shotgun revolver and made it a shotgun pistol revolver. Uses a magazine.

Raised armor pen on most projectiles, found their AP was too low to meet most armors effectively.

Added more job code to existing jobs, the only fully completed one is Militarum Officer, which edits the species code on equip to give unique traits depending on what world you came from.

Removed airlock scream from being crushed. Now when you crushed nobody will hear anything except a crunch.