### PR TITLE
RogueTrader - V1.0.10.7 - Misc

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -193,7 +193,7 @@ var/global/list/possible_genestealer_IDs = list("Alpha","Beta","Gamma","Delta","
 				src.visible_message(SPAN_DANGER("[src] stabs [T] with the proboscis!"))
 				to_chat(T, SPAN_DANGER("You feel a sharp stabbing pain!"))
 				affecting.take_external_damage(39, 0, DAMAGE_FLAG_SHARP, "large organic needle")
-		if(!do_after(src, 15 SECONDS, T, DO_PUBLIC_UNIQUE))
+		if(!do_after(src, 10 SECONDS, T, DO_PUBLIC_UNIQUE))
 			to_chat(src, SPAN_WARNING("Our absorption of [T] has been interrupted!"))
 			genestealer.isabsorbing = 0
 			return

--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -1,5 +1,5 @@
 /obj/machinery/bluespacedrive
-	name = "bluespace drive"
+	name = "archeotech warp engine"
 	desc = "The Naophoros-pattern jump drive is a machine created by ancient xenos, mated with countless human devices and apparatuses to make it able to interface with the vastly different technology used in their ships."
 	icon = 'icons/obj/machines/bluespacedrive.dmi'
 	icon_state = "bsd_core"

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -26,8 +26,6 @@
 	var/check_synth = 0 	//if active, will shoot at anything not an AI or cyborg
 	var/ailock = 0 	//Silicons cannot use this
 
-	req_access = list(access_mechanicus)
-
 /obj/machinery/turretid/stun
 	enabled = 1
 	icon_state = "control_stun"

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -225,3 +225,31 @@
 /obj/item/trash/usedplatter
 	name = "dirty platter"
 	icon_state = "usedplatter"
+
+
+/obj/item/trash/warfare_can
+	icon = 'icons/obj/food.dmi'
+	name = "used can"
+	icon_state = "cbeans_empty"
+	var/drop_sound = 'sound/items/handle/can_drop.ogg'
+
+/obj/item/trash/warfare_can/throw_impact(atom/hit_atom)
+	..()
+	if(drop_sound)
+		playsound(src, drop_sound, 50, 0)
+
+/obj/item/trash/warfare_can/flower
+	icon_state = "flowersgrub_empty"
+
+/obj/item/trash/warfare_can/sardine
+	icon_state = "pisssardine_empty"
+
+/obj/item/trash/warfare_can/rat
+	icon_state = "ratmeat_empty"
+
+/obj/item/trash/warfare_can/nim
+	icon_state = "nim_empty"
+
+/obj/item/trash/corpsestarch
+	name = "protein bar"
+	icon_state = "proteinbar"

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -1,7 +1,6 @@
 /obj/structure/closet/secure_closet/guncabinet
 	name = "gun cabinet"
-	req_access = list(access_restricted_command)
-	icon = 'icons/obj/structures/guncabinet.dmi'
+	icon = 'icons/obj/structures/guncabinet.dmi' // 'icons/map_project/gunrack.dmi' do later
 	closet_appearance = null
 
 /obj/structure/closet/secure_closet/guncabinet/Initialize()

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -1,34 +1,38 @@
-/obj/structure/closet/secure_closet/personal
+/obj/structure/closet/warhammer/secure_closet/personal
 	name = "personal closet"
 	desc = "It's a secure locker for personnel."
+	icon = 'icons/map_project/furniture_and_decor.dmi'
+	icon_state = "metal_locker_closed"
+	icon_opened = "metal_locker_open"
+	icon_closed = "metal_locker_closed"
 	req_access = list(access_restricted_command)
 	locked = FALSE
 	var/registered_name = null
 
-/obj/structure/closet/secure_closet/personal/WillContain()
+/obj/structure/closet/warhammer/secure_closet/personal/WillContain()
 	return list(
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel/grey)),
 		/obj/item/device/radio/headset
 	)
 
-/obj/structure/closet/secure_closet/personal/empty/WillContain()
+/obj/structure/closet/warhammer/secure_closet/personal/empty/WillContain()
 	return
 
-/obj/structure/closet/secure_closet/personal/patient
+/obj/structure/closet/warhammer/secure_closet/personal/patient
 	name = "patient's closet"
-/obj/structure/closet/secure_closet/personal/patient/WillContain()
+/obj/structure/closet/warhammer/secure_closet/personal/patient/WillContain()
 	return list(/obj/item/clothing/suit/hospital/blue, /obj/item/clothing/suit/hospital/green, /obj/item/clothing/suit/hospital/pink)
 
-/obj/structure/closet/secure_closet/personal/cabinet
+/obj/structure/closet/warhammer/secure_closet/personal/cabinet
 	closet_appearance = /singleton/closet_appearance/cabinet/secure
 
-/obj/structure/closet/secure_closet/personal/cabinet/WillContain()
+/obj/structure/closet/warhammer/secure_closet/personal/cabinet/WillContain()
 	return list(/obj/item/storage/backpack/satchel/grey/withwallet, /obj/item/device/radio/headset)
 
-/obj/structure/closet/secure_closet/personal/CanToggleLock(mob/user, obj/item/card/id/id_card)
+/obj/structure/closet/warhammer/secure_closet/personal/CanToggleLock(mob/user, obj/item/card/id/id_card)
 	return ..() || (istype(id_card) && id_card.registered_name && (!registered_name || (registered_name == id_card.registered_name)))
 
-/obj/structure/closet/secure_closet/personal/togglelock(mob/user, obj/item/card/id/id_card)
+/obj/structure/closet/warhammer/secure_closet/personal/togglelock(mob/user, obj/item/card/id/id_card)
 	if (..())
 		if(locked)
 			id_card = istype(id_card) ? id_card : user.GetIdCard()
@@ -37,7 +41,7 @@
 		else
 			set_owner(null)
 
-/obj/structure/closet/secure_closet/personal/proc/set_owner(registered_name)
+/obj/structure/closet/warhammer/secure_closet/personal/proc/set_owner(registered_name)
 	if (registered_name)
 		src.registered_name = registered_name
 		src.SetName(name + " ([registered_name])")

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -424,16 +424,22 @@
 	name = "\the rogue throne"
 	desc = "Fit for baron, count, or even duke. Surely fit for your sorry rear end."
 	icon = 'icons/map_project/furniture_and_decor.dmi'
-	base_icon = "throne"
-	icon_state = "throne"
+	base_icon = "cave_throne"
+	icon_state = "cave_throne"
 
-/obj/structure/bed/chair/governor_throne
-	name = "planetary Governor Throne"
+/obj/structure/bed/chair/throne/two
+	name = "imperial throne"
 	desc = "An expensive and serious looking chair to use on an office."
 	base_icon = "comm"
 	icon = 'icons/map_project/furniture_and_decor.dmi'
 	icon_state = "comm"
 
+/obj/structure/bed/chair/throne/three
+	name = "imperial throne"
+	desc = "An expensive and serious looking chair to use on an office."
+	base_icon = "chair"
+	icon = 'icons/map_project/furniture_and_decor.dmi'
+	icon_state = "chair"
 
 /obj/structure/bed/chair/ancient_throne
 	name = "ancient throne"

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -618,6 +618,13 @@
 	icon = 'icons/map_project/furniture_and_decor.dmi'
 	icon_state = "well"
 
+/obj/structure/hygiene/sink/puddle/well
+	name = "fountain water"
+	icon = 'icons/obj/structures/fountain.dmi'
+	icon_state = "water"
+	desc = "Fresh water streams from the fountain. Fresh is debatable."
+	layer = 4
+
 /obj/item/taperoll/bog
 	name = "toilet paper roll"
 	icon = 'icons/obj/bog.dmi'

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -618,7 +618,7 @@
 	icon = 'icons/map_project/furniture_and_decor.dmi'
 	icon_state = "well"
 
-/obj/structure/hygiene/sink/puddle/well
+/obj/structure/hygiene/sink/puddle/fountain
 	name = "fountain water"
 	icon = 'icons/obj/structures/fountain.dmi'
 	icon_state = "water"

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -2,7 +2,7 @@
 #define MIN_FIELD_STR 1
 
 /obj/machinery/power/fusion_core
-	name = "\improper R-UST Mk. 8 Tokamak core"
+	name = "\improper Void Fusion Core"
 	desc = "An enormous solenoid for generating extremely high power electromagnetic fields. It includes a kinetic energy harvester."
 	icon = 'icons/obj/machines/power/fusion_core.dmi'
 	icon_state = "core0"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -119,6 +119,8 @@
 	var/lock_time = -100
 	var/last_safety_check = -INFINITY
 	var/safety_state = 0
+	var/calibrated = 0
+	var/calibration_penalty = 1
 	var/has_safety = TRUE
 	/// Overlay to apply to gun based on safety state, if any.
 	var/safety_icon
@@ -665,6 +667,36 @@
 			to_chat(usr, SPAN_WARNING("You need a gun in your hands to do that."))
 			return
 	gun.toggle_safety(usr)
+
+
+/obj/item/gun/proc/toggle_calib(mob/user)
+	if (user?.is_physically_disabled())
+		to_chat(user, SPAN_WARNING("You can't do this right now!"))
+		return
+
+	if(user)
+		user.visible_message(SPAN_WARNING("[user] finishes calibrating the \the [src]."), SPAN_NOTICE("You calibrate \the [src] it should be more reliable now."), range = 4)
+		calibrated = 1
+		playsound(src, 'sound/weapons/guns/interaction/rifle_boltforward.ogg', 25, 1)
+
+
+/obj/item/gun/verb/toggle_calib_verb()
+	set name = "Calibrate Weapon"
+	set category = "Object"
+	set src in usr
+	if (usr.incapacitated())
+		to_chat(usr, SPAN_WARNING("You're in no condition to do that."))
+		return
+	var/obj/item/gun/gun = usr.get_active_hand()
+	if (!istype(gun))
+		gun = usr.get_inactive_hand()
+		if (!istype(gun))
+			to_chat(usr, SPAN_WARNING("You need a gun in your hands to do that."))
+			return
+	playsound(src, 'sound/weapons/guns/interaction/rifle_load.ogg', 25, 1)
+	if(!do_after(src, 10 SECONDS, DO_PUBLIC_UNIQUE))
+		return
+	gun.toggle_calib(usr)
 
 
 /obj/item/gun/CtrlClick(mob/user)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -24,6 +24,7 @@
 	var/use_external_power = 0 //if set, the weapon will look for an external power source to draw from, otherwise it recharges magically
 	var/recharge_time = 9
 	var/charge_tick = 0
+	calibration_penalty = 3
 
 /obj/item/gun/energy/switch_firemodes()
 	. = ..()
@@ -68,6 +69,11 @@
 	if(!power_supply) return null
 	if(!ispath(projectile_type)) return null
 	if(!power_supply.checked_use(charge_cost)) return null
+	if(calibrated == 0 && prob(calibration_penalty)) // Check if uncalibrated
+		src.visible_message(SPAN_DANGER("\The [src] energy coils overheat and fails to fire!"))
+		playsound(src, 'sound/warhammer/ds/detonator_fire.ogg', 40, 1)
+		calibration_penalty += 5
+		return null
 	return new projectile_type(src)
 
 /obj/item/gun/energy/proc/get_external_power_supply()

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -57,6 +57,8 @@
 	update_icon()
 
 /obj/item/gun/projectile/consume_next_projectile()
+	if(calibrated == 0) // If not calibrated, adjust jam chance
+		jam_chance = calibration_penalty
 	if(!is_jammed && prob(jam_chance))
 		src.visible_message(SPAN_DANGER("\The [src] jams!"))
 		is_jammed = 1

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3372,6 +3372,26 @@
 
 //Just a short line of Canned Consumables, great for treasure in faraway abandoned outposts
 
+/obj/item/reagent_containers/food/snacks/canned/warfare
+	name = "\improper canned beans"
+	desc = "Supposedly what's in there is edible."
+	icon_state = "cbeans"
+	icon = 'icons/obj/food.dmi'
+	trash = /obj/item/trash/warfare_can
+	nutriment_desc = list("meat" = 1)
+	nutriment_amt = 5
+	var/drop_sound = 'sound/items/handle/can_drop.ogg'
+
+/obj/item/reagent_containers/food/snacks/canned/warfare/throw_impact(atom/hit_atom)
+	..()
+	if(drop_sound)
+		playsound(src, drop_sound, 50, 0)
+
+/obj/item/reagent_containers/food/snacks/canned/warfare/on_update_icon()
+	if(!sealed)
+		icon_state = "[initial(icon_state)]_open"
+
+
 /obj/item/reagent_containers/food/snacks/canned/beef
 	name = "quadrangled beefium"
 	icon_state = "beef"

--- a/maps/away/lar_maria/lar_maria-1.dmm
+++ b/maps/away/lar_maria/lar_maria-1.dmm
@@ -258,7 +258,7 @@
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_main)
 "aL" = (
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/closet/warhammer/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_main)
 "aM" = (
@@ -1252,7 +1252,7 @@
 /turf/simulated/wall/r_wall,
 /area/lar_maria/vir_aux)
 "dt" = (
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/closet/warhammer/secure_closet/personal/patient,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -1263,7 +1263,7 @@
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_aux)
 "dv" = (
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/closet/warhammer/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_aux)
 "dw" = (

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -50,7 +50,7 @@
 							 /datum/computer_file/program/reports,
 							 /datum/computer_file/program/deck_management)
 /datum/job/rogue_trader/get_description_blurb()
-	return "You are the Rogue Trader, commander of the Dauntless, an Imperial corvette exploratory vessel. Tasked with navigating the uncharted terror -- the Ghoul Stars, you lead a diverse retinue representing many factions, each serving a crucial role aboard your ship. While you hold ultimate authority, you work closely with your Magos Explorator, whose resources and personnel are vital to your survival in this cursed region. Rely on your officers to manage the deck scum, explore forgotten worlds, and broker alliances or hostilities with the human, alien, and worse. The emperor protects..."
+	return "You are the Rogue Trader, an infamous member of the Landsraad, where noble houses vie for dominance over the Ghoul Stars. Through shared bonds and rivalries, they control the flow of power and resources. As one of their number, you forge your path amidst alliances, intrigue, and the perils of the void."
 
 /datum/job/rogue_trader/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name
@@ -71,16 +71,13 @@
 		current_title = title // use default title
 	H.fully_replace_character_name("[current_title] [current_name]")
 	captain_announcement.Announce("All crew, [current_title] [current_name] has arrived...")
-	if(prob(1))
-		H.make_genestealer()
-		to_chat(H, "<span class='notice'><b><font size=2>You are a genestealer bioform, a unique strain of tyranid genestealer capable of rapid transformation. The swarm considers you to be an abomination, but under the guidance of what you believe to be the true hivemind, you will surely succeed where the others have failed. Everything is connected.</font></b></span>")
-	else if(prob(1))
+	if(prob(2))
 		to_chat(H,"<span class='danger'><b><font size=4>YOUR CULT ITEMS ARE BEING SUMMONED. FIND SOMEWHERE PRIVATE TO HIDE. SUMMONING IN THIRTY SECONDS</font></b></span>")
 		to_chat(H,"<span class='danger'><b><font size=4>YOUR CULT ITEMS ARE BEING SUMMONED. FIND SOMEWHERE PRIVATE TO HIDE. SUMMONING IN THIRTY SECONDS</font></b></span>")
 		spawn(30 SECONDS)
 		GLOB.cult.add_antagonist(H.mind, ignore_role = 1, do_not_equip = 0)
 		to_chat(H, "<span class='notice'><b><font size=2>You are a heretical cultist loyal to one or more of the Chaos Gods -- unlike the many pretenders you are truly blessed by the warp and can survive encounters that would boil the brains of most mortal men.</font></b></span>")
-	to_chat(H, "<span class='notice'><b><font size=2>You are the [current_title], commander of the Dauntless, an Imperial corvette exploratory vessel. Tasked with navigating the uncharted terror -- the Ghoul Stars, you lead a diverse retinue representing many factions, each serving a crucial role aboard your ship. While you hold ultimate authority, you work closely with your Magos Explorator, whose resources and personnel are vital to your survival in this cursed region. Rely on your officers to manage the deck scum, explore forgotten worlds, and broker alliances or hostilities with the human, alien, and worse. The emperor protects...</font></b></span>")
+	to_chat(H, "<span class='notice'><b><font size=2>You are the [current_title], an infamous member of the Landsraad, where noble houses vie for dominance over the Ghoul Stars. Through shared bonds and rivalries, they control the flow of power and resources. As one of their number, you forge your path amidst alliances, intrigue, and the perils of the void.</font></b></span>")
 	return ..()
 
 /datum/job/seneschal
@@ -217,7 +214,7 @@
 							 /datum/computer_file/program/deck_management)
 
 /datum/job/void_officer/get_description_blurb()
-	return "As the Voidmaster, you are a crucial officer aboard the Dauntless, responsible for piloting the ship, managing ship-wide vox communications, and executing the Rogue Trader's commands. Your role involves coordinating with the deck crew and all departments to ensure smooth and efficient operations. "
+	return "As the Voidmaster, you are a crucial officer aboard the Dauntless, responsible for piloting the ship, managing ship-wide vox communications, and executing the Rogue Trader's commands. Your role involves coordinating with the deck crew and all departments to ensure smooth and efficient operation of the voidship."
 
 /datum/job/void_officer/equip(mob/living/carbon/human/H)
 	var/current_name = H.real_name

--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -273,7 +273,7 @@
 		current_title = title // use default title
 	if(current_title == "Penitent" || current_title == "Deck Scum" || current_title == "Pathfinder" || current_title == "Miner")
 		if(current_title == "Penitent")
-			if(prob(80))
+			if(prob(85))
 				to_chat(H,"<span class='danger'><b><font size=4>THE PENITENT</font></b></span>")
 				to_chat(H, "<span class='notice'><b><font size=2>As the Penitent, you are condemned to suffer for your past crimes, undertaking the most dangerous and brutal tasks, hoping to earn absolution through relentless service to the Imperium.</font></b></span>")
 				H.equip_to_slot_or_store_or_drop(new /obj/item/clothing/under/rank/penitent, slot_w_uniform)

--- a/maps/torch/job/torch_access.dm
+++ b/maps/torch/job/torch_access.dm
@@ -192,7 +192,7 @@ var/global/const/access_torch_fax = "ACCESS_TORCH_FAX"
 var/global/const/access_petrov = "ACCESS_TORCH_PETROV" //200
 /datum/access/petrov
 	id = access_petrov
-	desc = "Petrov"
+	desc = "Mowteng"
 	region = ACCESS_REGION_GENERAL
 
 var/global/const/access_petrov_helm = "ACCESS_TORCH_PETROV_HELM" //201

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -90,15 +90,14 @@
 
 /obj/structure/closet/secure_closet/guncabinet/sidearm/WillContain()
 	return list(
-		/obj/item/clothing/accessory/storage/holster/thigh = 3,
-		/obj/item/gun/projectile/pistol/slug = 2,
-	)
-
-/obj/structure/closet/secure_closet/guncabinet/PPE
-	name = "bridge PPE cabinet"
-
-/obj/structure/closet/secure_closet/guncabinet/PPE/WillContain()
-	return list(
 		/obj/item/gun/projectile/revolver/imperial/heavy = 2,
 		/obj/item/clothing/accessory/storage/holster/thigh = 2
+	)
+
+/obj/structure/closet/secure_closet/guncabinet/lasgun
+	name = "lasgun cabinet"
+
+/obj/structure/closet/secure_closet/guncabinet/lasgun/WillContain()
+	return list(
+		/obj/item/gun/energy/lasgun/triplex = 2
 	)

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -9,6 +9,9 @@
 "ac" = (
 /obj/structure/table/steel,
 /obj/item/pen/fancy,
+/obj/structure/torchwall{
+	dir = 8
+	},
 /turf/simulated/floor/lino,
 /area/command/pilot)
 "ad" = (
@@ -89,8 +92,8 @@
 /obj/machinery/light,
 /obj/floor_decal/corner/brown/half,
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/turf/simulated/floor/newsteel/dark2,
+/obj/structure/table/rack/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "an" = (
 /turf/simulated/wall/r_wall/hull,
@@ -160,11 +163,12 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "au" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/newsteel/dark2,
+/obj/structure/hivedecor/xenos/artifact/teslatower,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "av" = (
 /obj/item/stool/bar,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "aw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -193,7 +197,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/random/tool,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -253,10 +257,16 @@
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "aF" = (
-/turf/simulated/floor/tiled/monotile,
+/obj/catwalk_plated{
+	color = "grey"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "aG" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -293,15 +303,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "aI" = (
-/obj/floor_decal/corner/mauve{
-	dir = 10
-	},
-/obj/machinery/light,
 /obj/machinery/camera/network/fifth_deck{
 	c_tag = "Fifth Deck Hallway - Lift";
 	dir = 1
 	},
-/turf/simulated/floor/newsteel/dark2,
+/obj/structure/torchwall{
+	dir = 1
+	},
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "aJ" = (
 /turf/simulated/wall/prepainted,
@@ -387,14 +396,13 @@
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/crew)
 "aQ" = (
-/obj/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "aR" = (
 /obj/machinery/computer/ship/helm{
@@ -404,13 +412,18 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cockpit)
 "aS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "aT" = (
 /obj/structure/sign/warning/airlock{
@@ -448,7 +461,9 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
 "aX" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "aY" = (
@@ -496,7 +511,7 @@
 /area/shuttle/petrov/toxins)
 "bf" = (
 /obj/machinery/computer/shuttle_control/explore/exploration_shuttle,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cockpit)
 "bg" = (
 /obj/paint/sfv_arbiter,
@@ -507,7 +522,7 @@
 /area/exploration_shuttle/cockpit)
 "bh" = (
 /obj/structure/bed/chair/shuttle/blue,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "bi" = (
 /turf/simulated/floor/plating,
@@ -517,14 +532,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "bk" = (
 /obj/structure/bed/chair/shuttle/blue,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "bl" = (
 /obj/machinery/atmospherics/omni/mixer{
@@ -552,7 +567,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/obj/item/book/manual/chef_recipes,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "bn" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -609,7 +626,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "br" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
@@ -672,7 +689,7 @@
 /obj/item/device/radio/intercom/hailing{
 	pixel_y = 22
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cockpit)
 "bw" = (
 /obj/structure/bed/chair/shuttle/blue{
@@ -689,7 +706,12 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cockpit)
 "bx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -708,7 +730,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cockpit)
 "by" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -725,7 +747,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Cockpit"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cockpit)
 "bz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -739,7 +761,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "bA" = (
 /obj/structure/cable/cyan{
@@ -758,7 +780,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "bB" = (
 /obj/structure/cable/cyan{
@@ -766,7 +788,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "bC" = (
 /obj/structure/cable/cyan{
@@ -774,7 +796,12 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "bE" = (
 /obj/machinery/computer/air_control{
@@ -782,7 +809,12 @@
 	name = "Atmospheric Sensors";
 	sensor_tag = "charon_out"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "bF" = (
 /obj/machinery/door/blast/regular/open{
@@ -872,7 +904,9 @@
 /turf/simulated/floor/warhammer/splate,
 /area/guppy_hangar/start)
 "bL" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -907,8 +941,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
 "bP" = (
 /obj/paint/meatstation,
@@ -941,7 +974,7 @@
 	pixel_y = -22;
 	req_access = list("ACCESS_DAUNTLESS")
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cockpit)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -976,7 +1009,7 @@
 /obj/structure/handrail{
 	dir = 1
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cockpit)
 "bW" = (
 /obj/machinery/firealarm{
@@ -984,13 +1017,13 @@
 	pixel_y = -24
 	},
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cockpit)
 "bY" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "bZ" = (
 /obj/structure/cable/cyan{
@@ -1002,7 +1035,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "ca" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1015,13 +1048,13 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "cb" = (
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = -32
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "cc" = (
 /obj/machinery/alarm{
@@ -1029,7 +1062,7 @@
 	pixel_y = -22;
 	req_access = list("ACCESS_DAUNTLESS")
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "cd" = (
 /obj/structure/disposalpipe/segment{
@@ -1048,16 +1081,12 @@
 /turf/simulated/wall/prepainted,
 /area/quartermaster/expedition/storage)
 "cf" = (
-/obj/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/west,
 /area/quartermaster/hangar)
 "cg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/guppy{
@@ -1111,12 +1140,12 @@
 	dir = 8;
 	icon_state = "console"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "cm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass,
-/turf/simulated/floor/warhammer/metal,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/crew)
 "cn" = (
 /obj/structure/cable/cyan{
@@ -1127,7 +1156,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/warhammer/metal,
+/turf/simulated/floor/warhammer/plating,
+/area/exploration_shuttle/crew)
+"cp" = (
+/obj/paint/sun,
+/obj/machinery/pointdefense{
+	initial_id_tag = "charon"
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/wall/titanium,
 /area/exploration_shuttle/crew)
 "cq" = (
 /obj/paint/sfv_arbiter,
@@ -1137,7 +1177,7 @@
 /obj/machinery/cryopod{
 	dir = 2
 	},
-/turf/simulated/floor/warhammer/metal/northwest,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "cs" = (
 /obj/structure/bed/chair/shuttle/blue,
@@ -1145,7 +1185,7 @@
 	pixel_y = 25
 	},
 /obj/structure/closet/crate/warhammer/floorsafe,
-/turf/simulated/floor/warhammer/metal/north,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "ct" = (
 /obj/structure/sign/directions/engineering{
@@ -1167,7 +1207,7 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_DAUNTLESS")
 	},
-/turf/simulated/floor/warhammer/metal/north,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "cv" = (
 /obj/structure/closet/medical_wall/filled{
@@ -1185,11 +1225,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/warhammer/metal/northeast,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "cy" = (
-/obj/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/northwest,
 /area/quartermaster/hangar)
 "cA" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/guppy{
@@ -1224,7 +1263,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "cE" = (
 /obj/structure/cable/cyan{
@@ -1239,7 +1278,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "cF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
@@ -1286,7 +1325,7 @@
 /obj/item/device/drone_designator{
 	network = "torch_transport"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "cK" = (
 /obj/machinery/button/blast_door{
@@ -1295,7 +1334,7 @@
 	pixel_y = 25
 	},
 /obj/structure/handrail,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "cL" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -1306,7 +1345,7 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_DAUNTLESS")
 	},
-/turf/simulated/floor/warhammer/metal/northeast,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "cM" = (
 /obj/floor_decal/industrial/warning{
@@ -1318,24 +1357,21 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "cO" = (
-/turf/simulated/floor/warhammer/metal,
-/area/exploration_shuttle/medical)
-"cP" = (
-/turf/simulated/floor/warhammer/metal/west,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "cQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/warhammer/metal,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "cR" = (
 /obj/structure/bed/padded,
-/turf/simulated/floor/warhammer/metal/east,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "cS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "cT" = (
 /obj/machinery/hologram/holopad/longrange,
@@ -1398,7 +1434,7 @@
 	pixel_x = -22
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "cY" = (
 /obj/structure/cable/green{
@@ -1410,7 +1446,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1443,26 +1479,23 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "dd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/warhammer/metal/south,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "de" = (
-/turf/simulated/floor/warhammer/metal/south,
-/area/exploration_shuttle/cargo)
-"df" = (
-/turf/simulated/floor/warhammer/metal/southeast,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "dg" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/box/glowsticks,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/warhammer/metal/west,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "dh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1471,7 +1504,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/warhammer/metal,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "di" = (
 /obj/structure/cable/cyan{
@@ -1485,7 +1518,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "dj" = (
 /obj/structure/cable/cyan{
@@ -1503,7 +1536,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/warhammer/metal,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "dk" = (
 /obj/structure/cable/cyan{
@@ -1517,7 +1550,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "dl" = (
 /obj/structure/cable/cyan{
@@ -1537,7 +1570,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/east,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "dm" = (
 /obj/floor_decal/techfloor{
@@ -1593,20 +1626,20 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "dx" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/item/shuttle_beacon,
 /obj/item/shuttle_beacon,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/warhammer/metal/southwest,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "dy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/warhammer/metal,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "dz" = (
 /obj/structure/cable/cyan{
@@ -1619,13 +1652,13 @@
 /obj/structure/handrail{
 	dir = 8
 	},
-/turf/simulated/floor/warhammer/metal/east,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "dA" = (
 /obj/structure/handrail{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "dB" = (
 /obj/structure/cable/cyan{
@@ -1635,7 +1668,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/warhammer/metal/east,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "dE" = (
 /obj/structure/cable/green{
@@ -1773,13 +1806,13 @@
 	pixel_x = -32
 	},
 /obj/machinery/recharger,
-/turf/simulated/floor/warhammer/metal/south,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "dV" = (
 /obj/machinery/light,
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
-/turf/simulated/floor/warhammer/metal/south,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "dW" = (
 /obj/structure/cable/cyan,
@@ -1793,7 +1826,7 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/turf/simulated/floor/warhammer/metal/southeast,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/medical)
 "dY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1806,7 +1839,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "dZ" = (
 /obj/structure/cable/cyan{
@@ -1820,7 +1853,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/east,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "ea" = (
 /obj/floor_decal/techfloor{
@@ -1893,8 +1926,7 @@
 	},
 /area/exploration_shuttle/cargo)
 "ee" = (
-/obj/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/north,
 /area/quartermaster/hangar)
 "ef" = (
 /obj/wallframe_spawn/reinforced/titanium,
@@ -1926,16 +1958,12 @@
 	pixel_y = 32
 	},
 /obj/structure/handrail,
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/airlock)
 "el" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "em" = (
 /obj/structure/cable/cyan{
@@ -1946,7 +1974,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/cargo)
 "en" = (
 /obj/structure/disposalpipe/trunk{
@@ -1970,10 +1998,6 @@
 "eq" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
 	id_tag = "charon_shuttle_pump_out_external"
-	},
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
 	},
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1331;
@@ -2011,13 +2035,15 @@
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "eu" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/exploration)
 "ev" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/light/spot{
 	dir = 8
 	},
@@ -2046,7 +2072,7 @@
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "ey" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
@@ -2061,7 +2087,7 @@
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "ez" = (
 /obj/paint/sfv_arbiter,
@@ -2070,7 +2096,7 @@
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/airlock)
 "eA" = (
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "eB" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -2096,7 +2122,7 @@
 	dir = 4
 	},
 /obj/structure/cable/cyan,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "eE" = (
 /obj/paint/sfv_arbiter,
@@ -2121,13 +2147,10 @@
 	pixel_x = -22;
 	pixel_y = -10
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/power)
 "eH" = (
-/obj/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/northeast,
 /area/quartermaster/hangar)
 "eK" = (
 /obj/structure/cable/cyan{
@@ -2143,7 +2166,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/radio_beacon,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/power)
 "eM" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -2157,7 +2180,7 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_RESTRICTED")
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "eN" = (
 /obj/structure/railing/mapped,
@@ -2172,35 +2195,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/power)
-"eS" = (
-/obj/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/exploration)
 "eT" = (
-/obj/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
-"eU" = (
-/obj/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/machinery/floodlight,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
-"eV" = (
-/obj/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/floodlight,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/east,
 /area/quartermaster/hangar)
 "eW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2220,10 +2218,6 @@
 /obj/machinery/air_sensor{
 	id_tag = "charon_out"
 	},
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/airlock)
 "fa" = (
@@ -2237,23 +2231,23 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "ff" = (
 /obj/machinery/door/airlock/external{
@@ -2265,14 +2259,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fi" = (
 /obj/machinery/atmospherics/valve/shutoff/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "fj" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -2291,7 +2287,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fn" = (
 /obj/structure/cable/cyan{
@@ -2314,7 +2310,7 @@
 	pixel_x = 21;
 	pixel_y = 21
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fo" = (
 /obj/machinery/door/airlock/hatch,
@@ -2330,7 +2326,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2349,7 +2345,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/power)
 "fq" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -2360,7 +2356,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/power)
 "fr" = (
 /obj/machinery/power/terminal{
@@ -2378,7 +2374,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/power)
 "fu" = (
 /obj/paint/sfv_arbiter,
@@ -2394,21 +2390,20 @@
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/power)
 "fy" = (
-/obj/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/east,
 /area/quartermaster/hangar)
 "fz" = (
 /turf/simulated/wall/walnut,
 /area/vacant/bar)
 "fB" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -2430,7 +2425,7 @@
 	dir = 4
 	},
 /obj/machinery/artifact_analyser,
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
 "fE" = (
@@ -2455,7 +2450,7 @@
 /area/shuttle/petrov/isolation)
 "fH" = (
 /obj/item/stool,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "fI" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
@@ -2467,10 +2462,6 @@
 	id_tag = "charon_shuttle_sensor_external";
 	pixel_x = 25;
 	pixel_y = -25
-	},
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/airlock)
@@ -2494,7 +2485,7 @@
 	c_tag = "Charon - Airlock Compartment";
 	dir = 1
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fK" = (
 /obj/machinery/light/small,
@@ -2506,7 +2497,7 @@
 	id_tag = "charon_shuttle_pump"
 	},
 /obj/floor_decal/techfloor,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fL" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
@@ -2521,13 +2512,13 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fN" = (
 /obj/structure/cable/cyan{
@@ -2546,7 +2537,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "fO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2559,12 +2550,12 @@
 	pixel_x = -21;
 	req_access = list("ACCESS_DAUNTLESS")
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/power)
 "fP" = (
 /obj/machinery/recharge_station,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/power)
 "fQ" = (
 /obj/floor_decal/industrial/hatch/yellow,
@@ -2572,31 +2563,19 @@
 /obj/machinery/power/port_gen/pacman/super/potato,
 /obj/item/stack/material/uranium/ten,
 /obj/item/stack/material/uranium/ten,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/power)
 "fR" = (
 /obj/structure/handrail{
 	dir = 1
 	},
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/airlock)
 "fS" = (
-/obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/south,
 /area/quartermaster/hangar)
 "fT" = (
-/obj/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/southeast,
 /area/quartermaster/hangar)
 "fU" = (
 /obj/structure/closet/emcloset,
@@ -2604,15 +2583,12 @@
 /turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fifthdeck/aft)
 "fW" = (
-/obj/floor_decal/corner/mauve/half{
-	dir = 4
-	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/modular/preset/dock{
 	dir = 8;
 	icon_state = "console"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "fX" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -2637,18 +2613,15 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "gc" = (
 /obj/shuttle_landmark/supply/station,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "gd" = (
-/obj/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "ge" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -2668,7 +2641,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "gj" = (
 /obj/floor_decal/industrial/warning/fulltile,
@@ -2679,7 +2652,7 @@
 	dir = 6
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "gl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -2692,7 +2665,7 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_DAUNTLESS")
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "gm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2719,7 +2692,7 @@
 	pixel_x = 10;
 	pixel_y = 22
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "go" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2743,7 +2716,7 @@
 "gp" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/mining/drill,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "gq" = (
 /obj/structure/stairs/east,
@@ -2793,7 +2766,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "gx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2810,7 +2783,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "gy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2828,7 +2801,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "gz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2847,7 +2820,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "gB" = (
 /obj/structure/cable/green{
@@ -2881,17 +2854,17 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "gE" = (
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "gF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "gG" = (
 /obj/structure/cable/cyan{
@@ -2916,16 +2889,14 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
 "gK" = (
-/obj/catwalk_plated,
 /obj/structure/disposalpipe/segment,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "gM" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining{
-	name = "Expedition Storage";
-	req_access = list("ACCESS_RESTRICTED")
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -2934,7 +2905,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/machinery/door/airlock/warhammer{
+	req_access = list("ACCESS_RESTRICTED");
+	name = "Expedition Storage"
+	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "gO" = (
 /turf/simulated/wall/prepainted,
@@ -3037,7 +3012,7 @@
 	pixel_x = -10;
 	pixel_y = 22
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "he" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -3050,7 +3025,7 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_DAUNTLESS")
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "hf" = (
 /obj/structure/cable/cyan{
@@ -3077,11 +3052,6 @@
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/canister)
-"hh" = (
-/obj/machinery/door/firedoor,
-/obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
 "hi" = (
 /obj/structure/ladder/up,
 /obj/floor_decal/industrial/hatch/yellow,
@@ -3102,7 +3072,7 @@
 /obj/machinery/mining/brace{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "hm" = (
 /obj/structure/closet/secure_closet/pilot,
@@ -3115,7 +3085,7 @@
 "hn" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/suspension_gen,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "ho" = (
 /obj/random/junk,
@@ -3126,10 +3096,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/random/loot/lightmelee,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "hq" = (
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "hs" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup{
@@ -3139,13 +3110,13 @@
 	dir = 8
 	},
 /obj/floor_decal/industrial/outline/orange,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "ht" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/random_multi/single_item/boombox,
 /obj/structure/closet/crate/warhammer/cargo,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "hu" = (
 /obj/structure/railing/mapped,
@@ -3153,31 +3124,24 @@
 /area/hallway/primary/fifthdeck/fore)
 "hv" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
-"hw" = (
-/obj/floor_decal/corner/mauve{
-	dir = 5
-	},
-/turf/simulated/floor/newsteel/dark2,
-/area/quartermaster/exploration)
 "hx" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/floor_decal/corner/mauve/mono,
 /obj/structure/closet/secure_closet/explorer,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/item/material/twohanded/ravenor/sword/chopper,
 /obj/random/loot/basicarmorbundle,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "hy" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall/prepainted,
 /area/quartermaster/storage)
 "hz" = (
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "hA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3205,7 +3169,7 @@
 "hF" = (
 /obj/machinery/door/firedoor,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "hG" = (
 /obj/structure/cable/green{
@@ -3219,7 +3183,7 @@
 	icon_state = "1-8"
 	},
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "hL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3251,15 +3215,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "hO" = (
-/obj/floor_decal/corner/mauve/mono,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/explorer,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/item/material/twohanded/jack,
 /obj/random/loot/lightmelee,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/torchwall{
+	dir = 4
+	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "hP" = (
 /obj/structure/cable/cyan{
@@ -3279,7 +3242,7 @@
 "hR" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "hS" = (
 /obj/machinery/door/firedoor,
@@ -3303,30 +3266,27 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/fore)
 "hT" = (
-/obj/floor_decal/industrial/warning/corner{
-	dir = 4;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/southwest,
 /area/quartermaster/hangar)
 "hV" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector,
 /obj/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "hW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "hY" = (
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/floodlight,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "hZ" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -3335,7 +3295,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "ia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -3347,7 +3307,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "ie" = (
 /obj/machinery/door/firedoor,
@@ -3361,10 +3321,12 @@
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "ih" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -3373,14 +3335,18 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "il" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "im" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -3399,7 +3365,7 @@
 /obj/machinery/vending/coffee{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "iq" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/guppy{
@@ -3423,19 +3389,17 @@
 /obj/machinery/camera/network/fifth_deck{
 	c_tag = "Hangar - Midships Starboard"
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/floodlight,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "iu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "iv" = (
 /obj/machinery/computer/ship/navigation,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/pilot)
 "iw" = (
@@ -3446,7 +3410,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "ix" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -3455,7 +3419,7 @@
 	dir = 4;
 	pixel_x = -21
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "iy" = (
 /obj/wallframe_spawn/reinforced/titanium,
@@ -3515,7 +3479,6 @@
 /obj/floor_decal/industrial/warning/corner,
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
-/obj/random/powercell,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -3529,54 +3492,37 @@
 	pixel_x = 22;
 	pixel_y = 22
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "iE" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "iF" = (
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "iG" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "iH" = (
 /obj/item/clothing/mask/gas{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/item/clothing/mask/gas{
 	pixel_x = -3;
 	pixel_y = -3
 	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/warhammer/cargo,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "iI" = (
 /obj/structure/cable/green,
@@ -3584,6 +3530,9 @@
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
+	},
+/obj/structure/torchwall{
+	dir = 4
 	},
 /turf/simulated/floor/lino,
 /area/command/pilot)
@@ -3602,7 +3551,7 @@
 /obj/item/device/flashlight,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/warhammer/cargo,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/east,
 /area/quartermaster/storage)
 "iK" = (
 /obj/structure/table/steel,
@@ -3647,7 +3596,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "iO" = (
 /obj/structure/table/steel,
@@ -3656,7 +3605,6 @@
 	pixel_y = 7
 	},
 /obj/item/folder/blue,
-/obj/floor_decal/corner/mauve/mono,
 /obj/structure/sign/ecplaque{
 	pixel_y = 30
 	},
@@ -3664,20 +3612,20 @@
 	pixel_x = 22;
 	pixel_y = 22
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/structure/torchwall{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "iP" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/suit_cycler/exploration,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "iQ" = (
 /obj/machinery/suit_cycler/exploration,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "iS" = (
 /obj/machinery/door/firedoor,
@@ -3694,12 +3642,16 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/hangar)
 "iU" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "iV" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -3745,7 +3697,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/east,
 /area/quartermaster/storage)
 "ja" = (
 /obj/floor_decal/industrial/warning{
@@ -3754,12 +3706,12 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/north,
 /area/quartermaster/storage)
 "jc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "jd" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -3776,7 +3728,7 @@
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/west,
 /area/quartermaster/storage)
 "je" = (
 /obj/structure/cable/green{
@@ -3790,18 +3742,15 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "jf" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
+/obj/structure/table/steel,
 /obj/machinery/cell_charger,
-/obj/random/powercell,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/west,
 /area/quartermaster/storage)
 "jg" = (
 /obj/structure/cable/green{
@@ -3816,17 +3765,17 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "ji" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "jj" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/dispenser,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/east,
 /area/quartermaster/storage)
 "jk" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -3837,7 +3786,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/south,
 /area/quartermaster/storage)
 "jm" = (
 /obj/item/storage/firstaid/o2{
@@ -3851,12 +3800,10 @@
 /obj/item/stack/nanopaste,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/warhammer/xenos,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/south,
 /area/quartermaster/storage)
 "jn" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
+/obj/structure/table/rack/dark,
 /obj/item/stack/material/cardboard/fifty,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
@@ -3867,7 +3814,7 @@
 	pixel_y = -25
 	},
 /obj/machinery/light/spot,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/southwest,
 /area/quartermaster/storage)
 "jo" = (
 /obj/structure/cable/green{
@@ -3887,12 +3834,12 @@
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/spot,
 /obj/structure/closet/crate/warhammer/xenos,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/southeast,
 /area/quartermaster/storage)
 "jq" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/floodlight,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "jr" = (
 /obj/machinery/door/firedoor,
@@ -3911,7 +3858,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "js" = (
 /obj/machinery/door/blast/shutters{
@@ -3919,10 +3866,12 @@
 	id_tag = "mine_warehouse";
 	name = "Storage Shutters"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "jt" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -3943,7 +3892,7 @@
 	pixel_x = -21;
 	req_access = list("ACCESS_DAUNTLESS")
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "jw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3977,16 +3926,17 @@
 "jz" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/stasis_cage,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "jA" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/ore_box,
-/obj/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "jB" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1;
 	icon_state = "warningcorner"
@@ -4008,15 +3958,12 @@
 	req_access = list("ACCESS_DAUNTLESS");
 	name = "secure chest"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "jE" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/firealarm{
 	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/structure/closet/crate/warhammer/xenos/chest{
 	name = "secure chest";
@@ -4025,7 +3972,7 @@
 /obj/item/clothing/mask/gas/half,
 /obj/random/loot/armorinserts,
 /obj/random/loot/armorinserts,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "jF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4035,14 +3982,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "jG" = (
 /obj/structure/table/steel,
@@ -4054,7 +3998,6 @@
 "jH" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/glasses,
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/pilot)
 "jI" = (
@@ -4069,7 +4012,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "jJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4078,28 +4021,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "jK" = (
-/obj/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "jL" = (
-/obj/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -4107,7 +4040,7 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "jM" = (
 /obj/machinery/door/firedoor,
@@ -4129,7 +4062,8 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/fifthdeck/fore)
 "jO" = (
-/turf/simulated/floor/newsteel/dark2,
+/obj/structure/hivedecor/xenos/artifact/node3,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "jP" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -4268,7 +4202,7 @@
 /obj/item/device/binoculars,
 /obj/item/device/binoculars,
 /obj/item/device/binoculars,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "jX" = (
 /obj/structure/largecrate,
@@ -4301,10 +4235,13 @@
 "kb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/rotating_alarm/security_alarm,
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/floodlight,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "kd" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/light/spot{
 	dir = 1
 	},
@@ -4322,20 +4259,19 @@
 	pixel_x = 24;
 	pixel_y = -10
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/airlock)
 "kf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kh" = (
-/obj/floor_decal/corner/mauve/mono,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -4349,21 +4285,20 @@
 /obj/floor_decal/industrial/outline/yellow,
 /obj/item/material/twohanded/ravenor/axe,
 /obj/random/loot/lightmelee,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "ki" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kj" = (
-/obj/floor_decal/corner/mauve/mono,
 /obj/structure/closet/secure_closet/explorer,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/item/material/twohanded/jack,
 /obj/random/loot/lightmelee,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4375,7 +4310,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kl" = (
 /turf/unsimulated/mask,
@@ -4398,7 +4333,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "kn" = (
 /obj/structure/table/steel,
@@ -4408,25 +4343,22 @@
 /obj/item/clothing/glasses/science,
 /obj/item/device/geiger,
 /obj/item/device/geiger,
-/obj/floor_decal/corner/mauve{
-	dir = 5
-	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "ko" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/warhammer/biohazard,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/torchwall{
+	dir = 4
+	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kp" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 8
 	},
-/obj/floor_decal/corner/mauve/half{
-	dir = 4
-	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kq" = (
 /obj/machinery/door/firedoor,
@@ -4435,7 +4367,7 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/exploration)
 "kr" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/item/storage/box/greenglowsticks,
 /obj/item/storage/box/greenglowsticks,
@@ -4446,12 +4378,9 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/storage/box/ammo/flashshells,
 /obj/item/gun/projectile/flare,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kt" = (
 /obj/machinery/door/firedoor,
@@ -4459,7 +4388,7 @@
 	req_access = list("ACCESS_RESTRICTED");
 	name = "Expedition Storage"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/metal,
 /area/quartermaster/exploration)
 "ku" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -4475,7 +4404,7 @@
 	dir = 10
 	},
 /mob/living/exosuit/premade/light/exploration,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kv" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -4490,16 +4419,18 @@
 	req_access = list("ACCESS_DAUNTLESS");
 	name = "secure chest"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kx" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/button/alternate/door{
 	desc = "A remote control-switch for airlocks.";
 	id_tag = "hangarexit";
@@ -4510,7 +4441,7 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "ky" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/stack/flag/green,
 /obj/item/stack/flag/green,
 /obj/item/stack/flag/green,
@@ -4523,19 +4454,16 @@
 /obj/item/device/scanner/mining,
 /obj/item/device/scanner/mining,
 /obj/item/device/scanner/mining,
-/obj/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/item/device/drone_designator{
 	network = "torch_transport"
 	},
 /obj/item/device/drone_designator{
 	network = "torch_transport"
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kz" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/device/scanner/xenobio,
 /obj/item/device/scanner/xenobio,
 /obj/item/device/scanner/xenobio,
@@ -4547,22 +4475,16 @@
 /obj/item/device/scanner/plant,
 /obj/item/device/scanner/plant,
 /obj/item/device/scanner/plant,
-/obj/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 21
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kA" = (
-/obj/floor_decal/corner/mauve/half{
-	dir = 4
-	},
 /obj/structure/table/steel,
 /obj/item/device/camera,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kB" = (
 /obj/machinery/door/firedoor,
@@ -4578,7 +4500,7 @@
 	req_access = list("ACCESS_RESTRICTED");
 	name = "Expedition Storage"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4589,7 +4511,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -4606,7 +4528,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -4626,32 +4548,37 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kH" = (
-/obj/structure/sign/poster/poster4,
-/turf/simulated/wall/prepainted,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "kI" = (
-/obj/floor_decal/industrial/warning/corner,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/newsteel/dark2,
-/area/quartermaster/exploration)
-"kJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/warhammer,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/quartermaster/exploration)
+/obj/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/warhammer/metal/south,
+/area/quartermaster/storage)
 "kK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -4662,17 +4589,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "kL" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/machinery/disposal,
-/obj/floor_decal/corner/mauve{
-	dir = 10
-	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kM" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -4681,11 +4605,10 @@
 	pixel_x = -32
 	},
 /obj/structure/closet/crate/warhammer/biohazard,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kP" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/light,
 /obj/structure/closet/crate/warhammer/xenos/chest3{
 	req_access = list("ACCESS_DAUNTLESS");
 	name = "secure chest"
@@ -4693,34 +4616,39 @@
 /obj/item/ammo_magazine/shotholder/net,
 /obj/item/ammo_magazine/shotholder/stun,
 /obj/item/gun/projectile/shotgun/pump/exploration,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kQ" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "kS" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
 /area/quartermaster/exploration)
 "kT" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/light/spot{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "kU" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/light/spot{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "kV" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/light/spot{
 	dir = 4
 	},
@@ -4732,14 +4660,15 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "kW" = (
-/obj/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/northwest,
 /area/quartermaster/hangar)
 "kX" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/light/spot,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
@@ -4775,8 +4704,7 @@
 /area/quartermaster/shuttlefuel)
 "lc" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "ld" = (
 /obj/structure/closet/emcloset,
@@ -4802,15 +4730,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "lf" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/structure/closet/crate/plastic,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "lg" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/light/spot,
 /obj/structure/closet/crate,
 /obj/random_multi/single_item/boombox,
@@ -4822,13 +4754,9 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/structure/railing/mapped,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "li" = (
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
@@ -4893,14 +4821,14 @@
 /area/quartermaster/storage)
 "lq" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/ore_box,
+/obj/machinery/floodlight,
 /obj/floor_decal/industrial/warning{
-	dir = 4
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/expedition/storage)
+/turf/simulated/floor/warhammer/metal/alt,
+/area/quartermaster/storage)
 "lr" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -4921,7 +4849,7 @@
 /obj/floor_decal/corner/brown{
 	dir = 9
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "lt" = (
 /obj/machinery/computer/guestpass{
@@ -4931,46 +4859,37 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/pilot)
 "lu" = (
-/obj/floor_decal/corner/purple{
-	dir = 6
-	},
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 20
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "lv" = (
-/obj/machinery/door/firedoor,
-/obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/sign/mechanicus,
+/turf/simulated/wall/prepainted,
 /area/quartermaster/hangar)
 "lw" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/sign/mechanicus,
+/turf/simulated/wall/prepainted,
 /area/quartermaster/hangar)
 "lx" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/anomaly_container,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "ly" = (
 /obj/floor_decal/industrial/hatch/yellow,
-/obj/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/structure/ladder/up,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/storage)
 "lz" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup{
@@ -4981,7 +4900,7 @@
 	icon_state = "bulb1"
 	},
 /obj/floor_decal/industrial/outline/orange,
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "lA" = (
 /obj/machinery/light/small{
@@ -5013,9 +4932,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "lD" = (
-/obj/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
@@ -5024,17 +4940,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "lE" = (
-/obj/floor_decal/industrial/warning,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "lF" = (
 /obj/machinery/conveyor{
@@ -5090,11 +5005,11 @@
 	dir = 1
 	},
 /obj/structure/closet/crate,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "lR" = (
 /obj/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "lS" = (
 /obj/machinery/computer/mining,
@@ -5120,7 +5035,7 @@
 /area/guppy_hangar/start)
 "lV" = (
 /obj/machinery/light/spot,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "lW" = (
 /obj/structure/closet/crate,
@@ -5133,7 +5048,7 @@
 	},
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light/spot,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "lY" = (
 /turf/simulated/wall/prepainted,
@@ -5143,7 +5058,7 @@
 	id_tag = "hanger_atmos_storage";
 	name = "Storage Shutters"
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "mb" = (
 /obj/random/tech_supply,
@@ -5163,7 +5078,7 @@
 	dir = 8
 	},
 /obj/machinery/fabricator/hacked,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "mc" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -5180,13 +5095,11 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "md" = (
-/obj/machinery/light/spot{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/floodlight,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "mf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5239,7 +5152,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "mm" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/device/scanner/spectrometer/adv,
 /obj/item/storage/box/syringes,
 /obj/item/storage/box/beakers,
@@ -5279,7 +5192,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "mp" = (
 /obj/structure/cable/cyan{
@@ -5318,7 +5231,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "ms" = (
 /obj/machinery/door/firedoor,
@@ -5363,7 +5276,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "mw" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -5388,10 +5303,12 @@
 /obj/machinery/atmospherics/binary/pump/on{
 	name = "port thrust pump"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "mB" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -5402,7 +5319,9 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "mC" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -5421,10 +5340,12 @@
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "mE" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -5441,7 +5362,9 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "mF" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -5451,7 +5374,7 @@
 /obj/structure/handrail{
 	dir = 8
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "mH" = (
 /obj/structure/cable/green{
@@ -5463,11 +5386,10 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
 /obj/structure/catwalk,
+/obj/structure/torchwall{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "mI" = (
@@ -5549,7 +5471,7 @@
 	c_tag = "Fifth Deck Hallway - Stairs";
 	dir = 8
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "mP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5628,9 +5550,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "nb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5663,9 +5584,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "nf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -5727,7 +5645,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "nl" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -5918,8 +5838,8 @@
 /area/maintenance/fifthdeck/fore)
 "nA" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/turf/simulated/floor/newsteel/dark2,
+/obj/structure/table/rack/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "nB" = (
 /obj/structure/disposalpipe/segment{
@@ -6012,13 +5932,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "nK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "nL" = (
 /obj/structure/cable/green,
@@ -6031,17 +5951,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "nM" = (
-/obj/floor_decal/industrial/warning/corner{
-	dir = 4;
-	icon_state = "warningcorner"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/southwest,
 /area/quartermaster/hangar)
 "nN" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6053,7 +5971,9 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "nO" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -6068,7 +5988,9 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "nP" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -6083,9 +6005,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "nQ" = (
-/obj/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -6094,10 +6013,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "nR" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -6124,7 +6045,9 @@
 /turf/simulated/floor/warhammer/metal,
 /area/exploration_shuttle/airlock)
 "nU" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -6139,7 +6062,9 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "nV" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -6450,7 +6375,7 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/north,
 /area/quartermaster/storage)
 "ot" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6462,13 +6387,13 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "ou" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/mech_recharger,
 /mob/living/exosuit/premade/powerloader/old,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "ov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6477,7 +6402,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6488,11 +6413,11 @@
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "ox" = (
 /obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "oy" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -6502,16 +6427,14 @@
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/west,
 /area/quartermaster/storage)
 "oB" = (
 /obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/electrical,
 /obj/item/storage/toolbox/electrical,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/warhammer/cargo,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/northeast,
 /area/quartermaster/storage)
 "oD" = (
 /obj/machinery/door/firedoor,
@@ -6561,7 +6484,9 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/hangar)
 "oG" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 4;
 	icon_state = "warningcorner"
@@ -6577,7 +6502,9 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "oI" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/camera/network/fifth_deck{
 	c_tag = "Hangar - Aft Starboard"
 	},
@@ -6588,7 +6515,9 @@
 /turf/unsimulated/mask,
 /area/hallway/primary/fifthdeck/fore)
 "oL" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -6601,7 +6530,9 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "oM" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/camera/network/fifth_deck{
 	c_tag = "Hangar - Fore Port";
 	dir = 4
@@ -6609,7 +6540,9 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "oN" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/camera/network/fifth_deck{
 	c_tag = "Hangar - Aft Port";
 	dir = 8
@@ -6617,26 +6550,20 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "oQ" = (
-/obj/floor_decal/corner/purple{
-	dir = 6
-	},
 /obj/machinery/vending/cola{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "oR" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 21
 	},
-/obj/floor_decal/corner/purple{
-	dir = 6
-	},
 /obj/machinery/vending/snack{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "oS" = (
 /obj/machinery/disposal,
@@ -6646,53 +6573,25 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/floor_decal/corner/purple{
-	dir = 6
-	},
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
-"oU" = (
-/obj/floor_decal/corner/mauve{
-	dir = 10
-	},
-/turf/simulated/floor/newsteel/dark2,
-/area/hallway/primary/fifthdeck/fore)
 "oW" = (
-/obj/floor_decal/corner/mauve{
-	dir = 8
-	},
-/turf/simulated/floor/newsteel/dark2,
-/area/hallway/primary/fifthdeck/fore)
+/obj/structure/sign/poster/poster4,
+/turf/simulated/wall/prepainted,
+/area/command/pilot)
 "oX" = (
-/obj/structure/closet/emcloset,
-/obj/floor_decal/corner/mauve/half,
-/obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
-"oY" = (
-/obj/floor_decal/corner/mauve,
-/turf/simulated/floor/newsteel/dark2,
-/area/hallway/primary/fifthdeck/fore)
-"oZ" = (
-/obj/floor_decal/corner/mauve/half{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
-"pa" = (
-/obj/floor_decal/corner/mauve{
-	dir = 6
-	},
-/turf/simulated/floor/newsteel/dark2,
+/obj/structure/hivedecor/statue8,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "pb" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/button/alternate/door{
 	desc = "A remote control-switch for airlocks.";
 	id_tag = "hangarexit2";
@@ -6735,7 +6634,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "pf" = (
 /obj/structure/sign/mechanicus,
@@ -6761,7 +6660,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "pl" = (
 /obj/structure/cable/green{
@@ -6790,7 +6690,7 @@
 /area/maintenance/fifthdeck/fore)
 "po" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "pp" = (
 /obj/structure/sign/directions/bridge{
@@ -6848,9 +6748,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
 "pv" = (
-/obj/structure/table/rack,
-/obj/random/tech_supply,
+/obj/structure/table/rack/dark,
 /obj/floor_decal/industrial/outline/grey,
+/obj/random/loot/randomsupply,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
 "pw" = (
@@ -6998,7 +6898,7 @@
 	pixel_x = -14;
 	pixel_y = 2
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "pM" = (
 /obj/structure/iv_stand,
@@ -7058,7 +6958,7 @@
 /obj/item/device/drone_designator{
 	network = "torch_transport"
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "pQ" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -7077,7 +6977,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "pS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7113,10 +7013,11 @@
 	name = "Expedition Prep";
 	req_access = list("ACCESS_RESTRICTED")
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "pV" = (
-/obj/machinery/vending/medical,
+/obj/machinery/cell_charger,
+/obj/structure/table/steel,
 /turf/simulated/floor/warhammer/surgerynew,
 /area/vacant/infirmary)
 "pW" = (
@@ -7179,20 +7080,20 @@
 /area/maintenance/fifthdeck/fore)
 "qd" = (
 /obj/structure/dispenser/oxygen,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "qe" = (
 /obj/structure/closet/toolcloset/excavation,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "qf" = (
 /obj/structure/closet/secure_closet/secure_closet/xenoarchaeologist_torch,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "qg" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/shovel{
 	pixel_x = -5
 	},
@@ -7205,7 +7106,7 @@
 /obj/item/pickaxe,
 /obj/item/shovel,
 /obj/item/pickaxe,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "qh" = (
 /obj/structure/closet/secure_closet/prospector,
@@ -7213,10 +7114,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "qi" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7228,11 +7129,11 @@
 /obj/item/storage/ore,
 /obj/item/storage/belt/archaeology,
 /obj/item/storage/firstaid/radiation,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "qj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "qk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
@@ -7242,7 +7143,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "ql" = (
 /obj/wallframe_spawn/no_grille,
@@ -7251,11 +7152,11 @@
 /area/quartermaster/expedition)
 "qm" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "qn" = (
 /obj/machinery/suit_storage_unit/mining,
@@ -7265,20 +7166,20 @@
 	},
 /obj/floor_decal/corner/brown/half,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "qo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "qp" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "qq" = (
 /obj/machinery/door/firedoor,
@@ -7293,7 +7194,7 @@
 	name = "Expedition Prep";
 	req_access = list("ACCESS_RESTRICTED")
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "qr" = (
 /obj/machinery/light_switch{
@@ -7307,7 +7208,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "qu" = (
 /obj/machinery/light_switch{
@@ -7326,7 +7227,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "qv" = (
 /obj/machinery/alarm{
@@ -7412,7 +7313,6 @@
 /turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fifthdeck/aft)
 "qI" = (
-/obj/catwalk_plated,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -7425,19 +7325,19 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "qJ" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 1
+/obj/structure/hivedecor/statue8,
+/obj/structure/torchwall{
+	dir = 8
 	},
-/obj/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/firecloset,
-/obj/machinery/rotating_alarm/security_alarm,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "qK" = (
-/obj/catwalk_plated,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -7445,6 +7345,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "qL" = (
@@ -7455,10 +7358,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/torchwall{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "qM" = (
 /obj/structure/cable/green{
@@ -7473,7 +7376,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "qN" = (
-/obj/catwalk_plated,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -7484,6 +7386,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "qO" = (
@@ -7493,9 +7398,8 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/floor_decal/corner/mauve/half,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "qP" = (
 /obj/structure/cable{
@@ -7512,7 +7416,7 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "qQ" = (
 /obj/machinery/door/blast/shutters{
@@ -7524,16 +7428,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "qR" = (
-/obj/floor_decal/corner/mauve{
-	dir = 6
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "qS" = (
 /obj/structure/cable/green{
@@ -7564,7 +7465,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "qU" = (
 /obj/machinery/light/small{
@@ -7573,7 +7474,7 @@
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Fifth Deck Substation Bypass"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "qV" = (
 /obj/structure/cable/cyan{
@@ -7635,7 +7536,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "qZ" = (
 /obj/structure/cable/green{
@@ -7650,7 +7551,7 @@
 /obj/machinery/power/smes/buildable/preset/torch/substation{
 	RCon_tag = "Substation - 5th Deck"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "ra" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7669,7 +7570,7 @@
 "rb" = (
 /obj/wallframe_spawn/reinforced,
 /obj/structure/girder,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "rc" = (
 /obj/machinery/power/sensor{
@@ -7685,7 +7586,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "re" = (
 /obj/machinery/door/firedoor,
@@ -7698,7 +7599,7 @@
 	name = "Fifth Deck Substation";
 	req_access = list("ACCESS_MECHANICUS")
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "rg" = (
 /obj/structure/cable/green{
@@ -7836,7 +7737,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "rt" = (
 /obj/structure/cable/green{
@@ -7884,7 +7785,7 @@
 	name = "Fifth Deck Substation";
 	req_access = list("ACCESS_MECHANICUS")
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "ry" = (
 /obj/structure/cable{
@@ -7958,15 +7859,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/fore)
 "rF" = (
 /obj/machinery/power/smes/buildable/preset/torch/hangar{
 	RCon_tag = "Substation - Hangar"
 	},
 /obj/structure/cable/cyan,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "rG" = (
 /obj/structure/cable/green{
@@ -8029,12 +7929,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "rM" = (
-/obj/catwalk_plated,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -8043,10 +7940,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "rN" = (
-/obj/catwalk_plated,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -8059,6 +7958,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "rO" = (
@@ -8069,7 +7971,7 @@
 	dir = 4
 	},
 /obj/machinery/tele_beacon,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "rP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8078,20 +7980,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "rQ" = (
-/obj/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "rR" = (
-/obj/catwalk_plated,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -8105,19 +8008,26 @@
 	name = "Pilots Lounge";
 	sort_type = "Pilot's Lounge"
 	},
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "rS" = (
-/obj/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/catwalk_plated{
+	color = "grey"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "rT" = (
-/obj/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/catwalk_plated{
+	color = "grey"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
@@ -8149,7 +8059,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "rW" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/bodybag,
 /obj/item/storage/box/autoinjectors,
 /turf/simulated/floor/warhammer/surgerynew,
@@ -8227,9 +8137,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/fore)
 "sf" = (
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+/obj/structure/torchwall{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/fore)
@@ -8299,29 +8208,29 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 8
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "sn" = (
-/obj/floor_decal/corner/mauve/mono,
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "so" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/turf/simulated/floor/newsteel/dark2,
+/obj/structure/torchwall{
+	dir = 8
+	},
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fifthdeck/fore)
 "sp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "sq" = (
 /obj/decal/cleanable/dirt,
@@ -8354,7 +8263,7 @@
 	icon_state = "4-8"
 	},
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "su" = (
 /obj/structure/cable/green{
@@ -8399,7 +8308,7 @@
 /obj/machinery/atmospherics/binary/pump/on{
 	name = "starboard thrust pump"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "sC" = (
 /obj/structure/cable/green{
@@ -8422,7 +8331,7 @@
 /obj/structure/fuel_port{
 	pixel_x = 32
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "sI" = (
 /obj/landmark{
@@ -8463,7 +8372,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "sN" = (
 /obj/structure/bed/padded,
@@ -8541,8 +8450,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/fore)
 "tc" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -8666,7 +8574,7 @@
 	},
 /obj/wallframe_spawn/reinforced,
 /obj/structure/girder,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/substation/fifthdeck)
 "tn" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -8693,7 +8601,7 @@
 	name = "Expedition Prep";
 	req_access = list("ACCESS_RESTRICTED")
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "tr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -8773,7 +8681,7 @@
 	start_pressure = 4559.63
 	},
 /obj/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "tx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8875,7 +8783,9 @@
 /turf/simulated/floor/warhammer/plating,
 /area/shuttle/petrov/hallwaya)
 "tO" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 4
 	},
@@ -8932,7 +8842,7 @@
 "tV" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/floor_decal/industrial/outline,
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "tW" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -9087,7 +8997,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
 "um" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9121,7 +9033,9 @@
 /turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fifthdeck/aft)
 "uo" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -9170,7 +9084,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "ur" = (
 /obj/structure/cable/green{
@@ -9184,7 +9098,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "ut" = (
 /obj/structure/cable/green{
@@ -9192,14 +9106,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "uu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "uv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9229,7 +9143,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "ux" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/random/maintenance,
 /obj/random/maintenance,
 /obj/random/maintenance,
@@ -9239,18 +9153,16 @@
 "uy" = (
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
-/obj/random/powercell,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fifthdeck/fore)
 "uz" = (
 /obj/random/torchcloset,
-/obj/random/maintenance,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fifthdeck/fore)
 "uA" = (
 /obj/structure/table/steel,
-/obj/random/maintenance,
-/obj/random/maintenance,
+/obj/random/loot/armorinserts,
+/obj/random/loot/heavymelee,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fifthdeck/fore)
 "uB" = (
@@ -9368,7 +9280,7 @@
 /obj/machinery/pipedispenser{
 	anchored = 1
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "uO" = (
 /obj/structure/cable/cyan{
@@ -9436,15 +9348,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
-"uU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "uV" = (
@@ -9528,8 +9431,7 @@
 "vj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
 "vm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9550,7 +9452,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "vo" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper_bin{
 	pixel_x = 1;
 	pixel_y = 9
@@ -9604,7 +9506,7 @@
 	dir = 1
 	},
 /obj/floor_decal/industrial/outline/red,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/atmos)
 "vt" = (
 /obj/structure/shuttle/engine/heater{
@@ -9686,18 +9588,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "vL" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/device/flashlight/lamp,
+/obj/structure/table/steel,
+/obj/random/loot/randomcolonyitems,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "vM" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
+/obj/structure/table/steel,
 /obj/random/junk,
 /obj/random/maintenance/solgov,
+/obj/item/device/flashlight/lamp,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "vN" = (
@@ -9749,7 +9648,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "wc" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled/techfloor,
@@ -9792,10 +9691,6 @@
 "wj" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
-"wk" = (
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "wl" = (
 /obj/structure/handrail{
 	dir = 8
@@ -9815,7 +9710,7 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/phoron)
 "wn" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/mask/gas,
 /obj/machinery/light{
@@ -9829,7 +9724,7 @@
 	},
 /obj/floor_decal/industrial/outline/blue,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "ws" = (
 /turf/simulated/wall/r_wall/hull,
@@ -9843,7 +9738,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "wu" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -9874,7 +9769,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/airlock)
 "wx" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/device/integrated_electronics/wirer,
 /obj/item/device/integrated_electronics/debugger{
 	pixel_x = -5
@@ -9952,7 +9847,7 @@
 	start_pressure = 1013.25
 	},
 /obj/floor_decal/industrial/outline/orange,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "wL" = (
 /obj/structure/cable/cyan{
@@ -9988,8 +9883,17 @@
 	dir = 1;
 	start_pressure = 1013.25
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
+"wR" = (
+/obj/paint/sun,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/wall/titanium,
+/area/exploration_shuttle/cockpit)
 "wS" = (
 /obj/structure/sign/solgov,
 /turf/simulated/wall/prepainted,
@@ -10074,7 +9978,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "xh" = (
 /obj/wallframe_spawn/reinforced/titanium,
@@ -10097,7 +10001,7 @@
 "xm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/meter,
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/plating,
 /area/exploration_shuttle/fuel)
 "xn" = (
 /obj/floor_decal/industrial/outline{
@@ -10113,10 +10017,10 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "xr" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/anodevice{
 	pixel_x = 3;
 	pixel_y = 3
@@ -10182,7 +10086,7 @@
 /area/exploration_shuttle/airlock)
 "xA" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/armor/grim/bio_suit/anomaly,
 /obj/item/clothing/mask/breath,
@@ -10519,7 +10423,7 @@
 /turf/simulated/floor/warhammer/plating,
 /area/shuttle/petrov/hallwaya)
 "yy" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/crowbar,
 /obj/item/flame/lighter/random,
 /obj/item/storage/box/evidence,
@@ -10655,11 +10559,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"yR" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/paint/meatstation,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/equipment)
 "yU" = (
 /obj/machinery/atmospherics/unary/heater,
 /obj/machinery/light{
@@ -10673,7 +10572,9 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
 "yW" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -10699,7 +10600,9 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
 "zf" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/light/spot{
 	dir = 8
 	},
@@ -10744,11 +10647,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell1)
-"zl" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/paint/meatstation,
-/turf/simulated/floor/warhammer/metal/alt,
-/area/shuttle/petrov/rnd)
 "zm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/button/blast_door{
@@ -10763,7 +10661,7 @@
 	pixel_y = -25
 	},
 /obj/machinery/artifact_harvester,
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
 "zn" = (
@@ -10810,7 +10708,6 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/phoron)
 "zv" = (
-/obj/floor_decal/industrial/warning/corner,
 /obj/machinery/button/blast_door{
 	id_tag = "hanger_atmos_storage";
 	name = "Atmospheric Storage Door Control";
@@ -10824,7 +10721,7 @@
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10867,7 +10764,7 @@
 "zL" = (
 /obj/structure/table/steel,
 /obj/item/device/flashlight/lamp/green,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "zO" = (
 /obj/floor_decal/industrial/hatch/yellow,
@@ -10881,6 +10778,15 @@
 /obj/machinery/meter,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
+"zT" = (
+/obj/paint/sun,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/titanium,
+/area/exploration_shuttle/crew)
 "zW" = (
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -10890,7 +10796,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "zZ" = (
 /obj/structure/disposalpipe/segment{
@@ -11086,7 +10992,7 @@
 "AT" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_soft/full,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "AU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11169,7 +11075,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "Bm" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -11215,7 +11123,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -11227,7 +11135,7 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
 "Bu" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/storage/box/monkeycubes,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
@@ -11314,7 +11222,7 @@
 /area/shuttle/petrov/control)
 "BO" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/stack/material/plastic/ten,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/rnd)
@@ -11427,7 +11335,7 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "Ct" = (
 /obj/random_multi/single_item/piano,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "Cy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11527,13 +11435,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "CR" = (
-/obj/floor_decal/industrial/warning/corner{
-	dir = 4;
-	icon_state = "warningcorner"
-	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -11548,7 +11452,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "CS" = (
 /obj/paint/meatstation,
@@ -11561,7 +11465,7 @@
 	},
 /area/shuttle/petrov/rd)
 "CV" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/device/scanner/health,
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -11674,7 +11578,7 @@
 	name = "Blast Shutter Control";
 	pixel_x = 26
 	},
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "Dm" = (
 /obj/structure/cable/cyan{
@@ -11682,15 +11586,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "Dn" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/turf/simulated/floor/newsteel/dark2,
+/obj/structure/table/rack/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "Do" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -11798,7 +11702,7 @@
 	dir = 1;
 	level = 2
 	},
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/stack/flag/red,
 /obj/item/stack/flag/red,
 /obj/item/stack/flag/red,
@@ -11964,7 +11868,7 @@
 "Eg" = (
 /obj/structure/closet/secure_closet/prospector,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "Ek" = (
 /obj/structure/disposalpipe/segment{
@@ -11985,7 +11889,7 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
 "El" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
 /obj/item/device/scanner/reagent,
@@ -12026,7 +11930,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Et" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -12081,13 +11987,13 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "EC" = (
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "EE" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
@@ -12128,7 +12034,7 @@
 "EK" = (
 /obj/floor_decal/industrial/outline/blue,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "EL" = (
 /obj/structure/cable{
@@ -12262,7 +12168,7 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell2)
 "FD" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/device/flashlight/lamp,
 /obj/machinery/light/small{
 	dir = 4;
@@ -12285,6 +12191,17 @@
 	},
 /turf/space,
 /area/space)
+"FT" = (
+/obj/paint/sun,
+/obj/machinery/pointdefense{
+	initial_id_tag = "charon"
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/wall/titanium,
+/area/exploration_shuttle/cockpit)
 "FU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -12318,7 +12235,7 @@
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "Gb" = (
 /obj/machinery/door/window/southright{
@@ -12403,7 +12320,7 @@
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
 "Gr" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/random/tool,
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -12425,7 +12342,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Gw" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -12472,6 +12391,11 @@
 /obj/machinery/meter,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
+"GJ" = (
+/obj/structure/table/steel,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/tiled/techmaint,
+/area/maintenance/fifthdeck/fore)
 "GK" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -12545,7 +12469,7 @@
 	pixel_x = -2;
 	pixel_y = 6
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "GQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12667,18 +12591,10 @@
 	start_pressure = 4769
 	},
 /obj/floor_decal/industrial/outline/orange,
-/obj/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "Ho" = (
-/obj/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/west,
 /area/quartermaster/hangar)
 "Hr" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -12724,7 +12640,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Hw" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/scanning_module,
 /obj/item/device/paicard,
@@ -12756,7 +12672,7 @@
 "HE" = (
 /obj/structure/table/steel,
 /obj/landmark/corpse/doctor,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "HF" = (
 /obj/machinery/vitals_monitor,
@@ -12839,7 +12755,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "HR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12889,7 +12805,9 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/toxins)
 "HY" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12916,19 +12834,16 @@
 /area/shuttle/petrov/equipment)
 "Ia" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "Ib" = (
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/analysis)
 "Ic" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/capacitor,
 /obj/item/stock_parts/capacitor,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -12977,7 +12892,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "Iv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13052,7 +12967,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "IO" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/light/spot{
 	dir = 4
 	},
@@ -13149,7 +13066,9 @@
 /turf/simulated/wall/ocp_wall,
 /area/shuttle/petrov/cell1)
 "Jn" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
@@ -13314,7 +13233,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "JM" = (
 /obj/structure/bed/chair/shuttle/black{
@@ -13332,6 +13251,13 @@
 /obj/paint/meatstation,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
+"JR" = (
+/obj/structure/bed/chair/shuttle/blue,
+/obj/machinery/pointdefense_control{
+	initial_id_tag = "charon"
+	},
+/turf/simulated/floor/warhammer/plating,
+/area/exploration_shuttle/crew)
 "JS" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -13399,10 +13325,10 @@
 /obj/machinery/drone_pad{
 	initial_id_tag = "torch_transport"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "Kh" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/folder/nt,
 /obj/item/stack/nanopaste,
 /obj/machinery/newscaster{
@@ -13484,7 +13410,9 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/eva)
 "KA" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -13676,12 +13604,6 @@
 	},
 /turf/simulated/floor/warhammer/plating,
 /area/shuttle/petrov/hallwaya)
-"Li" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/paint/meatstation,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/warhammer/metal/alt,
-/area/shuttle/petrov/phoron)
 "Lj" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -13733,7 +13655,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "Lq" = (
 /obj/structure/cable{
@@ -13769,12 +13691,11 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell3)
 "Lx" = (
-/obj/floor_decal/corner/mauve/mono,
 /obj/structure/closet/secure_closet/explorer,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/item/material/twohanded/ravenor/sword/chopper/heavy,
 /obj/random/loot/basicarmorbundle,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "LA" = (
 /obj/paint/meatstation,
@@ -13787,7 +13708,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "LC" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/device/flashlight,
 /obj/item/device/radio,
 /obj/item/crowbar,
@@ -13817,7 +13738,7 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/analysis)
 "LF" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -13882,7 +13803,7 @@
 	pixel_x = 22;
 	pixel_y = -22
 	},
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "LU" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -14037,10 +13958,15 @@
 	},
 /turf/simulated/floor/warhammer/plating,
 /area/shuttle/petrov/control)
+"Mw" = (
+/obj/structure/table/rack/dark,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techmaint,
+/area/maintenance/fifthdeck/fore)
 "Mx" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
+/obj/structure/table/rack/dark,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /turf/simulated/floor/warhammer/metal/alt,
@@ -14124,7 +14050,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/north,
 /area/quartermaster/storage)
 "MP" = (
 /obj/structure/disposalpipe/segment{
@@ -14145,7 +14071,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "MQ" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/reagent_temperature,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/analysis)
@@ -14159,7 +14085,7 @@
 /obj/structure/closet/medical_wall/filled{
 	pixel_y = 32
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/north,
 /area/quartermaster/storage)
 "MX" = (
 /obj/machinery/light{
@@ -14186,10 +14112,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/cockpit)
 "Ne" = (
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "Nf" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/analysis)
@@ -14374,9 +14300,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/control)
 "NP" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
+/obj/structure/table/rack/dark,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/warhammer/metal/alt,
@@ -14499,7 +14423,7 @@
 /obj/random/loot/sidearmbundle,
 /obj/random/loot/randomsupply/engineering,
 /obj/random/loot/randomsupply/tech,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "Ol" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -14542,10 +14466,10 @@
 	pixel_x = 32
 	},
 /obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "OC" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/stack/material/phoron,
 /obj/item/stack/material/phoron,
 /obj/machinery/alarm{
@@ -14567,7 +14491,7 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
 "OG" = (
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "OH" = (
 /obj/structure/cable/cyan{
@@ -14654,7 +14578,9 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/quartermaster/exploration)
 "OY" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -14676,7 +14602,7 @@
 /area/shuttle/petrov/toxins)
 "Pd" = (
 /obj/random_multi/single_item/runtime,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "Pe" = (
 /obj/floor_decal/industrial/warning{
@@ -14718,7 +14644,7 @@
 /turf/simulated/floor/warhammer/plating,
 /area/shuttle/petrov/hallwaya)
 "Pr" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 8
 	},
@@ -14965,10 +14891,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/equipment)
 "QA" = (
-/obj/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "QB" = (
 /obj/structure/cable/cyan{
@@ -15002,10 +14925,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "QF" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/stack/material/steel/fifty,
 /obj/item/stack/material/glass/fifty,
 /turf/simulated/floor/warhammer/metal/alt,
@@ -15031,7 +14954,7 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/phoron)
 "QK" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/device/scanner/reagent,
 /obj/item/device/scanner/spectrometer/adv,
 /turf/simulated/floor/warhammer/metal/alt,
@@ -15068,7 +14991,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "QW" = (
 /obj/structure/cable/cyan{
@@ -15251,9 +15174,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "Rz" = (
-/obj/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -15265,7 +15185,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "RB" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -15315,7 +15235,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/anobattery{
 	pixel_x = -6;
 	pixel_y = 2
@@ -15351,7 +15271,9 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell2)
 "Sc" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15374,7 +15296,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
 "Sg" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/computer/atmoscontrol/laptop{
 	monitored_alarm_ids = list("petrov1","petrov2","petrov3");
@@ -15438,14 +15360,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Sy" = (
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "Sz" = (
 /obj/structure/closet/secure_closet/scientist_torch,
@@ -15463,19 +15381,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "SE" = (
-/obj/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "SF" = (
-/obj/structure/table/standard,
 /obj/machinery/reagent_temperature,
 /obj/machinery/alarm{
 	pixel_y = 23;
 	req_access = list("ACCESS_MECHANICUS_COMMAND")
 	},
+/obj/structure/table/rack/xenos,
 /turf/simulated/floor/plating,
 /area/vacant/infirmary)
 "SH" = (
@@ -15547,9 +15464,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "SN" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
+/obj/structure/table/rack/dark,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/rnd)
 "SQ" = (
@@ -15591,7 +15506,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "SW" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -15712,10 +15629,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "Tx" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/paint/meatstation,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/analysis)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/warhammer{
+	req_access = list("ACCESS_RESTRICTED");
+	name = "Expedition Storage"
+	},
+/turf/simulated/floor/warhammer/metal,
+/area/quartermaster/exploration)
 "TA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15735,7 +15663,7 @@
 /obj/structure/table/steel,
 /obj/item/storage/box/glasses,
 /obj/item/storage/box/glasses/rocks,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "TD" = (
 /obj/structure/cable/cyan{
@@ -15776,7 +15704,7 @@
 /turf/simulated/floor/warhammer/plating,
 /area/shuttle/petrov/control)
 "TH" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/cell_charger,
 /obj/item/screwdriver{
 	pixel_y = 15
@@ -15792,7 +15720,7 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 4
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "TM" = (
 /obj/structure/table/glass,
@@ -15961,7 +15889,7 @@
 /turf/simulated/floor/warhammer/brothel,
 /area/shuttle/petrov/rd)
 "UC" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
@@ -15978,16 +15906,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "UF" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/device/integrated_circuit_printer,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/equipment)
 "UG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition)
 "UH" = (
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "UL" = (
 /obj/item/stack/material/glass/reinforced{
@@ -15997,7 +15925,7 @@
 /obj/item/stack/material/glass,
 /obj/item/stack/material/glass,
 /obj/structure/closet/crate/warhammer/cargo,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "UM" = (
 /obj/machinery/door/airlock/research{
@@ -16015,7 +15943,7 @@
 /turf/simulated/floor/warhammer/plating,
 /area/shuttle/petrov/rd)
 "UO" = (
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "UQ" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -16051,7 +15979,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fifthdeck/aft)
 "UX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -16254,10 +16182,10 @@
 	c_tag = "Hangar - Midships Port";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/hangar)
 "VO" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/storage/belt/archaeology,
 /obj/item/storage/belt/archaeology,
 /obj/item/storage/belt/archaeology,
@@ -16285,7 +16213,7 @@
 /turf/simulated/floor/warhammer/brothel,
 /area/shuttle/petrov/rd)
 "VU" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/device/scanner/xenobio,
 /obj/item/device/scanner/xenobio,
 /obj/item/device/scanner/xenobio,
@@ -16459,11 +16387,11 @@
 "WH" = (
 /obj/floor_decal/corner/brown/half,
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/turf/simulated/floor/newsteel/dark2,
+/obj/structure/table/rack/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "WO" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/disk/tech_disk,
 /obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
@@ -16749,7 +16677,6 @@
 /area/shuttle/petrov/isolation)
 "Yg" = (
 /obj/structure/table/steel,
-/obj/item/book/manual/nt_regs,
 /obj/item/folder/nt,
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -16773,7 +16700,7 @@
 	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/warhammer/cargo,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage)
 "Yk" = (
 /obj/paint/meatstation,
@@ -16850,7 +16777,9 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/toxins)
 "Yu" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -16931,7 +16860,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/obstruction,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/bar)
 "YJ" = (
 /turf/simulated/floor/warhammer/metal/alt,
@@ -17061,7 +16990,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/newsteel/dark2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/eva)
 "Ze" = (
 /obj/machinery/computer/modular/preset/civilian,
@@ -17079,7 +17008,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber/broken,
-/turf/simulated/floor/newsteel/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/expedition/atmos)
 "Zm" = (
 /obj/structure/cable{
@@ -17087,8 +17016,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
 "Zn" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
@@ -17108,7 +17036,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
 "Zo" = (
-/obj/catwalk_plated,
+/obj/catwalk_plated{
+	color = "grey"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17217,8 +17147,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "ZF" = (
-/obj/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/torchwall{
+	dir = 8
+	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/exploration)
 "ZG" = (
 /turf/simulated/wall/r_wall/hull,
@@ -17273,7 +17205,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "ZU" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/device/geiger,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -28919,12 +28851,12 @@ an
 an
 an
 an
-pi
+GJ
 pi
 uB
 yq
 ux
-ux
+Mw
 an
 an
 an
@@ -29715,7 +29647,7 @@ er
 uM
 uP
 uT
-uU
+tb
 uV
 uW
 pl
@@ -30323,7 +30255,7 @@ DF
 Rj
 pp
 db
-pk
+kH
 ip
 wF
 iv
@@ -30726,10 +30658,10 @@ yq
 mh
 fl
 ct
-jO
+sn
 pk
 fl
-wF
+oW
 iy
 iy
 wF
@@ -31132,14 +31064,14 @@ fl
 so
 mN
 sm
-hh
-jO
+MR
+MR
 rO
-oY
-oZ
+MR
+MR
 qR
-pa
-sn
+MR
+MR
 fl
 mH
 uT
@@ -31337,7 +31269,7 @@ fl
 fl
 jO
 rP
-oU
+MR
 kS
 eu
 eu
@@ -31536,7 +31468,7 @@ kl
 kl
 kl
 oJ
-kH
+fl
 au
 rQ
 aI
@@ -31739,11 +31671,11 @@ kl
 kl
 kl
 MR
-jO
+MR
 rS
-oY
+MR
 wS
-hw
+hz
 iu
 kf
 kk
@@ -31754,7 +31686,7 @@ kE
 kC
 kG
 kC
-kJ
+Tx
 mn
 nr
 ns
@@ -31933,7 +31865,7 @@ hk
 hk
 jJ
 jA
-lq
+jA
 fl
 kl
 kl
@@ -31941,11 +31873,11 @@ kl
 kl
 kl
 MR
-jO
-rS
-oU
+MR
+aF
+MR
 kt
-hw
+hz
 kg
 Pd
 ki
@@ -32145,7 +32077,7 @@ kl
 MR
 po
 rT
-oW
+MR
 wS
 kn
 fH
@@ -32156,7 +32088,7 @@ OX
 iQ
 hz
 hz
-kI
+kw
 kv
 eu
 mx
@@ -32346,7 +32278,7 @@ kl
 kl
 fl
 qJ
-aF
+MR
 oX
 eu
 iO
@@ -32356,7 +32288,7 @@ kA
 kz
 OX
 kr
-eS
+hz
 ku
 ZF
 kQ
@@ -32943,9 +32875,9 @@ eM
 aX
 cy
 Ho
-eU
-eU
-eU
+Ho
+Ho
+Ho
 Ho
 Ho
 Ho
@@ -33352,7 +33284,7 @@ bo
 bo
 gY
 cr
-cP
+cO
 dg
 dx
 cq
@@ -33548,8 +33480,8 @@ lZ
 EC
 ih
 ee
-gY
-gY
+FT
+wR
 bv
 bT
 gY
@@ -33949,7 +33881,7 @@ EK
 tV
 lz
 lY
-UH
+md
 ih
 ee
 aA
@@ -34357,7 +34289,7 @@ UH
 ih
 ee
 IS
-bh
+JR
 bz
 bY
 cm
@@ -35366,13 +35298,13 @@ aJ
 gw
 fB
 ee
-IS
-IS
+cp
+zT
 bE
 cl
 IS
 cL
-df
+de
 dw
 BQ
 eg
@@ -35767,7 +35699,7 @@ aW
 aW
 sr
 aJ
-UH
+md
 nN
 ee
 bi
@@ -35973,9 +35905,9 @@ kb
 nO
 eH
 eT
-eV
-eV
-eV
+eT
+eT
+eT
 eT
 eT
 eT
@@ -35993,7 +35925,7 @@ eT
 eT
 eT
 eT
-hY
+eT
 nU
 nK
 aJ
@@ -38623,7 +38555,7 @@ jc
 jc
 je
 jg
-jg
+kI
 lo
 ts
 pC
@@ -39400,7 +39332,7 @@ QL
 TC
 HE
 Ne
-XI
+Ne
 XI
 aD
 aK
@@ -39430,7 +39362,7 @@ Em
 hR
 iG
 mD
-jl
+lq
 jl
 Em
 uh
@@ -40413,7 +40345,7 @@ TA
 Ku
 hf
 An
-wk
+aW
 Na
 HM
 ZG
@@ -43861,7 +43793,7 @@ bu
 xA
 QW
 FU
-zl
+Lt
 WO
 AL
 vc
@@ -44063,7 +43995,7 @@ bu
 xA
 BM
 Wn
-zl
+Lt
 Ic
 Kh
 Hw
@@ -44871,7 +44803,7 @@ ZV
 Mm
 As
 Wn
-Li
+Yk
 Wz
 zs
 YJ
@@ -45070,10 +45002,10 @@ vo
 Fo
 Vk
 MQ
-Tx
+bb
 BM
 Wn
-Li
+Yk
 wn
 El
 OC
@@ -45272,7 +45204,7 @@ TH
 Ch
 LF
 mm
-Tx
+bb
 QW
 FU
 Wl
@@ -45469,9 +45401,9 @@ bb
 bb
 bb
 bb
-Tx
-Tx
-Tx
+bb
+bb
+bb
 bb
 bb
 bb
@@ -45676,7 +45608,7 @@ NP
 IC
 Mz
 wY
-yR
+LN
 Bo
 Yb
 JP
@@ -45878,7 +45810,7 @@ XW
 Xs
 XW
 QK
-yR
+LN
 Og
 Dq
 Ec

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1,11 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ab" = (
-/obj/structure/table/standard,
-/obj/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "ac" = (
 /obj/shuttle_landmark/skipjack/deck5{
 	name = "4th Deck, Aft Starboard"
@@ -27,12 +20,6 @@
 "af" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/galley)
-"ag" = (
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "ah" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fourthdeck/aft)
@@ -57,7 +44,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/fourthdeck/forestarboard)
 "ao" = (
 /obj/structure/ladder/up,
@@ -104,7 +91,7 @@
 	id_tag = "do_office";
 	name = "privacy shutters"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "av" = (
 /obj/floor_decal/industrial/warning,
@@ -127,7 +114,7 @@
 	id_tag = "sup_office";
 	name = "Supply Desk Shutters"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/quartermaster/office)
 "ay" = (
 /obj/machinery/door/firedoor,
@@ -302,12 +289,9 @@
 "bi" = (
 /obj/shuttle_landmark/escape_pod/start/pod6,
 /obj/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/shuttle/escape_pod6/station)
 "bk" = (
-/obj/floor_decal/corner/red/half{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -395,13 +379,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "bx" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "by" = (
 /obj/structure/cable/green{
@@ -450,7 +431,7 @@
 /area/tcommsat/chamber)
 "bE" = (
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fourthdeck/aft)
 "bF" = (
 /obj/structure/cable/green{
@@ -542,7 +523,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/fourthdeck/forestarboard)
 "bT" = (
 /obj/structure/cable/green{
@@ -644,9 +625,6 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/obj/floor_decal/corner/brown{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/cargo_lift)
 "cf" = (
@@ -663,15 +641,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/chamber)
-"cj" = (
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "ck" = (
 /obj/machinery/computer/telecomms/monitor{
 	dir = 4;
@@ -699,7 +668,7 @@
 	pixel_y = 32
 	},
 /obj/structure/table/marble,
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "cr" = (
 /obj/structure/adherent_bath,
@@ -708,11 +677,6 @@
 	},
 /turf/simulated/floor/crystal,
 /area/crew_quarters/adherent)
-"ct" = (
-/obj/floor_decal/corner/brown,
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
 "cu" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -766,7 +730,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/fourthdeck/forestarboard)
 "cB" = (
 /obj/machinery/light/small{
@@ -807,10 +771,7 @@
 /area/command/captainmess)
 "cF" = (
 /obj/machinery/door/firedoor,
-/obj/floor_decal/corner/brown{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "cI" = (
 /obj/machinery/power/terminal{
@@ -993,11 +954,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "ds" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -1141,7 +1099,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/command/captainmess)
 "dS" = (
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/fancyfloor/carpet/blue,
 /area/command/captainmess)
 "dT" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -1153,7 +1111,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "dU" = (
 /obj/structure/ladder,
@@ -1240,11 +1198,8 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/floor_decal/corner/red/half{
-	dir = 8
-	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "el" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -1264,7 +1219,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "em" = (
 /obj/structure/table/woodentable/walnut,
@@ -1304,7 +1259,7 @@
 	locked = 1;
 	name = "Escape Pod One Hatch"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/shuttle/escape_pod6/station)
 "ev" = (
 /obj/structure/catwalk,
@@ -1354,7 +1309,7 @@
 	locked = 1;
 	name = "Escape Pod Two Hatch"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/shuttle/escape_pod7/station)
 "eA" = (
 /obj/structure/cable/green{
@@ -1373,13 +1328,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 8
+	},
 /area/command/captainmess)
 "eC" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/drinks/glass2/carafe,
 /obj/item/reagent_containers/food/drinks/pitcher,
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "eE" = (
 /obj/structure/cable/green{
@@ -1462,9 +1419,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/floor_decal/corner/green/half{
-	dir = 8
-	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8;
 	icon_state = "warningcorner"
@@ -1485,11 +1439,7 @@
 /area/hallway/primary/fourthdeck/aft)
 "fa" = (
 /obj/structure/bookcase,
-/obj/item/book/manual/solgov_law,
-/obj/item/book/manual/sol_sop,
-/obj/item/book/manual/military_law,
-/obj/item/book/manual/nt_regs,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "fb" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -1511,11 +1461,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/aft)
-"fi" = (
-/obj/structure/closet/crate,
-/obj/random/powercell,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/storage/auxillary/starboard)
 "fj" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -1523,12 +1468,6 @@
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck - Fore Starboard Airlock";
 	dir = 4
-	},
-/obj/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/floor_decal/corner/white{
-	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -1548,18 +1487,6 @@
 "fl" = (
 /turf/simulated/wall/prepainted,
 /area/command/pathfinder)
-"fp" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22;
-	pixel_y = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "fq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
@@ -1682,7 +1609,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "fE" = (
 /obj/machinery/ntnet_relay,
@@ -1750,22 +1677,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
-"fY" = (
-/obj/structure/table/rack,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tool,
-/obj/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/storage/auxillary/starboard)
-"fZ" = (
-/obj/structure/closet/crate,
-/obj/random/toy,
-/obj/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/storage/auxillary/starboard)
 "ga" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -1775,12 +1688,6 @@
 	pixel_x = -25
 	},
 /obj/structure/flora/pottedplant/large,
-/obj/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
 "gb" = (
@@ -1795,16 +1702,12 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "gc" = (
-/obj/floor_decal/corner/mauve/mono,
-/obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/pathfinder,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "gd" = (
-/obj/floor_decal/corner/mauve/mono,
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/ship/navigation,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "gf" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -1886,10 +1789,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/floor_decal/corner/brown/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "gr" = (
 /obj/machinery/power/apc{
@@ -1907,7 +1807,7 @@
 "gu" = (
 /obj/structure/table/marble,
 /obj/item/storage/box/glasses/pint,
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "gw" = (
 /obj/structure/table/marble,
@@ -1917,7 +1817,7 @@
 	pixel_x = 22;
 	pixel_y = 4
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "gx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1964,7 +1864,7 @@
 "gM" = (
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "gU" = (
 /obj/structure/catwalk,
@@ -1987,57 +1887,6 @@
 	},
 /turf/simulated/open,
 /area/maintenance/fourthdeck/port)
-"gY" = (
-/obj/structure/closet/l3closet/general,
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/storage/auxillary/starboard)
-"gZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/floor_decal/techfloor{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/storage/auxillary/starboard)
-"ha" = (
-/obj/floor_decal/industrial/warning/corner,
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "starboardaux_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/storage/auxillary/starboard)
-"hb" = (
-/obj/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/obj/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "starboardaux_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -24;
-	pixel_y = 6;
-	req_access = list("ACCESS_DAUNTLESS")
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
 "hc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2045,7 +1894,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "hd" = (
-/obj/floor_decal/corner/mauve/mono,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -2055,23 +1903,17 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "he" = (
-/obj/floor_decal/corner/mauve{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "hf" = (
-/obj/floor_decal/corner/mauve{
-	dir = 5
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -2084,24 +1926,8 @@
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
-"hg" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "hh" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
@@ -2171,7 +1997,9 @@
 /obj/structure/bed/chair/wood/wings/mahogany{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 4
+	},
 /area/command/captainmess)
 "hp" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -2186,7 +2014,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "hq" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -2200,14 +2028,16 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "hr" = (
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -25
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 8
+	},
 /area/crew_quarters/lounge)
 "hs" = (
 /obj/structure/bed/chair/shuttle{
@@ -2222,7 +2052,6 @@
 "ht" = (
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
-/obj/random/powercell,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/starboard)
 "hu" = (
@@ -2239,8 +2068,7 @@
 	name = "Hangar Deck Hallway Shutters";
 	opacity = 0
 	},
-/obj/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "hw" = (
 /obj/structure/cable{
@@ -2278,80 +2106,7 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/fourthdeck/starboard)
-"hE" = (
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
-/area/storage/primary)
-"hO" = (
-/obj/structure/table/rack,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/medical,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/storage/auxillary/starboard)
-"hP" = (
-/obj/structure/closet/crate/internals,
-/obj/random/tank,
-/obj/random/tank,
-/obj/random/tank,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/storage/auxillary/starboard)
-"hQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/floor_decal/techfloor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/storage/auxillary/starboard)
-"hR" = (
-/obj/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/storage/auxillary/starboard)
-"hS" = (
-/obj/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id_tag = "starboardaux_warehouse";
-	name = "Warehouse Shutters"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/storage/auxillary/starboard)
 "hT" = (
-/obj/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
 "hU" = (
@@ -2360,23 +2115,25 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "hV" = (
-/obj/floor_decal/corner/mauve/half{
-	dir = 8
-	},
 /obj/machinery/photocopier,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "hW" = (
-/turf/simulated/floor/tiled,
-/area/command/pathfinder)
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 6
+	},
+/area/crew_quarters/lounge)
 "hX" = (
 /obj/structure/table/standard,
 /obj/item/folder/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "hY" = (
 /obj/machinery/alarm{
@@ -2427,7 +2184,7 @@
 /area/shuttle/escape_pod6/station)
 "ic" = (
 /obj/machinery/alarm,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "id" = (
 /obj/structure/table/rack{
@@ -2452,13 +2209,6 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod7/station)
-"ii" = (
-/obj/machinery/door/firedoor,
-/obj/floor_decal/corner/brown{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
 "ij" = (
 /obj/machinery/light{
 	dir = 8
@@ -2474,7 +2224,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "io" = (
 /obj/floor_decal/corner/brown/three_quarters{
@@ -2485,7 +2235,7 @@
 	pixel_y = 26
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "ix" = (
 /turf/simulated/floor/plating,
@@ -2552,66 +2302,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "iQ" = (
-/obj/floor_decal/corner/green{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
-"iS" = (
-/turf/simulated/wall/walnut,
-/area/crew_quarters/lounge)
 "iT" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
 /obj/structure/sign/warning/pods/east{
 	pixel_y = 32
 	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
-"iZ" = (
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/storage/auxillary/starboard)
-"ja" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/storage/auxillary/starboard)
-"jb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/storage/auxillary/starboard)
-"jc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/storage/auxillary/starboard)
-"jd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/floor_decal/techfloor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/storage/auxillary/starboard)
 "je" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2625,14 +2326,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
 "jf" = (
-/obj/floor_decal/corner/mauve/half{
-	dir = 8
-	},
 /obj/machinery/papershredder,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "jg" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -2640,28 +2338,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
-"jh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "ji" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2708,7 +2386,7 @@
 	pixel_x = -24;
 	pixel_y = 6
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "js" = (
 /obj/structure/catwalk,
@@ -2747,10 +2425,7 @@
 	pixel_x = 26;
 	pixel_y = 28
 	},
-/obj/floor_decal/corner/brown/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "jE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2825,7 +2500,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "kg" = (
-/obj/floor_decal/corner/mauve/mono,
 /obj/machinery/button/windowtint{
 	id = "pathfinder_office";
 	pixel_x = -24;
@@ -2839,22 +2513,16 @@
 /obj/machinery/photocopier/faxmachine{
 	department = "Dauntless - Pathfinder"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "kh" = (
-/obj/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "ki" = (
-/obj/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -2866,23 +2534,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
-"kj" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/civilian{
-	name = "Diplomatic Meeting Room"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/crew_quarters/diplomatic_office)
 "kk" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/diplomatic_office)
@@ -3061,12 +2714,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "kX" = (
-/obj/floor_decal/corner/green{
-	dir = 6
-	},
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck - Ladders";
 	dir = 8
@@ -3088,27 +2738,6 @@
 /obj/item/tank/oxygen_emergency_double,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/eva)
-"la" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/prepainted,
-/area/storage/auxillary/starboard)
-"lb" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/mining{
-	name = "Starboard Auxiliary Storage"
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/storage/auxillary/starboard)
 "lc" = (
 /obj/structure/table/rack{
 	dir = 8
@@ -3137,7 +2766,7 @@
 	pixel_x = -24;
 	pixel_y = 6
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "ld" = (
 /obj/machinery/door/firedoor,
@@ -3173,17 +2802,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Commissary";
-	sort_type = "Commissary"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -3192,7 +2810,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "lk" = (
 /obj/structure/railing/mapped,
@@ -3207,9 +2826,6 @@
 /turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod9/station)
 "lt" = (
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3218,7 +2834,7 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "lw" = (
 /obj/machinery/washing_machine,
@@ -3285,12 +2901,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/aft)
 "lJ" = (
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/floor_decal/corner/red{
-	dir = 8
-	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 4
 	},
@@ -3318,16 +2928,13 @@
 	dir = 4
 	},
 /obj/machinery/tele_beacon,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "lR" = (
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "lU" = (
 /obj/machinery/light{
@@ -3349,26 +2956,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/walnut,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/lounge)
-"lY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "mb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eva)
@@ -3379,17 +2971,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/floor_decal/corner/blue{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "md" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
-	},
-/obj/floor_decal/corner/blue{
-	dir = 5
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -3409,7 +2995,7 @@
 /obj/structure/closet/emcloset,
 /obj/floor_decal/corner/paleblue/mono,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "mf" = (
 /obj/structure/cable/green{
@@ -3420,10 +3006,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "mg" = (
 /obj/structure/cable/green{
@@ -3431,24 +3014,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 5
-	},
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
-"mh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "mi" = (
 /obj/structure/cable/green{
@@ -3461,27 +3030,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "mj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "mk" = (
 /obj/structure/cable/green{
@@ -3492,13 +3048,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "ml" = (
 /obj/structure/cable/green{
@@ -3507,13 +3057,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "mm" = (
 /obj/structure/cable/green{
@@ -3524,13 +3068,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "mn" = (
 /obj/structure/cable/green{
@@ -3541,8 +3079,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "mo" = (
 /obj/machinery/hologram/holopad/longrange,
@@ -3550,7 +3087,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "mp" = (
 /obj/structure/cable/green{
@@ -3558,8 +3095,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "mr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3574,7 +3110,7 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "ms" = (
 /obj/structure/disposalpipe/segment,
@@ -3585,7 +3121,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "mt" = (
 /obj/structure/cable/green{
@@ -3595,18 +3131,14 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/closet/emcloset,
-/obj/floor_decal/corner/red/mono,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck Hallway - Stairs"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "my" = (
 /obj/structure/table/standard,
-/obj/floor_decal/corner/mauve/half{
-	dir = 4
-	},
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -3615,21 +3147,20 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "mz" = (
 /obj/machinery/light,
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
-/obj/floor_decal/corner/brown/half,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "mB" = (
 /obj/structure/railing/mapped,
@@ -3640,9 +3171,6 @@
 /turf/simulated/floor/shuttle_ceiling/torch/air,
 /area/quartermaster/hangar/catwalks_port)
 "mD" = (
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
@@ -3671,12 +3199,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/waterstore)
-"mK" = (
-/obj/wallframe_spawn/reinforced/polarized/no_grille{
-	id = "diplomatic_office"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/diplomatic_office)
 "mL" = (
 /obj/machinery/atmospherics/valve/shutoff/supply{
 	dir = 4
@@ -3706,9 +3228,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "mQ" = (
-/obj/floor_decal/corner/green/half{
-	dir = 8
-	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 4
 	},
@@ -3782,13 +3301,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 9
-	},
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "nl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3822,30 +3338,21 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "np" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/floor_decal/corner/red/half,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "nq" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "nr" = (
 /obj/item/device/radio/intercom{
@@ -3856,11 +3363,7 @@
 	c_tag = "Fourth Deck Hallway - Fore Starboard";
 	dir = 1
 	},
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "ns" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -3872,13 +3375,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "nt" = (
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3898,8 +3397,7 @@
 	name = "Hangar Deck Hallway Shutters";
 	opacity = 0
 	},
-/obj/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "nv" = (
 /obj/structure/sign/directions/bridge{
@@ -3931,20 +3429,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/corner/white,
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
 /obj/structure/sign/deck/fourth{
 	dir = 8;
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "nD" = (
 /obj/shuttle_landmark/escape_pod/start/pod7,
 /obj/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/shuttle/escape_pod7/station)
 "nH" = (
 /obj/structure/catwalk,
@@ -3969,7 +3463,7 @@
 	dir = 8
 	},
 /obj/random_multi/single_item/runtime,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fourthdeck/aft)
 "nT" = (
 /obj/random/ironing_board_structure,
@@ -4024,16 +3518,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "oh" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 1
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/command/captainmess)
 "ok" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4049,12 +3537,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "on" = (
-/obj/floor_decal/corner/red{
-	dir = 8
-	},
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
 /obj/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
@@ -4075,12 +3557,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "ou" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "ov" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -4090,7 +3572,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "ow" = (
 /obj/catwalk_plated,
@@ -4116,19 +3598,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
-"oz" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/teleporter/fourthdeck)
 "oA" = (
 /turf/simulated/wall/prepainted,
 /area/teleporter/fourthdeck)
-"oB" = (
-/obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/storage/primary)
 "oC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4142,15 +3616,8 @@
 /obj/machinery/telecomms/server/presets/exploration,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
-"oE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/brown/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
 "oF" = (
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "oG" = (
 /obj/structure/catwalk,
@@ -4168,18 +3635,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
-"oI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/floor_decal/corner/white,
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
 "oK" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
@@ -4202,18 +3657,12 @@
 /obj/structure/sign/ecplaque{
 	pixel_x = 30
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "oT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
-"oV" = (
-/obj/floor_decal/corner/green{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
 "oW" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -4272,11 +3721,6 @@
 /obj/random/soap,
 /turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/laundry)
-"pj" = (
-/obj/structure/table/standard,
-/obj/random_multi/single_item/punitelli,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "pl" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -4305,10 +3749,6 @@
 /area/maintenance/fourthdeck/aft)
 "py" = (
 /obj/structure/bookcase,
-/obj/item/book/manual/solgov_law,
-/obj/item/book/manual/sol_sop,
-/obj/item/book/manual/military_law,
-/obj/item/book/manual/nt_regs,
 /turf/simulated/floor/wood,
 /area/command/captainmess)
 "pz" = (
@@ -4316,7 +3756,7 @@
 	c_tag = "Fourth Deck Hallway - Midships";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "pD" = (
 /obj/structure/railing/mapped{
@@ -4341,24 +3781,13 @@
 "pI" = (
 /turf/simulated/open,
 /area/quartermaster/hangar/catwalks_port)
-"pJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
 "pK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "pL" = (
 /obj/machinery/door/blast/shutters{
@@ -4388,40 +3817,33 @@
 /obj/floor_decal/techfloor{
 	dir = 8
 	},
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "pO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "pP" = (
 /obj/structure/closet/crate,
 /obj/random/tank,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "pQ" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/primary)
 "pR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/primary)
 "pS" = (
 /obj/machinery/firealarm{
@@ -4430,7 +3852,7 @@
 /obj/machinery/vending/tool{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/primary)
 "pT" = (
 /obj/random/junk,
@@ -4441,11 +3863,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "pV" = (
 /obj/structure/stairs/east,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "pW" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -4456,13 +3878,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/corner/red/half{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "pZ" = (
 /obj/structure/sign/directions/science{
@@ -4474,12 +3893,6 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/prepainted,
-/area/hallway/primary/fourthdeck/center)
-"qa" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "qb" = (
 /obj/structure/sign/directions/bridge{
@@ -4504,13 +3917,10 @@
 /turf/simulated/wall/prepainted,
 /area/command/pathfinder)
 "qf" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "qg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4519,23 +3929,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/floor_decal/industrial/warning/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
-"ql" = (
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
 "qn" = (
 /obj/structure/table/rack,
 /obj/item/stock_parts/circuitboard/telecomms/broadcaster,
@@ -4583,7 +3981,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "qx" = (
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "qy" = (
 /obj/machinery/telecomms/processor/preset_three,
@@ -4606,7 +4004,7 @@
 /area/eva)
 "qM" = (
 /obj/machinery/rotating_alarm/security_alarm,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "qQ" = (
 /obj/machinery/door/airlock/external{
@@ -4620,7 +4018,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "qR" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "qT" = (
 /obj/structure/table/steel_reinforced,
@@ -4629,7 +4027,7 @@
 /obj/item/device/radio/off,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "qV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4641,7 +4039,7 @@
 	dir = 4;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "qW" = (
 /obj/machinery/tele_projector,
@@ -4651,28 +4049,19 @@
 /obj/floor_decal/techfloor{
 	dir = 8
 	},
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "qY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "qZ" = (
 /obj/structure/table/rack,
 /obj/random/tech_supply,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "ra" = (
 /obj/structure/table/standard,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -4683,7 +4072,7 @@
 	dir = 4;
 	pixel_x = -21
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/primary)
 "rb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4697,7 +4086,7 @@
 /obj/machinery/lapvend{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/primary)
 "re" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4711,44 +4100,9 @@
 /obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
-"rg" = (
-/obj/floor_decal/corner/mauve{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
-"rh" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
-"ri" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
-"rj" = (
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
 "rk" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/head/deck4)
-"rl" = (
-/obj/floor_decal/corner/mauve{
-	dir = 5
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
 "rm" = (
 /obj/structure/railing/mapped,
 /obj/machinery/light{
@@ -4762,7 +4116,6 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/maintenance/solgov,
-/obj/random/medical,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/port)
 "ro" = (
@@ -4817,18 +4170,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "ru" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 1
-	},
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "rz" = (
 /obj/machinery/door/firedoor,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "rF" = (
 /obj/structure/cable{
@@ -4860,12 +4210,6 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/port)
-"rH" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
 "rO" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -4897,10 +4241,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "sd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -4934,7 +4275,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "sk" = (
 /obj/machinery/access_button{
@@ -4949,7 +4290,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "sl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -4957,14 +4298,14 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "sm" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
 	target_pressure = 200
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "sn" = (
 /obj/structure/cable/green{
@@ -4976,7 +4317,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "so" = (
 /obj/machinery/door/firedoor,
@@ -5003,9 +4344,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -5017,7 +4355,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "sq" = (
 /obj/machinery/firealarm{
@@ -5047,7 +4385,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "st" = (
 /obj/machinery/alarm{
@@ -5058,7 +4396,7 @@
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "su" = (
 /obj/structure/table/standard,
@@ -5070,7 +4408,7 @@
 /obj/item/stack/package_wrap/cargo_wrap,
 /obj/item/hand_labeler,
 /obj/item/device/destTagger,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/primary)
 "sv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5087,11 +4425,11 @@
 /obj/machinery/disposal,
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/primary)
 "sx" = (
 /obj/machinery/vending/generic,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/primary)
 "sy" = (
 /obj/structure/table/rack{
@@ -5103,7 +4441,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/primary)
 "sz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5142,7 +4480,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/tele_beacon,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "sC" = (
 /obj/structure/cable/green{
@@ -5159,7 +4497,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "sD" = (
 /obj/structure/cable/green{
@@ -5217,7 +4555,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "sH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5239,7 +4577,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "sI" = (
 /obj/catwalk_plated,
@@ -5272,7 +4610,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "sL" = (
 /obj/structure/cable/green{
@@ -5291,9 +4629,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/center)
 "sR" = (
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -5302,7 +4637,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "sZ" = (
 /obj/structure/cable/green{
@@ -5380,7 +4715,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "ti" = (
 /obj/structure/cable/green{
@@ -5413,7 +4748,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "tk" = (
 /obj/structure/cable/green{
@@ -5524,8 +4859,7 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/sorting)
 "tA" = (
-/obj/floor_decal/corner/brown/half,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "tC" = (
 /obj/structure/cable/green{
@@ -5597,7 +4931,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "tP" = (
 /obj/structure/cable/green{
@@ -5605,7 +4939,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "tQ" = (
 /obj/structure/cable/green{
@@ -5613,7 +4947,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "tR" = (
 /obj/structure/table/steel_reinforced,
@@ -5630,13 +4964,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/cell/high,
 /obj/item/cell/high,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "tS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "tU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5657,11 +4991,7 @@
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "tW" = (
 /obj/floor_decal/corner_techfloor_grid{
@@ -5670,10 +5000,7 @@
 /obj/floor_decal/techfloor/corner{
 	dir = 1
 	},
-/obj/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "tX" = (
 /obj/structure/table/standard,
@@ -5681,7 +5008,7 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "tY" = (
 /obj/random/tech_supply,
@@ -5693,7 +5020,7 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/primary)
 "tZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5708,20 +5035,19 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/primary)
 "ub" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/primary)
 "uc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/storage/primary)
 "ud" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5765,8 +5091,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/floor_decal/corner/red,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "uh" = (
 /obj/structure/cable/green{
@@ -5776,10 +5101,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/red{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "ui" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -5793,20 +5115,16 @@
 	c_tag = "Fourth Deck Hallway - Lift";
 	dir = 1
 	},
-/obj/floor_decal/corner/red{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "uj" = (
-/obj/floor_decal/corner/white{
+/obj/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/obj/floor_decal/corner/red{
-	dir = 8
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/crew_quarters/lounge)
 "uk" = (
 /obj/structure/closet/emcloset,
 /obj/floor_decal/industrial/outline/yellow,
@@ -5819,14 +5137,11 @@
 /turf/simulated/open,
 /area/quartermaster/storage/upper)
 "um" = (
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "un" = (
 /obj/structure/cable/green{
@@ -5834,25 +5149,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "uo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
-"up" = (
-/obj/floor_decal/corner/brown/half,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
 "uq" = (
 /obj/machinery/door/blast/shutters{
 	dir = 4;
@@ -5919,7 +5226,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "uA" = (
 /obj/machinery/telecomms/processor/preset_two,
@@ -5946,8 +5253,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/floor_decal/corner/brown,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "uI" = (
 /obj/machinery/button/blast_door{
@@ -5965,19 +5271,16 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "uK" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "uL" = (
 /obj/structure/cable/green{
@@ -6114,16 +5417,13 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fourthdeck/aft)
 "vj" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 1
-	},
 /obj/structure/sign/warning/server_room{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "vk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -6131,7 +5431,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "vm" = (
 /obj/structure/cable/green{
@@ -6144,10 +5444,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "vn" = (
 /obj/structure/cable/green{
@@ -6161,7 +5458,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "vo" = (
 /obj/machinery/door/firedoor,
@@ -6193,7 +5490,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "vq" = (
 /obj/machinery/power/apc{
@@ -6210,7 +5507,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "vr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6220,14 +5517,14 @@
 	dir = 9
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "vs" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/teleporter/fourthdeck)
 "vt" = (
 /obj/structure/table/standard,
@@ -6242,7 +5539,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/primary)
 "vu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6252,12 +5549,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/primary)
 "vv" = (
 /obj/machinery/hologram/holopad,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/primary)
 "vw" = (
 /obj/machinery/requests_console{
@@ -6268,24 +5565,24 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/primary)
 "vx" = (
 /obj/machinery/computer/modular/preset/civilian{
 	dir = 8;
 	icon_state = "console"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/primary)
 "vy" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/primary)
 "vz" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/primary)
 "vA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6299,9 +5596,8 @@
 	name = "Hangar Deck Hallway Shutters";
 	opacity = 0
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "vB" = (
 /obj/structure/cable/green{
@@ -6317,8 +5613,7 @@
 	name = "Hangar Deck Hallway Shutters";
 	opacity = 0
 	},
-/obj/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "vC" = (
 /obj/machinery/status_display,
@@ -6382,7 +5677,7 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "vQ" = (
 /turf/simulated/wall/prepainted,
@@ -6391,7 +5686,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "vZ" = (
 /obj/structure/sign/directions/infirmary{
@@ -6455,7 +5750,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "wm" = (
 /obj/machinery/status_display/supply_display,
@@ -6499,9 +5794,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/floor_decal/corner/blue{
-	dir = 9
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -6514,7 +5806,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/eva)
 "wA" = (
 /obj/structure/dispenser/oxygen,
@@ -6528,26 +5820,15 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
-"wC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/floor_decal/corner/paleblue/half{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
 "wD" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "wE" = (
 /obj/machinery/door/firedoor,
@@ -6613,7 +5894,6 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/machinery/light_switch{
 	pixel_x = 10;
 	pixel_y = 32
@@ -6621,7 +5901,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "wJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6634,15 +5914,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/floor_decal/corner/red/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "wK" = (
-/obj/floor_decal/corner/red/half{
-	dir = 1
-	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Militarum";
@@ -6650,7 +5924,7 @@
 	pixel_y = -32
 	},
 /obj/structure/disposalpipe/segment/bent,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "wL" = (
 /obj/structure/cable/cyan{
@@ -6670,12 +5944,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/machinery/computer/modular/preset/security{
 	dir = 8;
 	icon_state = "console"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "wQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -6736,12 +6009,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
-"xn" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/deckchief)
 "xo" = (
 /obj/structure/closet/emcloset,
 /obj/floor_decal/industrial/outline/yellow,
@@ -6807,7 +6074,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "xy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -6831,12 +6098,9 @@
 "xB" = (
 /obj/structure/closet/firecloset,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "xF" = (
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck Hallway - Aft Starboard";
 	dir = 4
@@ -6855,7 +6119,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "xL" = (
 /obj/structure/cable/green{
@@ -6879,15 +6143,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "xN" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "xO" = (
 /obj/shuttle_landmark/vox_raider/dock,
@@ -6912,10 +6173,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "xS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6963,7 +6221,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "xW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7018,7 +6276,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "ya" = (
 /obj/structure/railing/mapped{
@@ -7067,19 +6325,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "ye" = (
-/obj/floor_decal/corner/red/half{
-	dir = 8
-	},
 /obj/structure/bed/chair/padded/red{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "yf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7093,33 +6345,29 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "yg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "yh" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "yi" = (
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
 /obj/structure/table/steel,
 /obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "yj" = (
-/obj/floor_decal/corner/brown/mono,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "yl" = (
 /obj/structure/cable/green{
@@ -7155,22 +6403,6 @@
 /obj/shuttle_landmark/merc/dock,
 /turf/space,
 /area/space)
-"yu" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/obj/floor_decal/corner/brown{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/turbolift/cargo_lift)
-"yy" = (
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 "yB" = (
 /obj/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -7186,17 +6418,11 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/galley)
-"yC" = (
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
 "yD" = (
 /obj/landmark/test/safe_turf,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "yF" = (
-/obj/floor_decal/corner/green{
-	dir = 6
-	},
 /obj/structure/sign/deck/fourth{
 	dir = 8;
 	pixel_x = 32
@@ -7222,7 +6448,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "yN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7263,12 +6489,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
-"za" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
 "ze" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -7287,10 +6507,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "zl" = (
 /obj/machinery/conveyor{
@@ -7314,9 +6531,8 @@
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
-/obj/floor_decal/corner/paleblue/mono,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "zn" = (
 /obj/structure/cable/green{
@@ -7327,10 +6543,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "zo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7343,7 +6556,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "zp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7365,11 +6578,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "zr" = (
 /obj/structure/cable/green{
@@ -7381,24 +6590,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/floor_decal/corner/red/half,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
-"zs" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "zt" = (
 /obj/structure/cable/green{
@@ -7409,11 +6601,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "zu" = (
 /obj/structure/cable/green{
@@ -7424,11 +6612,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "zv" = (
 /obj/structure/cable/green{
@@ -7442,8 +6626,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light,
-/obj/floor_decal/corner/red/half,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "zx" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -7455,8 +6638,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/obj/floor_decal/corner/red/half,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "zz" = (
 /obj/structure/cable/green{
@@ -7471,13 +6653,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "zA" = (
 /obj/structure/cable/green{
@@ -7489,9 +6667,8 @@
 	dir = 1
 	},
 /obj/structure/closet/emcloset,
-/obj/floor_decal/corner/red/mono,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "zC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -7502,25 +6679,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
-"zD" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "zE" = (
-/obj/floor_decal/corner/mauve/half{
-	dir = 4
-	},
 /obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "zF" = (
 /obj/machinery/power/apc{
@@ -7532,15 +6695,12 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
 /obj/structure/ladder/up,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "zM" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "zP" = (
 /obj/structure/cable/green{
@@ -7572,9 +6732,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "zZ" = (
-/obj/floor_decal/corner/green{
-	dir = 6
-	},
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/aft)
@@ -7595,13 +6752,13 @@
 	icon_state = "railing0-1"
 	},
 /obj/catwalk_plated,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "Ad" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "Ae" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -7610,9 +6767,6 @@
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
-	},
-/obj/floor_decal/corner/green/half{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -7683,14 +6837,7 @@
 "An" = (
 /obj/structure/closet/emcloset,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
-"Ap" = (
-/obj/machinery/door/firedoor,
-/obj/floor_decal/corner/brown{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "Aq" = (
 /obj/structure/catwalk,
@@ -7730,15 +6877,9 @@
 	pixel_x = -23;
 	pixel_y = -3
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "AB" = (
-/obj/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 4
 	},
@@ -7774,15 +6915,12 @@
 /area/maintenance/fourthdeck/forestarboard)
 "AE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "AF" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/suit_storage_unit/security/alt,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "AH" = (
 /turf/simulated/wall/prepainted,
@@ -7839,23 +6977,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "AN" = (
-/obj/floor_decal/corner/red/mono,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "AO" = (
 /obj/machinery/photocopier,
-/obj/floor_decal/corner/red/mono,
 /obj/floor_decal/industrial/outline/grey,
 /obj/item/device/radio/intercom/department/security{
 	dir = 8;
 	pixel_x = 21
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "AP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7885,7 +7021,6 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/obj/floor_decal/corner/brown,
 /obj/shuttle_landmark/lift/cargo_top,
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/cargo_lift)
@@ -7895,15 +7030,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "Bo" = (
 /obj/structure/sign/warning/docking_area,
@@ -7935,16 +7066,10 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "BC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 10
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/command/captainmess)
 "BD" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/foreport)
@@ -8048,9 +7173,6 @@
 /obj/floor_decal/corner/red/diagonal{
 	dir = 8
 	},
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8;
 	icon_state = "warningcorner"
@@ -8140,9 +7262,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/floor_decal/corner/blue{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "Cm" = (
@@ -8166,12 +7285,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
-"Ct" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "Cy" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -8205,7 +7318,7 @@
 	dir = 4;
 	pixel_x = 21
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fourthdeck/aft)
 "CG" = (
 /turf/simulated/floor/shuttle_ceiling/torch/air,
@@ -8215,14 +7328,16 @@
 	dir = 1
 	},
 /obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 1
+	},
 /area/crew_quarters/lounge)
 "CK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod7/station)
 "CL" = (
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "CN" = (
 /obj/structure/closet/crate,
@@ -8378,7 +7493,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "Dl" = (
 /turf/space,
@@ -8393,8 +7508,7 @@
 "Dr" = (
 /obj/floor_decal/corner/brown/mono,
 /obj/machinery/photocopier,
-/obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "Ds" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -8403,22 +7517,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/aft)
-"Dw" = (
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
-/obj/machinery/oxygen_pump{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "Dx" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/suit_storage_unit/medical/alt/sol,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "DA" = (
 /obj/structure/cable{
@@ -8587,10 +7692,7 @@
 /turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/laundry)
 "Em" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "En" = (
 /obj/floor_decal/corner/green/mono,
@@ -8604,32 +7706,7 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
-"Eo" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
 "Eq" = (
-/obj/floor_decal/corner/brown{
-	dir = 6
-	},
 /obj/machinery/light/spot{
 	dir = 4
 	},
@@ -8644,7 +7721,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "Et" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
@@ -8691,12 +7768,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/storage/auxillary/port)
 "EH" = (
-/obj/floor_decal/corner/red{
-	dir = 8
-	},
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1;
 	icon_state = "warningcorner"
@@ -8754,24 +7825,32 @@
 "ER" = (
 /obj/item/storage/pill_bottle/dice_nerd,
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 1
+	},
 /area/crew_quarters/lounge)
 "ES" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 1
+	},
 /area/crew_quarters/lounge)
 "ET" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 1
+	},
 /area/crew_quarters/lounge)
 "EY" = (
 /obj/item/paper_bin,
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 1
+	},
 /area/crew_quarters/lounge)
 "EZ" = (
 /obj/structure/bed/chair/comfy/brown{
@@ -8782,18 +7861,17 @@
 	pixel_x = 22
 	},
 /obj/random_multi/single_item/runtime,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 5
+	},
 /area/crew_quarters/lounge)
 "Fb" = (
 /obj/landmark{
 	name = "lightsout"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "Fd" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 4
-	},
 /obj/machinery/requests_console{
 	department = "Munitorum";
 	departmentType = 2;
@@ -8811,7 +7889,7 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "Fe" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -8820,7 +7898,7 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/suit_storage_unit/security/alt,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "Fi" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -8854,7 +7932,7 @@
 	pixel_x = -22
 	},
 /obj/item/inflatable_dispenser,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "Fk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -8864,9 +7942,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	dir = 8
-	},
-/obj/floor_decal/corner/green/half{
 	dir = 8
 	},
 /obj/floor_decal/industrial/warning/corner{
@@ -8886,7 +7961,6 @@
 /area/storage/auxillary/port)
 "Fm" = (
 /obj/structure/closet/crate/warhammer/freezer,
-/obj/random/medical,
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
@@ -8904,12 +7978,6 @@
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
-/obj/floor_decal/corner/red{
-	dir = 8
-	},
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
 "Fo" = (
@@ -9020,11 +8088,11 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet/middle,
 /area/crew_quarters/lounge)
 "FD" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet/middle,
 /area/crew_quarters/lounge)
 "FI" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -9033,23 +8101,17 @@
 /obj/machinery/vending/snack{
 	dir = 8
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "FK" = (
 /obj/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/quartermaster/sorting)
 "FL" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 8
-	},
 /obj/machinery/papershredder,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "FM" = (
-/obj/floor_decal/corner/brown{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9067,7 +8129,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "FO" = (
 /obj/structure/table/rack,
@@ -9131,12 +8193,6 @@
 	c_tag = "Fourth Deck - Fore Port Airlock";
 	dir = 4
 	},
-/obj/floor_decal/corner/red{
-	dir = 8
-	},
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
 "Ga" = (
@@ -9159,9 +8215,6 @@
 "Ge" = (
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
 /turf/simulated/floor/plating,
 /area/vacant/monitoring)
 "Gf" = (
@@ -9242,7 +8295,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "Gq" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -9252,7 +8305,7 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 1
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Gr" = (
 /obj/machinery/power/apc{
@@ -9270,7 +8323,7 @@
 /obj/machinery/vending/cigarette{
 	dir = 8
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Gt" = (
 /obj/shuttle_landmark/scavver_gantry/torch,
@@ -9329,7 +8382,7 @@
 	tag_exterior_door = "skipjack_shuttle_dock_outer";
 	tag_interior_door = "skipjack_shuttle_dock_inner"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "GC" = (
 /obj/machinery/constructable_frame/computerframe,
@@ -9381,7 +8434,7 @@
 	locked = 1;
 	name = "Escape Pod Three Hatch"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/shuttle/escape_pod8/station)
 "GQ" = (
 /obj/machinery/door/airlock/external{
@@ -9391,7 +8444,7 @@
 	locked = 1;
 	name = "Escape Pod Four Hatch"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/shuttle/escape_pod9/station)
 "GR" = (
 /turf/simulated/floor/warhammer/brothel,
@@ -9434,13 +8487,13 @@
 	},
 /obj/item/storage/box/cups,
 /obj/structure/table/woodentable,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "GZ" = (
 /obj/machinery/vending/games{
 	dir = 8
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Hd" = (
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -9472,7 +8525,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "Hm" = (
 /obj/structure/cable{
@@ -9499,10 +8552,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "Ho" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -9538,28 +8588,7 @@
 	},
 /turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod9/station)
-"Hv" = (
-/obj/structure/stairs/north,
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/lounge)
-"Hw" = (
-/obj/floor_decal/corner/brown{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
 "HB" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Lounge Maintenance"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -9568,7 +8597,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/lounge)
 "HE" = (
 /obj/wallframe_spawn/reinforced/no_grille,
@@ -9603,9 +8632,6 @@
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
-	},
-/obj/floor_decal/corner/brown{
-	dir = 4
 	},
 /obj/machinery/computer/shuttle_control/lift/cargo,
 /turf/simulated/floor/tiled/steel_grid,
@@ -9784,13 +8810,10 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "Iq" = (
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "Ir" = (
 /obj/machinery/light/small{
@@ -9872,9 +8895,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/floor_decal/corner/blue{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "Ix" = (
@@ -9907,15 +8927,12 @@
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "II" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 1
-	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "IL" = (
 /obj/structure/catwalk,
@@ -9977,7 +8994,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "IZ" = (
 /obj/structure/cable/green{
@@ -9997,7 +9014,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "Ji" = (
 /obj/floor_decal/industrial/warning{
@@ -10013,7 +9030,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "Jl" = (
 /obj/structure/disposalpipe/segment{
@@ -10054,7 +9071,9 @@
 /obj/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 9
+	},
 /area/crew_quarters/lounge)
 "Js" = (
 /obj/structure/catwalk,
@@ -10070,12 +9089,6 @@
 /area/maintenance/fourthdeck/port)
 "Jx" = (
 /obj/machinery/light{
-	dir = 8
-	},
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/floor_decal/corner/red{
 	dir = 8
 	},
 /obj/structure/sign/warning/docking_area{
@@ -10113,7 +9126,7 @@
 "JG" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/donut,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "JI" = (
 /obj/structure/cable/green{
@@ -10171,9 +9184,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fourthdeck/aft)
 "JP" = (
-/obj/floor_decal/corner/red/half{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -10263,12 +9273,6 @@
 /obj/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod9/station)
-"JY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "Kb" = (
 /obj/structure/ladder/up,
 /obj/floor_decal/industrial/hatch/yellow,
@@ -10329,9 +9333,6 @@
 	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 8
-	},
-/obj/floor_decal/corner/green{
-	dir = 6
 	},
 /obj/structure/closet/emcloset,
 /obj/structure/railing/mapped{
@@ -10427,20 +9428,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "KD" = (
 /obj/machinery/fabricator,
-/obj/floor_decal/corner/brown/half,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -10448,7 +9445,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "KE" = (
 /obj/machinery/door/firedoor,
@@ -10468,16 +9465,13 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/expedition/storage)
 "KG" = (
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "KH" = (
 /obj/machinery/door/blast/shutters{
@@ -10545,17 +9539,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "KU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
-	},
-/obj/floor_decal/corner/green/half{
-	dir = 8
 	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -10596,24 +9584,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "Lb" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
-"Le" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
 "Lf" = (
 /obj/machinery/power/smes/buildable/preset/on_full{
 	RCon_tag = "Substation - Telecommunications"
@@ -10635,15 +9611,14 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "Li" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/medical_cloning,
 /obj/item/book/manual/medical_diagnostics_manual,
 /obj/item/book/manual/nuclear,
-/obj/item/book/manual/detective,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Lj" = (
 /obj/structure/cable/green{
@@ -10697,12 +9672,9 @@
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "Lq" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 8
-	},
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
@@ -10711,7 +9683,7 @@
 	pixel_x = -3
 	},
 /obj/item/folder/blue,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "Lu" = (
 /obj/structure/cable/green{
@@ -10746,7 +9718,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/waterstore)
 "Lx" = (
-/obj/floor_decal/corner/brown/half,
 /obj/machinery/photocopier,
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -10756,7 +9727,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/quartermaster/deckchief)
 "Lz" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -10768,7 +9739,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "LC" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -10795,10 +9766,7 @@
 /area/maintenance/fourthdeck/port)
 "LI" = (
 /obj/machinery/light,
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "LK" = (
 /obj/structure/catwalk,
@@ -10889,9 +9857,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/floor_decal/corner/green/half{
-	dir = 8
-	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1;
 	icon_state = "warningcorner"
@@ -10906,20 +9871,8 @@
 	dir = 8;
 	target_pressure = 200
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/maintenance/fourthdeck/forestarboard)
-"LZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "Ma" = (
 /obj/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -10932,7 +9885,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Mb" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -10945,9 +9898,6 @@
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/hull,
 /area/eva)
-"Me" = (
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage/upper)
 "Mf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10958,21 +9908,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "Mh" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/quartermaster/expedition/storage)
 "Mi" = (
-/obj/floor_decal/corner/paleblue{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "Mk" = (
 /obj/floor_decal/industrial/warning{
@@ -11000,7 +9947,7 @@
 /area/maintenance/fourthdeck/aft)
 "Ml" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Mp" = (
 /turf/simulated/wall/prepainted,
@@ -11012,9 +9959,6 @@
 	},
 /turf/simulated/open,
 /area/maintenance/fourthdeck/port)
-"Mr" = (
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "Ms" = (
 /obj/floor_decal/industrial/warning{
 	dir = 10
@@ -11043,7 +9987,7 @@
 	dir = 1
 	},
 /obj/machinery/libraryscanner,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Mv" = (
 /obj/structure/railing/mapped{
@@ -11078,24 +10022,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
-"Mx" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/obj/structure/sign/warning/docking_area{
-	name = "\improper ESCAPE POD LAUNCH PATHWAY";
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "My" = (
-/obj/floor_decal/corner/brown/mono,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 21
@@ -11111,7 +10038,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "MB" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -11131,7 +10058,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "MF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -11147,11 +10074,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/hangar/catwalks_starboard)
 "MG" = (
-/obj/floor_decal/corner/paleblue{
-	dir = 5
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
+/area/command/captainmess)
 "MH" = (
 /obj/machinery/space_heater,
 /obj/floor_decal/industrial/outline/grey,
@@ -11216,7 +10142,7 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "MR" = (
 /turf/simulated/floor/tiled/steel_ridged,
@@ -11224,7 +10150,7 @@
 "MS" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/suit_storage_unit/engineering/alt/sol,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "MT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11233,7 +10159,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "MW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11247,19 +10173,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "MX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 9
+	},
 /area/command/captainmess)
 "MY" = (
 /obj/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "MZ" = (
 /obj/structure/railing/mapped{
@@ -11278,7 +10206,7 @@
 /obj/item/book/manual/anomaly_testing,
 /obj/item/book/manual/materials_chemistry_analysis,
 /obj/item/book/manual/stasis,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Nc" = (
 /obj/structure/cable/green{
@@ -11287,32 +10215,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
-"Nd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/button/windowtint{
-	id = "diplomatic_office";
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -6
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "Nf" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -11358,7 +10262,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "Nl" = (
-/obj/floor_decal/corner/brown/mono,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -11378,7 +10281,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "Nm" = (
 /obj/machinery/door/blast/shutters{
@@ -11406,7 +10309,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "Np" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11423,7 +10326,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "Nq" = (
 /obj/floor_decal/industrial/warning{
@@ -11479,14 +10382,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "Nu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "Nv" = (
@@ -11504,7 +10411,9 @@
 	pixel_x = -26;
 	pixel_y = -24
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 10
+	},
 /area/crew_quarters/lounge)
 "Nx" = (
 /obj/structure/cable/green{
@@ -11521,7 +10430,7 @@
 "Nz" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/suit_storage_unit/atmos/alt/sol,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "NA" = (
 /obj/structure/cable/green{
@@ -11529,21 +10438,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "NC" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "ND" = (
 /obj/structure/catwalk,
@@ -11596,9 +10499,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/hangcheck)
-"NP" = (
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
 "NQ" = (
 /obj/floor_decal/industrial/warning{
 	dir = 10
@@ -11679,10 +10579,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/floor_decal/corner/brown{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "NZ" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -11692,7 +10589,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Oa" = (
 /obj/structure/catwalk,
@@ -11725,20 +10622,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
-"Oh" = (
-/obj/structure/table/standard,
-/obj/machinery/light,
-/obj/item/reagent_containers/food/drinks/glass2/coffeecup/SCG{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/glass2/coffeecup/SCG{
-	pixel_x = 4
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "Oj" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -11818,7 +10701,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "Ow" = (
 /obj/structure/cable{
@@ -11856,7 +10739,7 @@
 "OC" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/suit_storage_unit/medical/alt/sol,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "OG" = (
 /obj/structure/railing/mapped,
@@ -11884,8 +10767,7 @@
 	dir = 1;
 	icon_state = "console"
 	},
-/obj/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "OK" = (
 /obj/structure/catwalk,
@@ -11924,17 +10806,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
-"OQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "OT" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/prepainted,
@@ -11948,8 +10821,7 @@
 	dir = 4;
 	pixel_y = -4
 	},
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/storage/primary)
 "OV" = (
 /obj/structure/cable{
@@ -11974,7 +10846,7 @@
 /obj/item/flora/pottedplantsmall/fern{
 	pixel_y = 4
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "Pa" = (
 /obj/machinery/door/blast/shutters{
@@ -12000,7 +10872,7 @@
 	dir = 8;
 	pixel_x = 40
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "Pe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -12010,7 +10882,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "Pf" = (
 /obj/machinery/door/firedoor,
@@ -12039,7 +10911,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "Ph" = (
 /obj/structure/disposalpipe/segment{
@@ -12076,7 +10948,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "Pk" = (
 /obj/structure/catwalk,
@@ -12132,9 +11004,6 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/floor_decal/corner/blue{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "Pt" = (
@@ -12151,18 +11020,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
-"Pv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
 "Px" = (
 /obj/floor_decal/industrial/warning{
 	dir = 9
@@ -12179,10 +11036,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "PB" = (
 /obj/structure/railing/mapped,
@@ -12192,7 +11046,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "PE" = (
 /obj/structure/cable/green{
@@ -12235,9 +11089,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "PI" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12245,31 +11096,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "PJ" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/laundry)
 "PK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet/middle,
 /area/crew_quarters/lounge)
 "PL" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
-"PO" = (
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/lounge)
 "PQ" = (
-/obj/floor_decal/corner/brown/half,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 2;
@@ -12282,7 +11122,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "PR" = (
 /obj/structure/railing/mapped{
@@ -12295,17 +11135,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "PS" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "PT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "PU" = (
 /obj/random/junk,
@@ -12332,10 +11169,6 @@
 /obj/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
-"PY" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "PZ" = (
 /obj/structure/table/rack,
 /obj/item/stock_parts/subspace/treatment,
@@ -12364,7 +11197,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fourthdeck/aft)
 "Qc" = (
 /obj/structure/table/steel,
@@ -12376,7 +11209,6 @@
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fourthdeck/aft)
 "Qe" = (
-/obj/floor_decal/corner/brown/mono,
 /obj/structure/closet/secure_closet/decktech,
 /obj/item/material/coin/silver{
 	pixel_x = -3;
@@ -12387,7 +11219,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "Qf" = (
 /obj/structure/catwalk,
@@ -12427,11 +11259,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "Qo" = (
-/obj/floor_decal/corner/paleblue{
-	dir = 9
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
+/area/crew_quarters/lounge)
 "Qp" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4
@@ -12458,13 +11289,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "Qq" = (
-/obj/floor_decal/corner/red/half{
-	dir = 1
-	},
 /obj/structure/bed/chair/padded/red{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "Qr" = (
 /obj/structure/railing/mapped,
@@ -12489,12 +11317,12 @@
 	},
 /obj/machinery/recharger,
 /obj/structure/table/woodentable,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Qu" = (
 /obj/structure/table/standard,
 /obj/item/folder/envelope/dcorder,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "Qy" = (
 /obj/structure/railing/mapped,
@@ -12527,21 +11355,14 @@
 	},
 /turf/space,
 /area/space)
-"QC" = (
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
 "QD" = (
-/obj/floor_decal/corner/brown/half,
 /obj/structure/filingcabinet,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/quartermaster/deckchief)
 "QG" = (
 /obj/structure/table/standard,
@@ -12555,7 +11376,7 @@
 /obj/random_multi/single_item/memo_exploration,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/folder/envelope/exploorder,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "QI" = (
 /obj/machinery/door/airlock/mining{
@@ -12576,7 +11397,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "QJ" = (
 /obj/structure/railing/mapped{
@@ -12670,7 +11491,7 @@
 /area/maintenance/fourthdeck/foreport)
 "Rb" = (
 /obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "Re" = (
 /obj/machinery/pager/cargo{
@@ -12680,7 +11501,7 @@
 	level = 2
 	},
 /obj/machinery/computer/modular/preset/supply_public,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fourthdeck/aft)
 "Rf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12696,7 +11517,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "Rg" = (
 /obj/structure/railing/mapped{
@@ -12762,14 +11583,11 @@
 /turf/simulated/floor/wood,
 /area/command/captainmess)
 "Rr" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "Rs" = (
 /obj/structure/railing/mapped{
@@ -12785,10 +11603,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/floor_decal/corner/red{
-	dir = 4
-	},
-/obj/floor_decal/corner/white,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12797,17 +11611,14 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "Rv" = (
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "Rw" = (
 /obj/structure/flora/pottedplant/crystal,
@@ -12826,11 +11637,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/floor_decal/corner/brown{
-	dir = 8
-	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "Ry" = (
 /obj/structure/sign/directions/bridge{
@@ -12841,8 +11649,7 @@
 	dir = 1;
 	pixel_y = -4
 	},
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/storage/primary)
 "RA" = (
 /turf/simulated/wall/prepainted,
@@ -12871,9 +11678,6 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/floor_decal/corner/green{
-	dir = 9
 	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
@@ -12923,23 +11727,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "RK" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "RL" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/drinks/teapot,
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "RM" = (
-/obj/floor_decal/corner/brown{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -12957,20 +11755,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "RN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/floor_decal/corner/red/diagonal,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
 "RP" = (
@@ -13015,7 +11806,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 4
+	},
 /area/command/captainmess)
 "RU" = (
 /obj/machinery/telecomms/server/presets/supply,
@@ -13030,23 +11823,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
-"RW" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
 "RY" = (
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
-"RZ" = (
-/obj/structure/bed/chair/office/comfy/brown{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "Sa" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -13064,15 +11845,12 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/lounge)
 "Se" = (
-/obj/floor_decal/corner/paleblue/half{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "Sf" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -13097,9 +11875,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/waterstore)
 "Sh" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 4
-	},
 /obj/structure/table/standard,
 /obj/machinery/light{
 	dir = 4
@@ -13107,7 +11882,7 @@
 /obj/machinery/photocopier/faxmachine{
 	department = "Dauntless - Deck Chief's Office"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/quartermaster/deckchief)
 "Si" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13119,8 +11894,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "Sj" = (
 /obj/machinery/door/firedoor,
@@ -13210,11 +11984,7 @@
 /area/shuttle/escape_pod6/station)
 "Su" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
-"Sv" = (
-/obj/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "Sx" = (
 /obj/structure/railing/mapped{
@@ -13224,15 +11994,12 @@
 /turf/simulated/open,
 /area/quartermaster/storage/upper)
 "Sy" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 4
-	},
 /obj/structure/table/standard,
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
 /obj/random_multi/single_item/memo_supply,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/quartermaster/deckchief)
 "Sz" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -13274,24 +12041,8 @@
 /obj/floor_decal/industrial/shutoff{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
-"SC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "SD" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -13378,15 +12129,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/eva)
 "SI" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/fourthdeck)
 "SK" = (
-/obj/floor_decal/corner/brown{
-	dir = 9
-	},
 /obj/structure/table/rack{
 	dir = 8
 	},
@@ -13403,7 +12151,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "SL" = (
 /obj/floor_decal/techfloor,
@@ -13427,7 +12175,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "SP" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -13437,7 +12185,7 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "SR" = (
 /obj/machinery/alarm{
@@ -13445,7 +12193,7 @@
 	},
 /obj/structure/table/rack,
 /obj/random/donkpocket_box,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/fourthdeck/forestarboard)
 "SS" = (
 /obj/machinery/door/firedoor,
@@ -13487,19 +12235,8 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/quartermaster/deckchief)
-"SU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
 "SV" = (
 /obj/structure/closet,
 /obj/random/maintenance/solgov,
@@ -13565,7 +12302,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "Tb" = (
 /obj/floor_decal/industrial/warning{
@@ -13641,21 +12378,15 @@
 /turf/simulated/floor/shuttle_ceiling/torch/air,
 /area/quartermaster/hangar/catwalks_starboard)
 "Tr" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 8
-	},
 /obj/machinery/requests_console{
 	department = "Munitorum";
 	departmentType = 2;
 	pixel_x = -30
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "Ts" = (
 /obj/structure/bed/chair/office/comfy/purple,
-/obj/floor_decal/corner/mauve{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -13667,7 +12398,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "Tt" = (
 /obj/structure/closet/emcloset,
@@ -13709,7 +12440,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Tz" = (
 /obj/structure/table/standard,
@@ -13720,12 +12451,16 @@
 /turf/simulated/floor/wood/walnut,
 /area/command/captainmess)
 "TA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "TB" = (
 /obj/random/maintenance/solgov/clean,
@@ -13738,11 +12473,10 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/floor_decal/industrial/outline/grey,
 /obj/random_multi/single_item/boombox,
 /obj/item/device/binoculars,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "TD" = (
 /obj/structure/cable/green{
@@ -13763,15 +12497,11 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/papershredder,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/security/hangcheck)
 "TH" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -13781,7 +12511,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "TJ" = (
 /obj/structure/catwalk,
@@ -13822,13 +12552,10 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "TO" = (
-/obj/floor_decal/corner/brown{
-	dir = 9
-	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/deckofficer,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "TP" = (
 /obj/random/trash,
@@ -13875,7 +12602,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "TY" = (
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet/middle,
 /area/crew_quarters/lounge)
 "Ub" = (
 /obj/machinery/telecomms/bus/preset_three,
@@ -13891,33 +12618,12 @@
 	pixel_y = -24;
 	tag_door = "escape_pod_8_berth_hatch"
 	},
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
 /obj/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
-"Uh" = (
-/obj/floor_decal/corner/brown/half,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/storage/upper)
 "Ui" = (
 /obj/machinery/telecomms/server/presets/science,
 /turf/simulated/floor/bluegrid,
@@ -13928,38 +12634,27 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
-"Ul" = (
-/obj/structure/bed/chair/office/comfy/brown{
-	dir = 4
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
+/area/crew_quarters/lounge)
 "Un" = (
 /obj/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
 /obj/floor_decal/spline/fancy/wood/corner,
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "Uo" = (
 /turf/simulated/floor/wood/walnut,
 /area/command/captainmess)
-"Up" = (
-/obj/floor_decal/corner/red{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
 "Uq" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/corner/red/half,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "Ur" = (
 /obj/structure/cable/green{
@@ -14027,10 +12722,7 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/obj/floor_decal/corner/red/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "UA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14044,7 +12736,7 @@
 /area/maintenance/fourthdeck/forestarboard)
 "UB" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/fourthdeck/forestarboard)
 "UC" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -14055,7 +12747,7 @@
 /area/maintenance/fourthdeck/forestarboard)
 "UD" = (
 /obj/machinery/bookbinder,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "UE" = (
 /obj/structure/catwalk,
@@ -14093,7 +12785,7 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "UJ" = (
 /obj/structure/railing/mapped,
@@ -14186,9 +12878,6 @@
 	pixel_y = 24;
 	tag_door = "escape_pod_6_berth_hatch"
 	},
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
 /obj/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
@@ -14227,7 +12916,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "UY" = (
 /obj/catwalk_plated,
@@ -14277,7 +12966,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "Vd" = (
 /obj/structure/disposalpipe/segment,
@@ -14291,7 +12980,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fourthdeck/aft)
 "Vh" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -14306,10 +12995,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/brown{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "Vj" = (
 /obj/structure/catwalk,
@@ -14328,14 +13014,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/chamber)
 "Vm" = (
-/obj/floor_decal/corner/brown{
-	dir = 5
-	},
 /obj/machinery/computer/modular/preset/dock{
 	dir = 4;
 	icon_state = "console"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/quartermaster/deckchief)
 "Vo" = (
 /obj/structure/railing/mapped{
@@ -14345,14 +13028,11 @@
 /turf/simulated/open,
 /area/quartermaster/storage/upper)
 "Vp" = (
-/obj/floor_decal/corner/yellow{
-	dir = 9
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "Vr" = (
 /turf/simulated/wall/r_wall/hull,
@@ -14374,12 +13054,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
 "Vw" = (
-/obj/floor_decal/corner/brown/half{
-	dir = 1
-	},
 /obj/structure/filingcabinet/filingcabinet,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "Vx" = (
 /obj/catwalk_plated,
@@ -14430,9 +13107,6 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/floor_decal/corner/brown/half{
-	dir = 1
-	},
 /obj/item/folder/yellow,
 /obj/item/stamp/supply,
 /obj/item/stamp/denied{
@@ -14445,7 +13119,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "VD" = (
 /obj/structure/railing/mapped,
@@ -14508,16 +13182,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/center)
-"VL" = (
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
 "VO" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "VQ" = (
 /obj/machinery/light/small,
@@ -14564,10 +13232,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "VU" = (
-/obj/floor_decal/corner/mauve{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "VW" = (
 /turf/simulated/wall/prepainted,
@@ -14614,7 +13279,9 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 1
+	},
 /area/crew_quarters/lounge)
 "Wi" = (
 /obj/structure/sign/warning/moving_parts,
@@ -14628,7 +13295,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "Wl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14644,7 +13311,7 @@
 "Wm" = (
 /obj/floor_decal/corner/green/mono,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "Wn" = (
 /obj/structure/sign/directions/engineering{
@@ -14673,10 +13340,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "Wu" = (
-/obj/floor_decal/corner/yellow{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
 "Ww" = (
 /obj/structure/cable/green{
@@ -14705,7 +13369,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 8
+	},
 /area/command/captainmess)
 "Wy" = (
 /obj/structure/cable/cyan{
@@ -14768,9 +13434,6 @@
 /turf/space,
 /area/space)
 "WC" = (
-/obj/floor_decal/corner/mauve{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14779,7 +13442,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "WD" = (
 /obj/structure/synthesized_instrument/synthesizer/minimoog{
@@ -14789,7 +13452,9 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 9
+	},
 /area/crew_quarters/lounge)
 "WF" = (
 /obj/structure/cable/cyan{
@@ -14810,7 +13475,7 @@
 "WH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/fore)
 "WI" = (
 /obj/structure/catwalk,
@@ -14874,30 +13539,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
-"WQ" = (
-/obj/machinery/door/firedoor,
-/obj/floor_decal/corner/brown,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
 "WR" = (
-/obj/floor_decal/corner/mauve{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "WS" = (
-/obj/floor_decal/corner/brown/half,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/aft)
 "WU" = (
 /obj/structure/table/marble,
 /obj/item/storage/box/glasses/wine,
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "WW" = (
 /obj/machinery/door/airlock/mining{
@@ -14954,7 +13610,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 8
+	},
 /area/command/captainmess)
 "Xh" = (
 /obj/structure/cable/green{
@@ -14987,18 +13645,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
-"Xk" = (
-/obj/structure/sign/directions/science{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/sign/directions/infirmary{
-	dir = 1;
-	pixel_y = -4
-	},
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
-/area/storage/primary)
 "Xl" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15043,19 +13689,12 @@
 "Xn" = (
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/aft)
-"Xo" = (
-/obj/floor_decal/corner/mauve{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
 "Xr" = (
-/obj/floor_decal/corner/brown/half,
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "Xs" = (
 /obj/structure/cable/green{
@@ -15081,9 +13720,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "Xv" = (
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck Hallway - Aft Center";
 	dir = 1
@@ -15093,7 +13729,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "Xw" = (
 /obj/structure/railing/mapped{
@@ -15111,18 +13747,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "XA" = (
-/obj/floor_decal/corner/brown{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -15136,7 +13763,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "XB" = (
 /obj/structure/catwalk,
@@ -15176,20 +13803,6 @@
 /obj/item/storage/box/donut,
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
-"XH" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -21;
-	req_access = list("ACCESS_DAUNTLESS")
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/floor_decal/corner/paleblue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
 "XI" = (
 /obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -15209,7 +13822,7 @@
 /obj/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "XN" = (
 /obj/floor_decal/corner/brown/mono,
@@ -15221,7 +13834,7 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/quartermaster/deckchief)
 "XP" = (
 /obj/floor_decal/corner/brown/mono,
@@ -15234,7 +13847,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/quartermaster/deckchief)
 "XQ" = (
 /obj/machinery/door/blast/shutters{
@@ -15274,7 +13887,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/fourthdeck/center)
 "XW" = (
 /obj/structure/table/woodentable,
@@ -15284,12 +13897,9 @@
 /obj/item/modular_computer/telescreen/preset/generic{
 	pixel_x = 32
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "XX" = (
-/obj/floor_decal/corner/brown{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15301,7 +13911,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "XY" = (
 /obj/structure/disposalpipe/segment{
@@ -15333,7 +13943,9 @@
 "XZ" = (
 /obj/item/device/flashlight/lamp/green,
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 1
+	},
 /area/crew_quarters/lounge)
 "Ya" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15389,9 +14001,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/aft)
 "Yn" = (
@@ -15425,9 +14034,8 @@
 	pixel_y = 3
 	},
 /obj/item/stack/material/steel,
-/obj/floor_decal/corner/brown/half,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "Yt" = (
 /obj/structure/cable{
@@ -15451,7 +14059,9 @@
 /obj/structure/bed/chair/wood/wings/mahogany{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 4
+	},
 /area/command/captainmess)
 "Yw" = (
 /obj/machinery/shield_diffuser,
@@ -15474,10 +14084,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/floor_decal/corner/brown{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "Yz" = (
 /obj/structure/disposalpipe/sortjunction/untagged/flipped,
@@ -15504,7 +14111,7 @@
 	},
 /obj/floor_decal/industrial/warning/corner,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/fourthdeck/aft)
 "YC" = (
 /obj/structure/cable/green{
@@ -15522,20 +14129,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
-"YE" = (
-/obj/structure/reagent_dispensers/water_cooler{
-	dir = 8
-	},
-/obj/floor_decal/corner/paleblue{
+/turf/simulated/floor/fancyfloor/carpet{
 	dir = 10
 	},
-/obj/floor_decal/corner/paleblue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/diplomatic_office)
+/area/crew_quarters/lounge)
 "YF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15607,7 +14204,7 @@
 /area/hallway/primary/fourthdeck/fore)
 "YL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/center)
 "YN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -15627,12 +14224,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "YR" = (
-/obj/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
 "YS" = (
@@ -15646,7 +14237,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "YV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -15677,7 +14268,7 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/fancyfloor/coralg,
 /area/crew_quarters/lounge)
 "Za" = (
 /obj/catwalk_plated,
@@ -15741,11 +14332,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "Zj" = (
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 "Zk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15754,7 +14341,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "Zl" = (
 /obj/structure/disposalpipe/segment{
@@ -15789,7 +14376,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
 "Zm" = (
-/obj/floor_decal/corner/brown/half,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15802,7 +14388,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/storage/upper)
 "Zo" = (
 /obj/structure/cable{
@@ -15828,7 +14414,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "Zq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15837,7 +14423,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet,
 /area/crew_quarters/lounge)
 "Zr" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -15921,7 +14507,7 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/command/pathfinder)
 "ZA" = (
 /obj/machinery/door/airlock/external/escapepod{
@@ -15953,7 +14539,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "ZG" = (
 /obj/catwalk_plated,
@@ -16024,30 +14610,20 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "ZO" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/turf/simulated/floor/fancyfloor/carpet/blue{
+	dir = 5
 	},
-/obj/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/storage/auxillary/starboard)
+/area/command/captainmess)
 "ZP" = (
 /obj/machinery/oxygen_pump{
 	pixel_x = -32
 	},
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
 "ZQ" = (
-/obj/floor_decal/corner/brown/half,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 2;
@@ -16060,7 +14636,7 @@
 	name = "Deck Chief";
 	sort_type = "Deck Chief"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark2,
 /area/quartermaster/deckchief)
 "ZR" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -16072,11 +14648,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/ceramic,
 /area/command/captainmess)
 "ZS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/aft)
 "ZU" = (
 /obj/catwalk_plated/dark,
@@ -16088,7 +14664,9 @@
 /area/hallway/primary/fourthdeck/aft)
 "ZV" = (
 /obj/item/stool/bar/padded,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/fancyfloor/carpet{
+	dir = 1
+	},
 /area/crew_quarters/lounge)
 "ZW" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -16123,15 +14701,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/red,
-/obj/floor_decal/corner/white{
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = -28
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/fourthdeck/fore)
 
 (1,1,1) = {"
@@ -26526,18 +25100,18 @@ Dl
 RQ
 RQ
 RQ
-iZ
+RQ
 ej
 me
 nk
 Se
-oh
-oh
-pJ
+KR
+KR
+KR
 sp
-BC
+KR
 vm
-wC
+Se
 xR
 zm
 AH
@@ -26728,8 +25302,8 @@ Dl
 RQ
 RQ
 RQ
-ja
-la
+RQ
+ej
 mf
 nl
 WH
@@ -26929,13 +25503,13 @@ Dl
 RQ
 RQ
 RQ
-hO
-jb
+RQ
+RQ
 ej
 mg
 nm
 oA
-oz
+dg
 pL
 dg
 dg
@@ -27130,11 +25704,11 @@ Dl
 RQ
 RQ
 RQ
-gY
-hP
-jc
+RQ
+RQ
+RQ
 ej
-mh
+Pz
 RB
 oA
 dg
@@ -27331,11 +25905,11 @@ Dl
 RQ
 RQ
 RQ
-fY
-gZ
-hQ
-jd
-lb
+RQ
+RQ
+RQ
+RQ
+ej
 mi
 Nu
 no
@@ -27532,11 +26106,11 @@ Dl
 RQ
 RQ
 RQ
-fi
-fZ
-ha
-hR
-ZO
+RQ
+RQ
+RQ
+RQ
+RQ
 ej
 Uy
 mj
@@ -27737,8 +26311,8 @@ ej
 ej
 ej
 ej
-hS
-hS
+ej
+ej
 ej
 mk
 nm
@@ -27751,7 +26325,7 @@ tX
 vs
 dg
 xW
-zs
+ZZ
 AH
 AH
 CS
@@ -27938,7 +26512,7 @@ cv
 ek
 fj
 ga
-hb
+hT
 hT
 RN
 le
@@ -28153,7 +26727,7 @@ ra
 su
 tY
 vt
-oB
+wF
 xY
 zu
 AK
@@ -28340,10 +26914,10 @@ YK
 WZ
 WZ
 kk
-mK
-mK
-mK
-mK
+kk
+kk
+kk
+kk
 kk
 kk
 NA
@@ -28541,25 +27115,25 @@ Dl
 Dl
 tv
 tv
-XH
-Qo
-Qo
-Qo
-Qo
-YE
+kk
+kk
+kk
+kk
+kk
+kk
 kk
 mn
 Si
-Sv
+oF
 wF
 pS
 rc
 sw
 ua
 vv
-oB
+wF
 nx
-Le
+Pz
 le
 BT
 CU
@@ -28743,12 +27317,12 @@ Dl
 Dl
 tv
 tv
-MG
-Ul
-Ul
-Ul
-Mr
-ab
+kk
+kk
+kk
+kk
+kk
+kk
 kk
 hu
 nu
@@ -28945,25 +27519,25 @@ Dl
 Dl
 tv
 tv
-LZ
-PY
-pj
-PY
-Ct
-Oh
+kk
+kk
+kk
+kk
+kk
+kk
 kk
 mp
 qg
-oE
+Su
 Su
 pU
-Xk
+Tv
 sy
 Ye
 vx
-hE
+wF
 yb
-Le
+Pz
 le
 BV
 BV
@@ -29147,14 +27721,14 @@ Dl
 Dl
 tv
 tv
-OQ
-RZ
-RZ
-RZ
-JY
-zD
 kk
-SU
+kk
+kk
+kk
+kk
+kk
+kk
+Pz
 Mf
 Yx
 Nf
@@ -29163,7 +27737,7 @@ Ry
 sy
 Ye
 vy
-hE
+wF
 nx
 Bm
 le
@@ -29349,14 +27923,14 @@ Dl
 Dl
 tv
 tv
-lY
-fp
-SC
-hg
-Nd
-jh
-kj
-Eo
+kk
+kk
+kk
+kk
+kk
+kk
+kk
+Pz
 TA
 Yx
 OG
@@ -29365,7 +27939,7 @@ OU
 sy
 ub
 vz
-hE
+wF
 nx
 ZZ
 le
@@ -29564,11 +28138,11 @@ le
 le
 le
 wF
-hE
+wF
 uc
 wF
 wF
-Pv
+Si
 zy
 le
 BY
@@ -29965,7 +28539,7 @@ le
 mt
 Rt
 nA
-oI
+KR
 pX
 KR
 sA
@@ -30169,9 +28743,9 @@ rp
 rp
 rp
 rp
-rj
+WR
 sG
-Up
+WR
 vC
 Nm
 ay
@@ -30371,7 +28945,7 @@ kl
 kl
 kl
 pZ
-rh
+qx
 sC
 ug
 OX
@@ -30573,7 +29147,7 @@ kl
 kl
 kl
 MR
-qa
+WR
 sD
 uh
 vE
@@ -30775,7 +29349,7 @@ kl
 kl
 kl
 MR
-ri
+YL
 sL
 ui
 OX
@@ -30977,9 +29551,9 @@ kl
 kl
 kl
 MR
-qa
+WR
 sF
-Up
+WR
 KH
 Qq
 yh
@@ -31781,11 +30355,11 @@ id
 fl
 gd
 he
-hW
+VU
 Wk
 kh
 fl
-rl
+YL
 sI
 um
 rp
@@ -31987,9 +30561,9 @@ hX
 jg
 VU
 nn
-rg
+WR
 UY
-QC
+WR
 vJ
 CG
 CG
@@ -32191,7 +30765,7 @@ ki
 lf
 WC
 VJ
-QC
+WR
 vJ
 CG
 CG
@@ -32202,11 +30776,11 @@ gg
 UN
 Yl
 Yr
-iS
-iS
-iS
-iS
-iS
+Sd
+Sd
+Sd
+Sd
+Sd
 Ra
 MZ
 Ze
@@ -32391,9 +30965,9 @@ my
 zE
 oO
 nn
-Xo
+qx
 sK
-up
+qx
 HE
 CG
 CG
@@ -32402,13 +30976,13 @@ CG
 Wf
 gg
 Sd
-iS
-iS
-iS
+Sd
+Sd
+Sd
 Nb
 Li
 fa
-iS
+Sd
 Db
 LO
 Pu
@@ -32593,9 +31167,9 @@ TT
 TT
 fl
 fl
-Hw
+rU
 MW
-ct
+LI
 rp
 iI
 wS
@@ -32603,14 +31177,14 @@ wS
 wS
 Cg
 gg
-Yd
+Sd
 WD
 hr
 YD
 SP
 RY
 RY
-iS
+Sd
 Db
 PR
 mL
@@ -32795,9 +31369,9 @@ WI
 WI
 kb
 Wo
-za
+WR
 MW
-QC
+WR
 jY
 gg
 gg
@@ -32805,14 +31379,14 @@ gg
 gg
 gg
 gg
-Yd
+Sd
 ZV
 TY
 PC
 MY
 YZ
 Ml
-iS
+Sd
 IN
 Rk
 QJ
@@ -32999,7 +31573,7 @@ Tp
 rp
 cF
 wl
-ii
+cF
 rp
 EC
 EC
@@ -33014,7 +31588,7 @@ Zq
 Mu
 NZ
 UD
-iS
+Sd
 Nr
 Pp
 Pk
@@ -33199,9 +31773,9 @@ vH
 aY
 aY
 rp
-za
+WR
 Yn
-QC
+WR
 rp
 CG
 CG
@@ -33218,8 +31792,8 @@ Sd
 Sd
 Sd
 uw
-iS
-iS
+Sd
+Sd
 Uu
 Uu
 Dl
@@ -33386,24 +31960,24 @@ ak
 NU
 bu
 uY
-fd
+Mp
 ap
-fd
-fd
-fd
-fd
-fd
-fd
-fd
+Mp
+Mp
+Mp
+Mp
+Mp
+Mp
+Mp
 Mp
 Pt
 vH
 aY
 aY
 rp
-za
+WR
 Yn
-QC
+WR
 rp
 CG
 CG
@@ -33416,8 +31990,8 @@ ER
 FB
 Zk
 Sd
-Hv
-PO
+Sd
+RY
 jr
 OO
 Jo
@@ -33588,7 +32162,7 @@ ak
 aS
 bv
 Lu
-fd
+Mp
 QA
 dR
 eA
@@ -33603,9 +32177,9 @@ vH
 aY
 aY
 rp
-za
+WR
 Yn
-QC
+WR
 rp
 CG
 CG
@@ -33797,7 +32371,7 @@ eB
 Wx
 Wx
 Xg
-dS
+BC
 jn
 WI
 Pn
@@ -33805,9 +32379,9 @@ aY
 aY
 aY
 rp
-za
+WR
 sK
-QC
+WR
 rp
 CG
 CG
@@ -33994,7 +32568,7 @@ er
 VR
 fd
 Tz
-dS
+oh
 OI
 fB
 gs
@@ -34026,8 +32600,8 @@ RV
 XW
 MN
 OO
-Jo
-ES
+uj
+hW
 pG
 sJ
 Dl
@@ -34194,9 +32768,9 @@ ak
 aV
 er
 VR
-fd
+Mp
 Rq
-dS
+oh
 em
 gs
 XG
@@ -34225,11 +32799,11 @@ FB
 Rf
 Sd
 Sd
-iS
-iS
+Sd
+Sd
 Ux
 lX
-iS
+Sd
 Uu
 Uu
 Dl
@@ -34396,14 +32970,14 @@ ak
 aU
 er
 VR
-fd
+Mp
 py
-dS
+ZO
 RT
 Yu
 Yu
 ho
-dS
+MG
 jn
 WI
 WI
@@ -34413,7 +32987,7 @@ rp
 rp
 qM
 Yn
-NP
+WR
 wn
 rp
 CG
@@ -34426,7 +33000,7 @@ ES
 TY
 Gp
 GY
-iS
+Sd
 NX
 Kz
 rt
@@ -34598,24 +33172,24 @@ ak
 cw
 er
 bY
-fd
-fd
+Mp
+Mp
 dT
 ZR
 XM
 XM
 hp
 Ol
-fd
-fd
+Mp
+Mp
 Pt
 vH
 aY
 aY
 ro
-NP
+WR
 UX
-NP
+WR
 ro
 CG
 CG
@@ -34628,7 +33202,7 @@ ET
 PK
 Pe
 Qt
-iS
+Sd
 YF
 zx
 Ss
@@ -34801,7 +33375,7 @@ bN
 bw
 bZ
 dU
-fd
+Mp
 OZ
 eC
 WU
@@ -34809,7 +33383,7 @@ gu
 hq
 LQ
 jq
-fd
+Mp
 hh
 oW
 Ga
@@ -34825,12 +33399,12 @@ pI
 pI
 mG
 WM
-Yd
+Sd
 Wh
 TY
 Gp
 Gq
-iS
+Sd
 Ib
 eq
 IT
@@ -35003,7 +33577,7 @@ bN
 bw
 bZ
 dU
-fd
+Mp
 Un
 XM
 XM
@@ -35011,15 +33585,15 @@ XM
 uy
 Uo
 Zd
-fd
+Mp
 hh
 TM
 Rg
 Ga
 ro
-NP
+WR
 UX
-NP
+WR
 ro
 pI
 pI
@@ -35027,7 +33601,7 @@ pI
 pI
 mG
 WM
-Yd
+Sd
 EY
 FB
 Zp
@@ -35205,7 +33779,7 @@ bN
 bw
 bZ
 dU
-fd
+Mp
 fd
 cq
 gw
@@ -35213,7 +33787,7 @@ RL
 in
 Uo
 RC
-fd
+Mp
 hh
 hh
 hh
@@ -35229,12 +33803,12 @@ pI
 pI
 lk
 WM
-Yd
+Sd
 EZ
-TY
+Qo
 Uj
 Tx
-iS
+Sd
 Id
 eq
 IT
@@ -35407,15 +33981,15 @@ er
 er
 cK
 er
-fd
-fd
-fd
-fd
-fd
-fd
-fd
-fd
-fd
+Mp
+Mp
+Mp
+Mp
+Mp
+Mp
+Mp
+Mp
+Mp
 VW
 VW
 Pt
@@ -35635,9 +34209,9 @@ WM
 if
 yp
 Sd
-iS
-iS
-iS
+Sd
+Sd
+Sd
 Sd
 If
 kw
@@ -35825,9 +34399,9 @@ VW
 WI
 vH
 rp
-za
+WR
 SA
-QC
+WR
 rp
 pI
 pI
@@ -36027,9 +34601,9 @@ VW
 WI
 vH
 rp
-za
+WR
 Yn
-QC
+WR
 rp
 pI
 pI
@@ -36229,9 +34803,9 @@ VW
 WI
 vH
 rp
-za
+WR
 Yn
-QC
+WR
 rp
 pI
 pI
@@ -36431,9 +35005,9 @@ mJ
 WI
 vH
 rp
-za
+WR
 Yn
-QC
+WR
 rp
 pI
 pI
@@ -36441,7 +35015,7 @@ mG
 WM
 Cr
 Vw
-yy
+Em
 Fb
 Lo
 Rb
@@ -36633,9 +35207,9 @@ VW
 hh
 TM
 rp
-Ap
+cF
 wl
-WQ
+cF
 rp
 Lk
 Lk
@@ -36643,10 +35217,10 @@ lk
 WM
 vQ
 VC
-yy
-yy
+Em
+Em
 uo
-yy
+Em
 KD
 tz
 kS
@@ -36835,9 +35409,9 @@ VW
 va
 Ar
 Wo
-RW
+qx
 xJ
-up
+qx
 jY
 WM
 ND
@@ -36848,7 +35422,7 @@ jB
 IF
 UI
 mo
-yy
+Em
 mz
 sh
 Zu
@@ -37239,9 +35813,9 @@ mM
 nT
 pf
 qr
-rH
+iQ
 UZ
-VL
+iQ
 Wn
 Ym
 kM
@@ -37441,11 +36015,11 @@ SG
 nU
 pg
 qr
-oV
+iQ
 UZ
-yC
+iQ
 gM
-yC
+iQ
 Ab
 Ab
 MT
@@ -37645,9 +36219,9 @@ kT
 Ed
 Hn
 GU
-yC
+iQ
 rz
-yC
+iQ
 yD
 ZS
 yH
@@ -37847,9 +36421,9 @@ pi
 qr
 iQ
 jW
-yC
+iQ
 rz
-yC
+iQ
 Jj
 Jj
 ZE
@@ -38060,9 +36634,9 @@ Yf
 Yf
 Yf
 uI
-Uh
+Np
 yj
-yu
+ce
 ce
 Yf
 eQ
@@ -38463,8 +37037,8 @@ vK
 Wd
 PB
 Qe
-Me
-Uh
+tA
+Np
 HV
 HV
 HV
@@ -38657,7 +37231,7 @@ bx
 MI
 Vi
 vK
-xn
+zM
 PT
 Pj
 ZQ
@@ -38857,7 +37431,7 @@ rk
 rk
 PI
 tK
-ql
+Vi
 Pa
 Vm
 Qu
@@ -40252,7 +38826,7 @@ tG
 RR
 aJ
 bk
-Mx
+Jx
 AB
 YR
 YR
@@ -40260,33 +38834,33 @@ YR
 eX
 US
 LU
-ag
-ag
+YR
+YR
 ZP
 xF
-ag
+YR
 mQ
-ag
+YR
 pu
 WX
-rH
+iQ
 Ta
 uK
 Wm
 JA
 mD
 Ae
-cj
-ag
-Dw
-ag
-ag
+AB
+YR
+ZP
+YR
+YR
 Fk
 Ud
 KU
-uj
-uj
-uj
+YR
+YR
+YR
 lJ
 Jx
 JP

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -23,11 +23,11 @@
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/brig)
 "ae" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "af" = (
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/vacant/brig)
 "ag" = (
 /turf/simulated/floor/plating,
@@ -35,22 +35,22 @@
 "ah" = (
 /obj/structure/table/standard,
 /obj/random/junk,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/vacant/brig)
 "ai" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/vacant/brig)
 "aj" = (
 /turf/simulated/wall/r_wall/hull,
 /area/crew_quarters/gym)
 "ak" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "al" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "am" = (
 /obj/machinery/shieldwallgen{
@@ -80,18 +80,18 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "aq" = (
 /obj/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "ar" = (
 /obj/decal/cleanable/vomit,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "as" = (
 /obj/structure/hygiene/toilet{
@@ -117,26 +117,16 @@
 /turf/simulated/floor/plating,
 /area/vacant/brig)
 "ax" = (
-/obj/floor_decal/corner/red{
-	dir = 1
-	},
 /obj/machinery/constructable_frame/computerframe,
-/turf/simulated/floor/tiled,
-/area/vacant/brig)
-"ay" = (
-/obj/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "az" = (
 /obj/structure/door_assembly,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "aA" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "aB" = (
 /obj/structure/closet{
@@ -148,17 +138,17 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/vacant/brig)
 "aD" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/vacant/brig)
 "aE" = (
 /obj/machinery/door/airlock/security{
 	name = "Old Brig"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "aF" = (
 /obj/random/obstruction,
@@ -169,14 +159,14 @@
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/brig,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "aH" = (
 /obj/floor_decal/industrial/warning{
 	dir = 5
 	},
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "aI" = (
 /turf/simulated/floor/reinforced,
@@ -185,7 +175,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "aK" = (
 /obj/structure/cable/green{
@@ -193,7 +183,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "aL" = (
 /obj/machinery/power/apc{
@@ -228,11 +218,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
-/obj/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "aQ" = (
 /turf/simulated/wall/r_wall/hull,
@@ -242,10 +228,7 @@
 /obj/structure/sign/deck/third{
 	pixel_y = 32
 	},
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "aS" = (
 /obj/structure/cable/green{
@@ -256,7 +239,7 @@
 /obj/machinery/door/airlock/security{
 	name = "Old Brig"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "aT" = (
 /turf/simulated/wall/r_wall/hull,
@@ -301,7 +284,7 @@
 /obj/floor_decal/corner/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "bd" = (
 /turf/simulated/wall/r_wall/hull,
@@ -348,7 +331,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "bn" = (
 /obj/decal/cleanable/dirt,
@@ -410,20 +393,14 @@
 /area/crew_quarters/gym)
 "bx" = (
 /obj/machinery/biogenerator,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "by" = (
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/floor_decal/corner/green{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "bz" = (
 /obj/structure/closet/crate,
@@ -463,14 +440,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "bC" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/smartfridge/drying_rack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "bD" = (
 /obj/machinery/alarm{
@@ -483,7 +457,7 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/floor_decal/corner/green/mono,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hydroponics)
 "bE" = (
 /obj/random/obstruction,
@@ -680,7 +654,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/janitor/storage)
 "bS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -694,7 +668,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/chief_steward)
 "bT" = (
 /obj/structure/table/standard,
@@ -755,8 +729,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "cd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -773,10 +746,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -798,10 +768,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "cf" = (
 /obj/structure/cable/green{
@@ -824,20 +791,17 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "cg" = (
 /obj/floor_decal/corner/yellow/half{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "ch" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "ci" = (
 /obj/machinery/button/blast_door{
@@ -850,7 +814,7 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/floor_decal/corner/green/mono,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hydroponics)
 "cj" = (
 /obj/structure/closet/emcloset,
@@ -961,18 +925,9 @@
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/thirddeck/aftstarboard)
-"cw" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
 "cz" = (
 /obj/machinery/photocopier,
-/obj/floor_decal/corner/green/half{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/chief_steward)
 "cB" = (
 /obj/structure/closet/jcloset_torch,
@@ -1089,7 +1044,7 @@
 "cN" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/galley)
 "cO" = (
 /obj/machinery/door/firedoor,
@@ -1135,10 +1090,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "cS" = (
 /obj/structure/cable/green{
@@ -1171,10 +1123,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/galley)
 "cV" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "cW" = (
 /obj/floor_decal/industrial/warning{
@@ -1201,27 +1150,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
-"cY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/floor_decal/corner/green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "cZ" = (
 /obj/machinery/door/firedoor,
@@ -1310,7 +1239,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "dd" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/thirddeck/starboard)
 "de" = (
 /obj/item/beach_ball,
@@ -1469,18 +1398,6 @@
 /obj/machinery/cooker/fryer,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
-"dB" = (
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
-"dC" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
 "dD" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
@@ -1542,11 +1459,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/vending/hydronutrients/generic,
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
-/obj/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "dI" = (
 /obj/structure/catwalk,
@@ -1590,7 +1503,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "dM" = (
 /obj/machinery/suit_storage_unit/atmos/alt/sol,
@@ -1606,7 +1519,7 @@
 	dir = 4
 	},
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "dO" = (
 /obj/machinery/field_generator,
@@ -1614,15 +1527,12 @@
 /area/maintenance/thirddeck/starboard)
 "dP" = (
 /obj/machinery/light,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1655,7 +1565,7 @@
 /area/maintenance/thirddeck/starboard)
 "dS" = (
 /obj/machinery/washing_machine,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/thirddeck/starboard)
 "dT" = (
 /obj/machinery/alarm{
@@ -1872,7 +1782,7 @@
 /area/hallway/primary/thirddeck/fore)
 "eA" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/vacant/brig)
 "eB" = (
 /obj/machinery/light{
@@ -1977,9 +1887,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/thirddeck)
 "eL" = (
-/obj/floor_decal/corner/green{
-	dir = 1
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -1989,7 +1896,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "eM" = (
 /obj/machinery/door/firedoor,
@@ -2100,7 +2007,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/chief_steward)
 "fb" = (
 /turf/simulated/wall/r_wall/hull,
@@ -2126,7 +2033,7 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/thirddeck/starboard)
 "ff" = (
 /obj/machinery/door/firedoor,
@@ -2142,7 +2049,7 @@
 	id_tag = "cs_door";
 	name = "Chief Steward's Office"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/chief_steward)
 "fg" = (
 /obj/structure/railing/mapped{
@@ -2206,7 +2113,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "fn" = (
 /obj/machinery/door/airlock/engineering{
@@ -2264,7 +2171,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "ft" = (
 /obj/structure/closet/secure_closet/bar_torch,
@@ -2323,7 +2230,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "fy" = (
 /obj/structure/closet/fridge/meat,
@@ -2353,7 +2260,6 @@
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
-/obj/structure/closet/secure_closet/personal/empty,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "fE" = (
@@ -2559,7 +2465,7 @@
 /obj/structure/table/steel,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/thirddeck/starboard)
 "fV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2636,9 +2542,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftstarboard)
 "ge" = (
-/obj/floor_decal/corner/green{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2773,7 +2676,7 @@
 	dir = 10
 	},
 /obj/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "gv" = (
 /obj/floor_decal/corner/blue/diagonal{
@@ -3023,7 +2926,7 @@
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "gV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -3174,7 +3077,6 @@
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
-/obj/structure/closet/secure_closet/personal/empty,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "hq" = (
@@ -3496,7 +3398,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "hY" = (
 /obj/machinery/door/firedoor,
@@ -3580,7 +3482,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/gym)
 "ih" = (
 /obj/structure/closet/crate/warhammer/freezer,
@@ -3678,7 +3580,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/obj/floor_decal/corner/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3688,7 +3589,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "iq" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -3885,7 +3786,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/floor_decal/corner/green/half,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -3893,13 +3793,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
-"iL" = (
-/obj/floor_decal/corner/green{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "iN" = (
 /obj/structure/table/standard,
@@ -4070,7 +3964,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "jc" = (
 /obj/floor_decal/corner/blue/diagonal{
@@ -4085,12 +3979,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
-"je" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
 "jf" = (
 /obj/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -4136,8 +4024,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/safe_room/thirddeck)
 "ji" = (
-/obj/floor_decal/corner/green/half,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/aft)
 "jj" = (
 /obj/floor_decal/corner/blue/diagonal{
@@ -4173,7 +4060,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "jn" = (
 /obj/floor_decal/corner/blue/diagonal{
@@ -4192,10 +4079,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/floor_decal/corner/green/half{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/chief_steward)
 "jp" = (
 /obj/machinery/button/windowtint{
@@ -4290,7 +4174,7 @@
 	dir = 8
 	},
 /obj/floor_decal/corner/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "jG" = (
 /obj/structure/ore_box,
@@ -4367,7 +4251,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "jO" = (
 /obj/machinery/light/small{
@@ -4426,7 +4310,7 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/floor_decal/corner/green/mono,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hydroponics)
 "jU" = (
 /obj/machinery/power/apc{
@@ -4700,12 +4584,11 @@
 /area/janitor/storage)
 "kB" = (
 /obj/machinery/disposal,
-/obj/floor_decal/corner/green,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "kC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4869,7 +4752,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/aft)
 "kS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4955,23 +4838,14 @@
 /obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
-"lc" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
 "ld" = (
 /turf/simulated/open,
 /area/crew_quarters/mess)
 "le" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "lf" = (
 /obj/random/junk,
@@ -5151,7 +5025,7 @@
 /obj/item/material/hatchet,
 /obj/item/material/minihoe,
 /obj/item/screwdriver,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "lB" = (
 /obj/floor_decal/corner/blue/diagonal{
@@ -5207,11 +5081,8 @@
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d3starboard)
 "lJ" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "lK" = (
 /obj/machinery/light{
@@ -5295,33 +5166,21 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftstarboard)
 "lV" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/structure/flora/pottedplant/orientaltree,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "lW" = (
 /obj/machinery/vending/hydronutrients/generic,
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "lX" = (
 /obj/machinery/seed_storage/garden,
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "lY" = (
 /obj/structure/table/standard,
 /obj/item/material/minihoe,
 /obj/item/material/hatchet,
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/machinery/light/spot{
 	dir = 1
 	},
@@ -5330,16 +5189,10 @@
 "lZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "ma" = (
 /obj/structure/closet/crate/hydroponics/beekeeping,
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "mb" = (
@@ -5355,9 +5208,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/service_break_room)
 "mc" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm{
 	dir = 8;
@@ -5555,13 +5405,13 @@
 "mw" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "mx" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/holocontrol)
 "my" = (
 /obj/structure/table/standard,
@@ -5573,7 +5423,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/holocontrol)
 "mB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5590,7 +5440,7 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "mF" = (
 /obj/structure/table/rack,
@@ -5606,7 +5456,7 @@
 /obj/structure/table/standard,
 /obj/machinery/recharger,
 /obj/item/wrench,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/gym)
 "mI" = (
 /obj/floor_decal/spline/plain/red,
@@ -5663,13 +5513,13 @@
 	dir = 4
 	},
 /obj/floor_decal/corner/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "mV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "mW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5717,7 +5567,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/closet/emcloset,
 /obj/floor_decal/corner/green/mono,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "nb" = (
 /obj/item/storage/mirror{
@@ -5811,7 +5661,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/holocontrol)
 "nm" = (
 /obj/structure/table/steel,
@@ -5831,7 +5681,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/hardstorage)
 "np" = (
-/obj/floor_decal/corner/green/half,
 /obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
@@ -5847,7 +5696,7 @@
 /obj/structure/bed/chair/office/comfy/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "nt" = (
 /obj/floor_decal/industrial/warning/corner,
@@ -5856,14 +5705,14 @@
 	linkedholodeck_area = /area/holodeck/alphadeck;
 	programs_list_id = "TorchMainPrograms"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/holocontrol)
 "nu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "nw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -5926,9 +5775,6 @@
 	departmentType = 5;
 	pixel_y = -32
 	},
-/obj/floor_decal/corner/red{
-	dir = 10
-	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
@@ -5953,14 +5799,14 @@
 	icon_state = "4-8"
 	},
 /obj/structure/hygiene/drain,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "nP" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "nQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6001,7 +5847,7 @@
 /obj/floor_decal/corner/yellow{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "nS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6111,40 +5957,31 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hydroponics)
 "oa" = (
 /obj/structure/stairs/west,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "ob" = (
-/obj/floor_decal/corner/green/half{
-	dir = 8
-	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "oc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/floor_decal/corner/green/half{
 	dir = 4
 	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "od" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -6161,14 +5998,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/floor_decal/corner/green{
-	dir = 6
-	},
 /obj/structure/sign/deck/third{
 	dir = 8;
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "og" = (
 /obj/structure/cable/green{
@@ -6211,7 +6045,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/holocontrol)
 "ol" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -6220,7 +6054,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/holocontrol)
 "om" = (
 /obj/machinery/door/firedoor,
@@ -6284,15 +6118,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/primary/thirddeck/fore)
 "ov" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6304,16 +6135,13 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "oy" = (
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "oz" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -6351,11 +6179,8 @@
 	pixel_y = 24
 	},
 /obj/structure/closet/hydroponics_torch,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "oJ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -6380,7 +6205,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "oL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -6389,7 +6214,7 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "oM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6428,14 +6253,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/floor_decal/corner/green/half{
-	dir = 4
-	},
 /obj/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "oV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6459,10 +6281,7 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/obj/floor_decal/corner/green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "oX" = (
 /obj/structure/bed/chair/wood{
@@ -6477,7 +6296,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/aft)
 "oY" = (
 /obj/structure/cable/green{
@@ -6685,7 +6504,7 @@
 	dir = 4;
 	pixel_x = -21
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/holocontrol)
 "pk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6694,7 +6513,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/holocontrol)
 "pl" = (
 /obj/random/obstruction,
@@ -6714,16 +6533,15 @@
 	name = "Habitation Deck Hallway Shutters";
 	opacity = 0
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "pp" = (
 /obj/structure/fitness/weightlifter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "pq" = (
 /obj/structure/cable/green{
@@ -6740,7 +6558,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "pr" = (
 /obj/structure/cable/green{
@@ -6778,7 +6596,6 @@
 /turf/simulated/floor/plating,
 /area/thruster/d3port)
 "pu" = (
-/obj/floor_decal/corner/green,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -6852,11 +6669,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/gym)
 "pG" = (
-/obj/floor_decal/corner/green/half,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/commissary)
 "pH" = (
 /obj/structure/disposalpipe/segment,
@@ -6867,7 +6683,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "pI" = (
 /turf/simulated/wall/r_wall/hull,
@@ -6891,7 +6707,7 @@
 	pixel_x = 24
 	},
 /obj/floor_decal/corner/paleblue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "pO" = (
 /turf/simulated/open,
@@ -6902,17 +6718,14 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/obj/floor_decal/corner/green/half{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "pR" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
 	dir = 4;
 	icon_state = "console"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/command/disperser)
 "pS" = (
 /obj/structure/sign/directions/evac{
@@ -7084,7 +6897,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "qs" = (
 /obj/structure/table/woodentable,
@@ -7095,7 +6908,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "qt" = (
 /obj/floor_decal/corner/lime/three_quarters{
@@ -7104,7 +6917,7 @@
 /obj/machinery/vending/cola{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "qu" = (
 /turf/simulated/floor/carpet,
@@ -7151,7 +6964,7 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "qB" = (
 /obj/decal/cleanable/dirt,
@@ -7197,11 +7010,11 @@
 /obj/floor_decal/corner/yellow{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "qL" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "qM" = (
 /obj/structure/catwalk,
@@ -7223,47 +7036,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
-"qP" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
 "qQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "qS" = (
 /obj/structure/disposalpipe/segment,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "qT" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/grass,
 /area/crew_quarters/observation)
 "qU" = (
-/obj/floor_decal/corner/green{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "qV" = (
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "qW" = (
 /obj/machinery/atmospherics/valve/digital{
@@ -7305,39 +7100,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/thirddeck/center)
-"rb" = (
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
 "rc" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
-"re" = (
-/obj/floor_decal/corner/green/half,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
-"rf" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "rh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/obj/floor_decal/corner/green{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "ri" = (
 /obj/machinery/light{
@@ -7346,16 +7119,13 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "rk" = (
 /obj/floor_decal/corner/yellow{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "rl" = (
 /obj/machinery/alarm{
@@ -7364,7 +7134,7 @@
 /obj/floor_decal/corner/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "rm" = (
 /obj/floor_decal/corner/grey/diagonal{
@@ -7384,7 +7154,7 @@
 "rp" = (
 /obj/machinery/door/firedoor,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "rr" = (
 /obj/machinery/power/apc{
@@ -7396,10 +7166,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/floor_decal/corner/green{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "rt" = (
 /obj/machinery/camera/network/third_deck{
@@ -7408,19 +7175,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/aft)
 "ru" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "rv" = (
 /obj/machinery/hologram/holopad,
@@ -7432,13 +7193,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/holocontrol)
 "rw" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "rx" = (
 /obj/machinery/newscaster{
@@ -7447,7 +7205,7 @@
 /obj/floor_decal/corner/lime{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "rz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7487,7 +7245,7 @@
 /obj/floor_decal/corner/lime/three_quarters{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "rC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7607,7 +7365,7 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "rS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7674,16 +7432,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "sc" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "se" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -7693,7 +7445,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "sf" = (
 /obj/structure/disposalpipe/segment{
@@ -7723,7 +7475,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "sg" = (
 /obj/structure/cable/green{
@@ -7740,7 +7492,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "sh" = (
 /obj/structure/cable/green{
@@ -7823,8 +7575,7 @@
 	name = "Habitation Deck Hallway Shutters";
 	opacity = 0
 	},
-/obj/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "sn" = (
 /obj/structure/cable/green{
@@ -7911,7 +7662,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "sv" = (
 /obj/structure/cable/green{
@@ -7928,7 +7679,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/aft)
 "sw" = (
 /obj/structure/cable/green{
@@ -7979,13 +7730,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "sz" = (
 /obj/floor_decal/corner/yellow{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "sA" = (
 /obj/floor_decal/corner/grey/diagonal{
@@ -8120,7 +7871,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/gym)
 "sJ" = (
 /obj/structure/disposalpipe/segment{
@@ -8153,7 +7904,7 @@
 /area/crew_quarters/recreation)
 "sM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/cryolocker)
 "sN" = (
 /obj/structure/disposalpipe/segment{
@@ -8170,7 +7921,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "sP" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -8218,10 +7969,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/tele_beacon,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
-"sW" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "sX" = (
 /obj/floor_decal/corner/lime{
@@ -8232,7 +7980,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "sZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8281,7 +8029,7 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "th" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8298,10 +8046,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "ti" = (
 /obj/random/junk,
@@ -8350,14 +8095,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "ts" = (
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Fore Center";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "tt" = (
 /obj/machinery/door/firedoor,
@@ -8371,21 +8116,6 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
-"tv" = (
-/obj/floor_decal/corner/red{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
-"tw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/floor_decal/corner/red{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
 "tx" = (
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Lift";
@@ -8395,10 +8125,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/floor_decal/corner/red{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "ty" = (
 /obj/floor_decal/corner/blue{
@@ -8421,44 +8148,34 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "tC" = (
 /obj/machinery/light,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "tD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = -28
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "tE" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/floor_decal/corner/green/half,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "tF" = (
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "tG" = (
 /obj/floor_decal/techfloor{
@@ -8468,11 +8185,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/thirddeck)
 "tH" = (
-/obj/floor_decal/corner/green/half,
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "tI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8481,19 +8197,13 @@
 /obj/machinery/computer/guestpass{
 	pixel_y = -32
 	},
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "tJ" = (
 /obj/machinery/atm{
 	pixel_y = -32
 	},
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "tK" = (
 /obj/structure/lattice,
@@ -8504,7 +8214,7 @@
 	c_tag = "Third Deck Hallway - Fore Starboard";
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "tN" = (
 /obj/structure/bed/chair/pew/left/mahogany,
@@ -8514,10 +8224,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"tP" = (
-/obj/floor_decal/corner/red/half,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
 "tR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8527,14 +8233,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "tS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
-	},
-/obj/floor_decal/corner/green{
-	dir = 10
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -8543,7 +8246,7 @@
 	c_tag = "Third Deck Hallway - Midships Aft";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "tT" = (
 /obj/structure/cable/green{
@@ -8551,7 +8254,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "tU" = (
 /obj/structure/cable/green{
@@ -8570,10 +8273,7 @@
 /area/maintenance/thirddeck/foreport)
 "tW" = (
 /obj/machinery/light,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "tX" = (
 /obj/decal/cleanable/dirt,
@@ -8596,9 +8296,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
 "ua" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -8606,7 +8303,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "ub" = (
 /turf/simulated/wall/walnut,
@@ -8618,10 +8315,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/gym)
 "ue" = (
-/obj/floor_decal/corner/green/half,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -8630,7 +8326,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/aft)
 "uf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -8677,7 +8373,7 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "ul" = (
 /obj/floor_decal/corner/lime{
@@ -8687,14 +8383,14 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "um" = (
 /obj/floor_decal/corner/lime{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "un" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -8708,7 +8404,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "up" = (
 /obj/wallframe_spawn/reinforced,
@@ -8743,7 +8439,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/gym)
 "ut" = (
 /turf/simulated/wall/prepainted,
@@ -8770,14 +8466,14 @@
 /obj/floor_decal/corner/lime{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "uz" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "uA" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -8808,13 +8504,12 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/recreation)
 "uE" = (
-/obj/floor_decal/corner/green,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "uG" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -9118,7 +8813,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "vw" = (
 /obj/structure/bed/chair/padded/green{
@@ -9150,7 +8845,7 @@
 /turf/simulated/floor/grass,
 /area/crew_quarters/observation)
 "vF" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "vG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9163,7 +8858,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "vH" = (
 /obj/item/device/radio/intercom{
@@ -9193,15 +8888,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
-"vN" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet,
-/obj/item/storage/secure/safe{
-	pixel_x = -22
-	},
-/obj/item/book/manual/sol_sop,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/sleep/bunk)
 "vO" = (
 /obj/structure/curtain/open/bed,
 /turf/simulated/floor/carpet,
@@ -9221,10 +8907,8 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/obj/machinery/vending/snack{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "vS" = (
 /obj/floor_decal/industrial/warning{
@@ -9233,17 +8917,16 @@
 /obj/landmark{
 	name = "JoinLateCryo"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "vT" = (
-/obj/machinery/cryopod,
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "vU" = (
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/warhammer,
 /area/crew_quarters/sleep/cryo)
 "vV" = (
 /obj/floor_decal/industrial/warning{
@@ -9252,7 +8935,7 @@
 /obj/landmark{
 	name = "JoinLateCryo"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "vW" = (
 /obj/structure/cable/green{
@@ -9263,7 +8946,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "vY" = (
 /obj/structure/hygiene/toilet{
@@ -9283,7 +8966,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "wa" = (
 /obj/floor_decal/techfloor{
@@ -9335,13 +9018,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "wk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "wl" = (
 /turf/simulated/wall/prepainted,
@@ -9356,7 +9039,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "wp" = (
 /turf/simulated/floor/lino,
@@ -9461,10 +9144,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "wC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9506,7 +9186,7 @@
 /obj/machinery/vending/fitness{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "wK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -9520,7 +9200,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "wM" = (
 /obj/structure/bed/chair/comfy/black,
@@ -9533,13 +9213,13 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "wO" = (
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "wP" = (
 /obj/structure/extinguisher_cabinet{
@@ -9548,13 +9228,13 @@
 /obj/floor_decal/corner/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "wQ" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "wR" = (
 /obj/floor_decal/industrial/warning/fulltile,
@@ -9582,7 +9262,7 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "wU" = (
 /obj/structure/sign/warning/vent_port{
@@ -9595,10 +9275,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "wW" = (
 /turf/simulated/wall/walnut,
@@ -9615,10 +9292,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/sleep/bunk)
 "wY" = (
-/obj/machinery/vending/cola{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/chef_recipes,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "xb" = (
 /obj/wallframe_spawn/reinforced,
@@ -9640,8 +9316,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "xg" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -9653,7 +9328,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "xi" = (
 /obj/wallframe_spawn/reinforced,
@@ -9697,10 +9372,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/seed_storage/garden,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "xo" = (
 /obj/structure/table/standard,
@@ -9782,17 +9454,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/hardstorage)
 "xC" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/machinery/rotating_alarm/security_alarm,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
-"xE" = (
-/obj/floor_decal/corner/green{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "xF" = (
 /turf/simulated/floor/tiled/steel_grid,
@@ -9802,7 +9465,7 @@
 	dir = 10
 	},
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "xI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -9811,7 +9474,7 @@
 /obj/structure/sign/directions/janitor{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "xJ" = (
 /obj/structure/cable/green{
@@ -9857,7 +9520,7 @@
 "xN" = (
 /obj/structure/table/marble,
 /obj/machinery/recharger,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "xO" = (
 /obj/structure/cable/green{
@@ -9885,10 +9548,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/chief_steward)
 "xQ" = (
 /obj/structure/cable/green{
@@ -9938,16 +9598,13 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "xT" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/floor_decal/corner/green{
-	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9959,7 +9616,7 @@
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "xU" = (
 /obj/wallframe_spawn/reinforced,
@@ -9999,10 +9656,9 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "xY" = (
 /obj/structure/bed/padded,
@@ -10013,7 +9669,6 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/sleep/bunk)
 "xZ" = (
-/obj/structure/table/standard,
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
@@ -10023,8 +9678,8 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/item/book/manual/solgov_law,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/table/warhammer/reinf_table,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "ya" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -10035,7 +9690,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yb" = (
 /obj/structure/cable/green{
@@ -10046,7 +9701,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yc" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -10057,7 +9712,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yd" = (
 /obj/structure/cable/green{
@@ -10075,7 +9730,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "ye" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -10084,7 +9739,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yf" = (
 /obj/floor_decal/industrial/warning{
@@ -10093,7 +9748,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yg" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -10102,7 +9757,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yh" = (
 /obj/machinery/alarm{
@@ -10119,13 +9774,9 @@
 	c_tag = "Third Deck Cryogenics - Aft";
 	dir = 8
 	},
-/obj/structure/table/standard,
-/obj/item/storage/box/cups{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/cups,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/engineering_guide,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yp" = (
 /obj/structure/ladder,
@@ -10134,7 +9785,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "yq" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -10182,7 +9833,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "yz" = (
 /obj/floor_decal/spline/fancy/black{
@@ -10207,7 +9858,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "yG" = (
-/obj/floor_decal/corner/green/half,
 /obj/structure/table/standard,
 /obj/item/storage/box/glasses/pint,
 /obj/item/reagent_containers/food/drinks/glass2/carafe,
@@ -10217,7 +9867,6 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/observation)
 "yI" = (
-/obj/floor_decal/corner/green/half,
 /obj/structure/table/standard,
 /obj/item/storage/box/cups,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -10272,7 +9921,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/sleep/bunk)
 "yS" = (
-/obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -10281,21 +9929,23 @@
 	pixel_x = -24
 	},
 /obj/random/coin,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/anomaly_testing,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yT" = (
 /obj/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yU" = (
 /obj/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yV" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -10304,7 +9954,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yW" = (
 /obj/structure/cable/green{
@@ -10325,7 +9975,7 @@
 /obj/landmark{
 	name = "Observer-Start"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yX" = (
 /obj/floor_decal/industrial/warning/corner,
@@ -10340,7 +9990,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yY" = (
 /obj/floor_decal/industrial/warning,
@@ -10355,7 +10005,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yZ" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -10372,21 +10022,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
-"za" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "zb" = (
 /obj/structure/bedsheetbin,
@@ -10409,7 +10045,7 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/floor_decal/corner/green/mono,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hydroponics)
 "zh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -10424,7 +10060,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "zl" = (
 /obj/structure/cable/green{
@@ -10434,10 +10070,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "zn" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -10502,14 +10135,12 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/thruster/d3port)
 "zz" = (
-/obj/floor_decal/corner/green/half,
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "zB" = (
-/obj/floor_decal/corner/green/half,
 /obj/structure/flora/pottedplant/stoutbush,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -10542,7 +10173,7 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "zF" = (
 /obj/structure/railing/mapped{
@@ -10578,7 +10209,7 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "zL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10594,7 +10225,7 @@
 /obj/floor_decal/corner/yellow{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "zQ" = (
 /obj/structure/railing/mapped{
@@ -10622,7 +10253,6 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/sleep/bunk)
 "zU" = (
-/obj/structure/table/standard,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
@@ -10630,11 +10260,11 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/research_and_development,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "zV" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/spot{
 	dir = 4
 	},
@@ -10643,7 +10273,9 @@
 	pixel_x = 21
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/engineering_hacking,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "zW" = (
 /obj/structure/sign/warning/hot_exhaust,
@@ -10705,12 +10337,6 @@
 "Al" = (
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/thruster/d3starboard)
-"Ap" = (
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
 "Aq" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -10802,20 +10428,22 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "AD" = (
-/obj/structure/table/standard,
 /obj/machinery/computer/cryopod{
 	pixel_x = -32
 	},
 /obj/random/plushie,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/supermatter_engine,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "AE" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/psionics,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "AG" = (
 /obj/structure/hygiene/shower{
@@ -10838,7 +10466,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/tools)
 "AJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -10861,12 +10489,12 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "AL" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/vending/generic,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "AM" = (
 /obj/structure/closet/toolcloset,
@@ -10874,7 +10502,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "AN" = (
 /turf/simulated/wall/prepainted,
@@ -10924,14 +10552,8 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
 /obj/floor_decal/industrial/outline/grey,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "AV" = (
 /obj/floor_decal/spline/fancy/black{
@@ -10979,14 +10601,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/service_break_room)
 "Bg" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "Bi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -11106,17 +10725,13 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Bw" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/uniform_vendor{
-	dir = 8
-	},
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/chemistry_recipes,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "By" = (
 /obj/structure/hygiene/shower{
@@ -11128,24 +10743,21 @@
 "Bz" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "BA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/tools)
 "BD" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/commissary)
 "BF" = (
 /obj/floor_decal/spline/fancy/black,
@@ -11155,12 +10767,6 @@
 	},
 /turf/simulated/floor/wood/maple,
 /area/chapel/main)
-"BG" = (
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
 "BH" = (
 /obj/machinery/firealarm{
 	pixel_y = 21
@@ -11174,19 +10780,19 @@
 /obj/floor_decal/corner/yellow{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "BK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/tools)
 "BL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/tools)
 "BM" = (
 /obj/random/junk,
@@ -11326,16 +10932,15 @@
 	dir = 1
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Cj" = (
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/water_cooler{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/chef_recipes,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Ck" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -11402,7 +11007,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Cs" = (
 /obj/floor_decal/industrial/warning{
@@ -11422,16 +11027,17 @@
 /obj/landmark{
 	name = "JoinLateCryo"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Ct" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/item/device/radio/intercom/entertainment{
 	dir = 8;
 	pixel_x = 22
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/medical_diagnostics_manual,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Cv" = (
 /obj/structure/table/steel,
@@ -11444,7 +11050,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "Cw" = (
 /obj/structure/table/steel,
@@ -11457,7 +11063,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "Cx" = (
 /obj/structure/table/steel,
@@ -11469,7 +11075,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "Cy" = (
 /obj/structure/table/steel,
@@ -11484,7 +11090,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "CB" = (
 /obj/floor_decal/corner/grey/diagonal{
@@ -11498,10 +11104,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
 "CD" = (
-/obj/floor_decal/corner/green/half{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "CE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11522,7 +11125,7 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/recreation)
 "CH" = (
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/maintenance/thirddeck/starboard)
 "CI" = (
 /obj/floor_decal/spline/fancy/black{
@@ -11589,7 +11192,7 @@
 "CP" = (
 /obj/decal/cleanable/dirt,
 /obj/structure/largecrate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/thirddeck/starboard)
 "CQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -11657,7 +11260,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Da" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -11673,7 +11276,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Db" = (
 /obj/floor_decal/industrial/warning{
@@ -11682,7 +11285,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Dc" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -11691,7 +11294,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Dd" = (
 /obj/structure/cable/green{
@@ -11710,7 +11313,7 @@
 /obj/landmark{
 	name = "lightsout"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "De" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -11719,7 +11322,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Df" = (
 /obj/floor_decal/industrial/warning{
@@ -11728,7 +11331,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Dg" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -11737,7 +11340,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Dh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -11746,9 +11349,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/personal,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/warhammer/secure_closet/personal,
+/obj/item/book/manual/barman_recipes,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Di" = (
 /obj/wallframe_spawn/reinforced,
@@ -11814,10 +11418,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "Du" = (
 /obj/machinery/door/firedoor,
@@ -11849,7 +11450,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "Dx" = (
 /obj/structure/disposalpipe/segment{
@@ -11867,13 +11468,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Dy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "Dz" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -11942,9 +11543,6 @@
 /turf/simulated/floor/plating,
 /area/command/disperser)
 "DK" = (
-/obj/random/firstaid,
-/obj/random/medical,
-/obj/random/medical,
 /obj/random/medical,
 /obj/machinery/light{
 	dir = 4;
@@ -11988,10 +11586,9 @@
 	c_tag = "Third Deck Cryogenics - Fore";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "DO" = (
-/obj/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -12001,39 +11598,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
-"DP" = (
-/obj/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
-"DQ" = (
-/obj/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "DR" = (
 /obj/structure/cable/green{
@@ -12055,7 +11620,7 @@
 	icon_state = "1-8"
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "DS" = (
 /obj/machinery/door/firedoor,
@@ -12097,12 +11662,12 @@
 	},
 /obj/structure/bed/chair/comfy/lime,
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/cabin)
 "DW" = (
 /obj/floor_decal/corner/lime,
 /obj/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/cabin)
 "DX" = (
 /obj/machinery/atmospherics/valve/digital{
@@ -12308,12 +11873,12 @@
 /obj/machinery/vending/coffee{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Ew" = (
-/obj/structure/closet/emcloset,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/random_multi/single_item/boombox,
+/obj/structure/closet/warhammer/secure_closet/personal,
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
 "Ex" = (
@@ -12359,7 +11924,7 @@
 /obj/floor_decal/corner/lime{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/cabin)
 "ED" = (
 /turf/simulated/floor/plating,
@@ -12523,7 +12088,7 @@
 /obj/machinery/vending/cigarette{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "EW" = (
 /obj/structure/sign/warning/fall,
@@ -12566,7 +12131,7 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/thirddeck/port)
 "Ff" = (
 /obj/machinery/door/airlock/maintenance{
@@ -12584,7 +12149,7 @@
 "Fh" = (
 /obj/floor_decal/corner/lime,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/cabin)
 "Fi" = (
 /obj/structure/bed/chair/office/light{
@@ -12662,7 +12227,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/holocontrol)
 "Fs" = (
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/gym)
 "Fv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -12715,9 +12280,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/floor_decal/corner/red{
-	dir = 5
-	},
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12748,7 +12310,7 @@
 	c_tag = "Third Deck Hallway - Fore Port";
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "FC" = (
 /obj/machinery/door/firedoor,
@@ -12819,7 +12381,7 @@
 /area/vacant/cabin)
 "FL" = (
 /obj/floor_decal/corner/lime,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/cabin)
 "FM" = (
 /obj/structure/table/steel,
@@ -12886,7 +12448,7 @@
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/cryolocker)
 "FW" = (
 /obj/machinery/firealarm{
@@ -12898,7 +12460,7 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/structure/closet/secure_closet/crew,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/cryolocker)
 "FY" = (
 /obj/floor_decal/corner/grey/diagonal{
@@ -12994,12 +12556,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
-"Gs" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
 "Gt" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4
@@ -13010,7 +12566,7 @@
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Gu" = (
 /obj/structure/disposalpipe/segment{
@@ -13145,15 +12701,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/cryolocker)
-"GC" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
 "GD" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13194,7 +12741,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/aft)
 "GI" = (
 /turf/simulated/floor/carpet,
@@ -13271,13 +12818,13 @@
 /area/maintenance/thirddeck/foreport)
 "GY" = (
 /obj/structure/hygiene/drain,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "GZ" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/cryolocker)
 "Ha" = (
 /obj/structure/disposalpipe/segment,
@@ -13291,9 +12838,6 @@
 /obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)
-"Hc" = (
-/turf/simulated/open,
-/area/crew_quarters/sleep/cryo)
 "Hd" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -13316,7 +12860,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "Hh" = (
 /obj/structure/cable/green{
@@ -13374,7 +12918,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
 "Ho" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/floor_decal/corner/lime{
 	dir = 10
 	},
@@ -13382,15 +12925,14 @@
 	dir = 1
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/cryolocker)
 "Hp" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/floor_decal/corner/lime{
 	dir = 10
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/cryolocker)
 "Hr" = (
 /obj/structure/sign/warning/hot_exhaust{
@@ -13402,7 +12944,7 @@
 /obj/structure/closet/medical_wall/filled{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/gym)
 "Hu" = (
 /obj/structure/cable/green{
@@ -13415,7 +12957,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/tools)
 "Hv" = (
 /obj/floor_decal/techfloor{
@@ -13497,13 +13039,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/port)
 "HF" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Midships Fore"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "HG" = (
 /obj/structure/largecrate,
@@ -13624,7 +13163,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/command/disperser)
 "HU" = (
 /obj/floor_decal/industrial/hatch/yellow,
@@ -13651,7 +13190,7 @@
 /area/command/disperser)
 "HZ" = (
 /obj/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/command/disperser)
 "Ia" = (
 /obj/wallframe_spawn/reinforced/hull,
@@ -13695,7 +13234,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/command/disperser)
 "If" = (
 /obj/machinery/light/small{
@@ -13723,9 +13262,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "Ik" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -13734,7 +13270,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "Il" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -13767,17 +13303,11 @@
 	},
 /turf/simulated/floor,
 /area/command/disperser)
-"Iq" = (
-/obj/floor_decal/corner/green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
 "Ir" = (
 /obj/machinery/computer/ship/disperser{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/command/disperser)
 "Is" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -13867,7 +13397,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random_multi/single_item/punitelli,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "IE" = (
 /obj/random_multi/single_item/punitelli,
@@ -13902,7 +13432,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/random_multi/single_item/punitelli,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "IK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14042,7 +13572,6 @@
 /area/maintenance/thirddeck/aftstarboard)
 "IX" = (
 /obj/item/stool/padded,
-/obj/floor_decal/corner/green/half,
 /obj/machinery/button/blast_door{
 	id_tag = "d3fore_shutters";
 	name = "Garden Shutter Control";
@@ -14069,7 +13598,7 @@
 /obj/machinery/atmospherics/valve/shutoff/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "IZ" = (
 /obj/structure/cable/green{
@@ -14132,10 +13661,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/center)
-"Jc" = (
-/obj/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
 "Je" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -14145,14 +13670,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "Jg" = (
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
 /obj/structure/flora/pottedplant/dead,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "Jh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -14163,10 +13685,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3starboard)
-"Ji" = (
-/obj/floor_decal/corner/green/half,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
 "Jk" = (
 /obj/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -14467,7 +13985,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/aft)
 "JL" = (
 /obj/structure/railing/mapped{
@@ -14501,7 +14019,7 @@
 /obj/item/storage/secure/safe{
 	pixel_y = 28
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/chief_steward)
 "JO" = (
 /obj/catwalk_plated,
@@ -14538,7 +14056,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "JR" = (
 /obj/structure/cable/green{
@@ -14634,9 +14152,6 @@
 /obj/structure/bed/chair/padded/red{
 	dir = 1
 	},
-/obj/floor_decal/corner/red/half{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/habcheck)
 "Kd" = (
@@ -14720,9 +14235,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/obj/floor_decal/corner/green,
 /obj/machinery/seed_extractor,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hydroponics)
 "Ko" = (
 /obj/floor_decal/corner/blue/diagonal{
@@ -14781,7 +14295,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "Ku" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -14972,9 +14486,6 @@
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d3starboard)
 "KQ" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -14986,7 +14497,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "KR" = (
 /obj/structure/cable/green{
@@ -15015,7 +14526,6 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/habcheck)
@@ -15057,7 +14567,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
 "KZ" = (
-/obj/floor_decal/corner/green/half,
 /obj/structure/closet/athletic_mixed,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
@@ -15099,8 +14608,8 @@
 /turf/simulated/floor/reinforced,
 /area/thruster/d3port)
 "Lh" = (
-/obj/structure/closet/emcloset,
 /obj/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/warhammer/secure_closet/personal,
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
 "Li" = (
@@ -15114,7 +14623,7 @@
 /obj/landmark{
 	name = "lightsout"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "Lk" = (
 /obj/structure/catwalk,
@@ -15250,8 +14759,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/corner/green/half,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "Lz" = (
 /obj/machinery/door/firedoor,
@@ -15289,9 +14797,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/service_break_room)
 "LC" = (
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
@@ -15313,7 +14818,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "LE" = (
 /obj/machinery/computer/air_control{
@@ -15328,9 +14833,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3starboard)
 "LF" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15339,7 +14841,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "LG" = (
 /turf/simulated/wall/prepainted,
@@ -15523,10 +15025,7 @@
 /area/maintenance/thirddeck/foreport)
 "LZ" = (
 /obj/machinery/vending/cigarette,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Ma" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
@@ -15607,10 +15106,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
-"Mi" = (
-/obj/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
 "Mj" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15625,7 +15120,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Mn" = (
 /obj/structure/disposalpipe/segment{
@@ -15648,10 +15143,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hydroponics)
 "Mp" = (
 /obj/floor_decal/industrial/warning{
@@ -15694,9 +15186,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
-"Mx" = (
-/turf/simulated/floor/tiled,
-/area/hydroponics)
 "My" = (
 /obj/machinery/jukebox/old,
 /obj/floor_decal/spline/fancy/wood,
@@ -15705,13 +15194,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/recreation)
-"Mz" = (
-/obj/structure/disposalpipe/segment,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
 "MB" = (
 /obj/structure/disposalpipe/segment,
 /obj/catwalk_plated,
@@ -15770,7 +15252,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "MI" = (
 /obj/structure/cable/green{
@@ -15837,10 +15319,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "MU" = (
 /obj/floor_decal/corner/yellow/half,
@@ -15935,7 +15414,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "Ni" = (
 /obj/structure/table/rack,
@@ -15973,9 +15452,6 @@
 /obj/structure/bed/chair/armchair/green{
 	dir = 8
 	},
-/obj/floor_decal/corner/green{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
@@ -15995,9 +15471,6 @@
 "Ns" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
-	},
-/obj/floor_decal/corner/red/half{
-	dir = 4
 	},
 /obj/item/device/radio/intercom/department/security{
 	dir = 8;
@@ -16063,19 +15536,6 @@
 "NB" = (
 /turf/simulated/wall/r_wall/hull,
 /area/crew_quarters/commissary)
-"NE" = (
-/obj/floor_decal/corner/green{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
-"NF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/civilian{
-	name = "Lounge"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/crew_quarters/sleep/cryo)
 "NG" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -16085,7 +15545,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "NH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16151,13 +15611,10 @@
 /turf/simulated/floor/plating,
 /area/vacant/mess)
 "NN" = (
-/obj/floor_decal/corner/green{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "NO" = (
 /obj/decal/cleanable/dirt,
@@ -16199,11 +15656,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "NV" = (
 /obj/structure/cable/green{
@@ -16259,7 +15713,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "Od" = (
 /obj/structure/table/marble,
@@ -16285,7 +15739,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/galley)
 "Oe" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
@@ -16293,14 +15746,11 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/gym)
 "Of" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/structure/bed/chair,
 /obj/floor_decal/corner/paleblue{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "Og" = (
 /obj/structure/table/standard,
@@ -16318,10 +15768,7 @@
 	dir = 1
 	},
 /obj/machinery/honey_extractor,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "Oj" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -16368,12 +15815,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "Oq" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -16381,7 +15825,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "Or" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -16430,10 +15874,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/vacant/cabin)
 "Oy" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "Oz" = (
 /obj/machinery/light/small{
@@ -16450,10 +15891,6 @@
 	dir = 4
 	},
 /obj/structure/bookcase,
-/obj/item/book/manual/sol_sop,
-/obj/item/book/manual/solgov_law,
-/obj/item/book/manual/military_law,
-/obj/item/book/manual/nt_regs,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -16473,7 +15910,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "OE" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -16555,7 +15992,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "OQ" = (
 /obj/machinery/computer/ship/navigation{
@@ -16564,7 +16001,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/command/disperser)
 "OS" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -16587,13 +16024,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "OU" = (
-/obj/floor_decal/corner/green{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "OW" = (
 /obj/structure/sign/directions/engineering{
@@ -16612,9 +16046,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/galley)
 "OY" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/machinery/door/airlock/glass/civilian,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -16642,7 +16073,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "Pc" = (
 /obj/structure/table/rack,
@@ -16694,11 +16125,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/machinery/beehive,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "Po" = (
 /obj/structure/disposalpipe/segment{
@@ -16745,9 +16173,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/center)
-"Pv" = (
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
 "Px" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -16772,13 +16197,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "Pz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "PA" = (
 /obj/structure/sign/directions/science{
@@ -16838,10 +16263,9 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "PH" = (
-/obj/floor_decal/corner/green/half,
 /obj/structure/flora/pottedplant/minitree,
 /obj/machinery/light/spot,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -16864,7 +16288,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "PL" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
@@ -16937,7 +16361,7 @@
 /obj/machinery/vending/coffee{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "PV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16947,7 +16371,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "PW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -16962,12 +16386,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/thruster/d3starboard)
-"PX" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
 "PY" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
@@ -17053,13 +16471,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table/standard,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "Qq" = (
 /turf/simulated/wall/r_wall/hull,
@@ -17080,7 +16495,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "Qu" = (
 /obj/floor_decal/corner/grey/diagonal{
@@ -17096,9 +16511,6 @@
 /area/crew_quarters/galley)
 "Qv" = (
 /obj/machinery/computer/modular/preset/security,
-/obj/floor_decal/corner/red{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17113,7 +16525,6 @@
 /area/security/habcheck)
 "Qx" = (
 /obj/machinery/computer/modular/preset/security,
-/obj/floor_decal/corner/red/mono,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17149,14 +16560,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/thirddeck)
 "QC" = (
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/vacant/brig)
 "QD" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/ship_map,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "QE" = (
 /obj/structure/table/rack,
@@ -17164,9 +16572,6 @@
 	dir = 4
 	},
 /obj/item/device/binoculars,
-/obj/floor_decal/corner/red{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17186,7 +16591,7 @@
 /area/crew_quarters/office)
 "QJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "QK" = (
 /obj/machinery/firealarm{
@@ -17211,10 +16616,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "QQ" = (
 /obj/wallframe_spawn/no_grille,
@@ -17246,7 +16648,7 @@
 "QT" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/solgov,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/maintenance/thirddeck/starboard)
 "QU" = (
 /obj/structure/railing/mapped{
@@ -17309,7 +16711,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Re" = (
 /obj/structure/cable/green{
@@ -17328,7 +16730,7 @@
 	pixel_x = -32
 	},
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "Rh" = (
 /obj/structure/bed/chair/padded/green{
@@ -17351,7 +16753,7 @@
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Rm" = (
 /obj/structure/cable/green{
@@ -17387,9 +16789,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder/juicer,
 /obj/item/reagent_containers/glass/beaker{
@@ -17398,10 +16797,9 @@
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "Ro" = (
-/obj/floor_decal/corner/green/half,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -17409,7 +16807,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/commissary)
 "Rq" = (
 /obj/floor_decal/corner/grey/diagonal{
@@ -17464,7 +16862,7 @@
 /obj/structure/table/rack,
 /obj/item/towel/random,
 /obj/item/towel/random,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "RB" = (
 /obj/structure/catwalk,
@@ -17473,14 +16871,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "RC" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "RD" = (
 /obj/floor_decal/corner/grey/diagonal{
@@ -17506,7 +16901,7 @@
 /area/crew_quarters/head)
 "RF" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/maintenance/thirddeck/starboard)
 "RG" = (
 /turf/simulated/wall/prepainted,
@@ -17569,7 +16964,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "RR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17617,7 +17012,7 @@
 	id_tag = "shop_shutters";
 	name = "Commissary Shutters"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "Sb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -17625,31 +17020,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/thruster/d3port)
-"Sc" = (
-/obj/floor_decal/corner/green{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
 "Sd" = (
 /obj/structure/closet/hydrant{
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Sf" = (
 /obj/machinery/light{
@@ -17658,7 +17033,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "Sg" = (
 /obj/machinery/door/blast/regular{
@@ -17695,7 +17070,7 @@
 	pixel_x = -21
 	},
 /obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/crew_quarters/cryolocker)
 "Sm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17708,7 +17083,6 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -17740,15 +17114,12 @@
 	icon_state = "1-8"
 	},
 /obj/structure/closet/emcloset,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "So" = (
 /obj/structure/cable/green{
@@ -17845,11 +17216,8 @@
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d3port)
 "Sz" = (
-/obj/floor_decal/corner/green{
-	dir = 1
-	},
 /obj/random/vendor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "SA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -18032,7 +17400,7 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/floor_decal/corner/green/mono,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hydroponics)
 "Te" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18084,19 +17452,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
 "Tm" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "Tn" = (
 /obj/floor_decal/corner/lime{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "To" = (
 /obj/structure/lattice,
@@ -18111,7 +17476,7 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Tr" = (
 /obj/floor_decal/corner/red/diagonal,
@@ -18200,10 +17565,6 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/thirddeck/port)
-"TC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
 "TE" = (
 /turf/simulated/wall/prepainted,
 /area/chapel/office)
@@ -18285,9 +17646,6 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "TS" = (
-/obj/floor_decal/corner/red{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/habcheck)
 "TV" = (
@@ -18296,7 +17654,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/storage/tools)
 "TW" = (
 /obj/floor_decal/corner/grey/diagonal{
@@ -18312,7 +17670,7 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/floor_decal/corner/green/mono,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hydroponics)
 "TY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18340,7 +17698,7 @@
 /obj/structure/closet/medical_wall/filled{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Uc" = (
 /obj/structure/bed/chair/comfy/black{
@@ -18404,10 +17762,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "Un" = (
 /obj/machinery/status_display,
@@ -18568,7 +17923,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "UD" = (
 /obj/structure/grille,
@@ -18657,9 +18012,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/thirddeck)
 "UM" = (
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
 /obj/machinery/button/blast_door{
 	id_tag = "d3fore_shutters";
 	name = "Garden Shutter Control";
@@ -18678,7 +18030,7 @@
 	name = "Sanitation Supplies"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/janitor/storage)
 "UP" = (
 /obj/structure/fitness/weightlifter,
@@ -18686,7 +18038,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "UQ" = (
 /obj/item/device/radio/intercom{
@@ -18694,10 +18046,7 @@
 	pixel_y = -28
 	},
 /obj/machinery/light,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "UR" = (
 /obj/machinery/sparker{
@@ -18721,10 +18070,7 @@
 /turf/simulated/floor/plating,
 /area/command/disperser)
 "UV" = (
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "UX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18749,7 +18095,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "UZ" = (
 /obj/structure/catwalk,
@@ -18780,7 +18126,7 @@
 /obj/machinery/vending/fitness{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "Vd" = (
 /obj/floor_decal/industrial/warning{
@@ -18852,7 +18198,7 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Vm" = (
 /obj/structure/cable/green{
@@ -18860,7 +18206,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "Vn" = (
 /obj/floor_decal/corner/lime{
@@ -18874,7 +18220,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "Vo" = (
 /obj/wallframe_spawn/reinforced/hull,
@@ -18970,10 +18316,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/floor_decal/corner/green/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "VD" = (
 /obj/structure/catwalk,
@@ -18995,14 +18338,14 @@
 	},
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "VF" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "VG" = (
 /obj/structure/cable/green{
@@ -19019,18 +18362,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "VH" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "VI" = (
 /obj/structure/ladder,
-/obj/floor_decal/corner/red/mono,
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/catwalk_plated/dark,
 /obj/machinery/light,
@@ -19079,7 +18421,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "VQ" = (
 /obj/structure/bed/chair/comfy/black{
@@ -19105,7 +18447,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/command/disperser)
 "VR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19138,8 +18480,9 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "VU" = (
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/obj/machinery/cryopod,
+/turf/simulated/floor/warhammer,
+/area/crew_quarters/sleep/cryo)
 "VV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -19211,11 +18554,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "We" = (
 /obj/random_multi/single_item/poppy,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/vacant/brig)
 "Wg" = (
 /obj/random/trash,
@@ -19236,7 +18579,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/aft)
 "Wk" = (
 /obj/structure/disposalpipe/segment,
@@ -19250,7 +18593,7 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Wo" = (
 /obj/machinery/meter,
@@ -19304,13 +18647,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3port)
 "Wx" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "Wy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -19345,13 +18685,12 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "WC" = (
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d3starboard)
 "WD" = (
-/obj/floor_decal/corner/red/mono,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 4;
@@ -19360,16 +18699,13 @@
 	name = "Habitation Deck Hallway Shutters";
 	opacity = 0
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "WE" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "WF" = (
 /obj/wallframe_spawn/reinforced_phoron,
@@ -19495,7 +18831,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/aft)
 "WZ" = (
 /obj/structure/disposalpipe/down{
@@ -19589,7 +18925,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Xj" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -19623,10 +18959,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)
 "Xn" = (
-/obj/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "Xo" = (
 /obj/floor_decal/corner/grey/diagonal{
@@ -19785,9 +19118,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/thirddeck)
 "XJ" = (
-/obj/floor_decal/corner/red{
-	dir = 10
-	},
 /obj/machinery/hologram/holopad,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/recharger/wallcharger{
@@ -19838,7 +19168,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/center)
 "XR" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/cryolocker)
 "XS" = (
 /obj/random/torchcloset,
@@ -19870,7 +19200,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 4;
@@ -19888,7 +19217,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/fore)
 "XY" = (
 /obj/structure/cable/green{
@@ -19937,18 +19266,9 @@
 /turf/simulated/floor/wood/maple,
 /area/crew_quarters/chief_steward)
 "Yd" = (
-/obj/floor_decal/corner/green{
-	dir = 4
-	},
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
-/obj/floor_decal/corner/green{
-	dir = 1
-	},
 /obj/structure/closet/emcloset,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Ye" = (
 /obj/machinery/light/small,
@@ -19963,7 +19283,7 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Yj" = (
 /obj/structure/railing/mapped{
@@ -20020,16 +19340,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
 /obj/structure/closet/crate/hydroponics/beekeeping,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck - Hydroponics";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hydroponics)
 "Yp" = (
 /obj/random/junk,
@@ -20055,7 +19372,7 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "Yv" = (
 /obj/floor_decal/industrial/warning{
@@ -20101,7 +19418,6 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "YF" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -20109,7 +19425,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/gym)
 "YG" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "YH" = (
 /obj/structure/railing/mapped{
@@ -20122,16 +19438,12 @@
 /obj/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
-"YJ" = (
-/obj/floor_decal/corner/red,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
 "YK" = (
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "YL" = (
 /obj/machinery/hologram/holopad/longrange,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/command/disperser)
 "YN" = (
 /obj/decal/cleanable/dirt,
@@ -20154,8 +19466,7 @@
 	name = "Habitation Deck Hallway Shutters";
 	opacity = 0
 	},
-/obj/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/newsteel/dark,
 /area/hallway/primary/thirddeck/center)
 "YQ" = (
 /obj/floor_decal/corner/yellow{
@@ -20182,7 +19493,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "YT" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
@@ -20196,10 +19507,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3starboard)
 "YU" = (
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/fore)
 "YV" = (
 /obj/item/stool,
@@ -20223,10 +19531,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/center)
 "YZ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -20245,13 +19550,13 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "Zb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/gym)
 "Zc" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -20303,7 +19608,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/storage/tools)
 "Zl" = (
 /obj/structure/cable/green{
@@ -20327,7 +19632,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "Zn" = (
-/obj/floor_decal/corner/green/half,
 /obj/machinery/vending/fitness{
 	dir = 1
 	},
@@ -20356,15 +19660,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/thirddeck)
 "Zq" = (
-/obj/floor_decal/corner/green{
-	dir = 8
-	},
 /obj/machinery/jukebox/old,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/crew_quarters/commissary)
 "Zt" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -20483,7 +19784,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/newsteel/dark2,
 /area/hallway/primary/thirddeck/aft)
 "ZF" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -29792,7 +29093,7 @@ Oc
 uE
 Nx
 NN
-VU
+YU
 Pz
 yH
 lY
@@ -30398,7 +29699,7 @@ gB
 gB
 gB
 gB
-VU
+YU
 sN
 yH
 ma
@@ -30420,7 +29721,7 @@ xP
 jo
 Kd
 Yd
-Sc
+bB
 OU
 zM
 Oo
@@ -30600,7 +29901,7 @@ Vc
 wJ
 mH
 gB
-Pv
+CD
 Py
 yH
 mc
@@ -30623,7 +29924,7 @@ eW
 ff
 LF
 fw
-VU
+YU
 qJ
 aN
 aN
@@ -30802,7 +30103,7 @@ vF
 vF
 Fs
 gM
-VU
+YU
 Dx
 yH
 yH
@@ -31006,8 +30307,8 @@ Fs
 gM
 wT
 NL
-VU
-VU
+YU
+YU
 bk
 nP
 oL
@@ -31020,15 +30321,15 @@ Dy
 ts
 xI
 OD
-VU
-BG
-Ap
-Ap
+YU
+YU
+YU
+YU
 CD
-iL
+YU
 bB
 Pz
-Gs
+YU
 UO
 YC
 CM
@@ -31415,19 +30716,19 @@ Sd
 mU
 nR
 wP
-VU
+YU
 pM
 Yt
 dL
 WB
-Pv
-VU
+CD
+YU
 pq
-VU
-VU
+YU
+YU
 Ml
-VU
-VU
+YU
+YU
 VF
 FB
 Rc
@@ -32027,7 +31328,7 @@ rU
 iE
 UH
 CF
-VU
+YU
 pq
 gu
 yN
@@ -32837,7 +32138,7 @@ uB
 CF
 wQ
 Uo
-VU
+YU
 yN
 yN
 yN
@@ -33837,15 +33138,15 @@ dx
 dx
 mi
 MD
-VU
+YU
 hK
 pO
 mj
 sc
 tp
-VU
-VU
-VU
+YU
+YU
+YU
 ip
 Bn
 Bm
@@ -34045,8 +33346,8 @@ pP
 mj
 se
 tp
-VU
-VU
+YU
+YU
 QJ
 iI
 jh
@@ -34445,13 +33746,13 @@ mj
 na
 oe
 oW
-Iq
-NE
+YU
+YU
 sg
-YJ
+YU
 oy
 YU
-rb
+mV
 xX
 mj
 zR
@@ -34852,7 +34153,7 @@ lu
 pS
 xC
 VM
-tP
+cV
 LV
 Qx
 Kc
@@ -35054,7 +34355,7 @@ lu
 pT
 Xn
 sj
-tv
+Xn
 UA
 Qv
 jQ
@@ -35256,7 +34557,7 @@ lu
 pT
 qQ
 sk
-tw
+xf
 xb
 QE
 jQ
@@ -35267,7 +34568,7 @@ zS
 Br
 Yb
 uM
-vN
+xY
 wW
 xY
 wW
@@ -36650,7 +35951,7 @@ aa
 aW
 aW
 bx
-Mx
+Oy
 cc
 cN
 fp
@@ -36682,8 +35983,8 @@ Cs
 OP
 Da
 DO
-vS
-vS
+vT
+vT
 FC
 XR
 UX
@@ -36852,7 +36153,7 @@ aa
 aW
 aW
 Oi
-Mx
+Oy
 cd
 cO
 du
@@ -36870,20 +36171,20 @@ nf
 nf
 pb
 pW
-qP
+cV
 IY
 tE
 Fd
-vT
-vT
+VU
+VU
 yb
 yU
-vT
-vT
-vT
-vT
+VU
+VU
+VU
+VU
 Db
-DP
+Cr
 vT
 vT
 Fd
@@ -37054,7 +36355,7 @@ aa
 aW
 aW
 oI
-Mx
+Oy
 th
 ev
 Ug
@@ -37072,9 +36373,9 @@ Vg
 Vg
 pc
 ev
-xE
+Xn
 IZ
-Jc
+Xn
 Fd
 vU
 vU
@@ -37085,9 +36386,9 @@ vU
 vU
 vU
 Db
-DP
-vU
-vU
+Cr
+vT
+vT
 Fd
 FS
 GB
@@ -37276,7 +36577,7 @@ pd
 pX
 qS
 sn
-dC
+Xn
 uQ
 vV
 vV
@@ -37287,9 +36588,9 @@ vV
 vV
 vV
 Dc
-DQ
-vV
-vV
+Cr
+vT
+vT
 Fd
 DL
 GD
@@ -37661,7 +36962,7 @@ mv
 be
 bC
 lA
-Mx
+Oy
 wn
 xn
 ey
@@ -37680,7 +36981,7 @@ jc
 pZ
 Xn
 sp
-Mz
+qS
 uS
 vS
 vS
@@ -37691,7 +36992,7 @@ vS
 vS
 vS
 De
-za
+PJ
 Fd
 LX
 Fd
@@ -37882,21 +37183,21 @@ pf
 fB
 qU
 sj
-dB
+Xn
 uT
-vT
-vT
+VU
+VU
 yf
 yY
-vT
-vT
-vT
-vT
+VU
+VU
+VU
+VU
 Df
-za
-NF
-Hc
-Hc
+PJ
+Fd
+Fd
+Fd
 Fd
 Lk
 EL
@@ -38065,7 +37366,7 @@ CS
 be
 Oy
 nO
-Mx
+Oy
 wn
 Mn
 eC
@@ -38297,7 +37598,7 @@ vV
 vV
 vV
 Dg
-za
+PJ
 Ew
 Fd
 Nj
@@ -38469,7 +37770,7 @@ LP
 pE
 Um
 vZ
-Mx
+Oy
 wn
 Yo
 bA
@@ -38872,8 +38173,8 @@ aa
 CS
 be
 Oy
-Mx
-Mx
+Oy
+Oy
 wn
 Qn
 bA
@@ -38892,7 +38193,7 @@ OB
 fB
 HF
 sj
-dC
+Xn
 uU
 vY
 eE
@@ -39094,7 +38395,7 @@ fB
 fB
 tF
 sj
-dC
+Xn
 uU
 uU
 uU
@@ -39480,7 +38781,7 @@ be
 bD
 jT
 ci
-cY
+aP
 dN
 bA
 fF
@@ -39698,7 +38999,7 @@ yQ
 aY
 CH
 cl
-qP
+cV
 RQ
 cV
 uU
@@ -39902,7 +39203,7 @@ cl
 cl
 Xn
 sj
-dB
+Xn
 uU
 fo
 YK
@@ -40104,7 +39405,7 @@ RB
 TO
 rc
 cS
-dC
+Xn
 fl
 YK
 YK
@@ -40508,7 +39809,7 @@ tX
 wD
 VC
 RQ
-dC
+Xn
 uU
 eD
 YK
@@ -40708,9 +40009,9 @@ YN
 YN
 uu
 wD
-rf
+Xn
 VG
-re
+Xn
 uU
 uU
 fl
@@ -40910,7 +40211,7 @@ TI
 cl
 cl
 wD
-cw
+Xn
 su
 Ly
 uL
@@ -41112,7 +40413,7 @@ hd
 dd
 ti
 wD
-xE
+Xn
 XP
 ov
 wD
@@ -41720,7 +41021,7 @@ eI
 eI
 ri
 sy
-Ji
+cV
 OW
 IV
 Pr
@@ -41893,7 +41194,7 @@ QC
 al
 ae
 av
-ay
+aA
 aA
 ag
 aF
@@ -42124,11 +41425,11 @@ MU
 fn
 sz
 Jb
-rf
+Xn
 rp
 wk
 Lj
-rf
+Xn
 jm
 PA
 AK
@@ -42326,12 +41627,12 @@ MU
 eI
 rl
 Jb
-rf
+Xn
 rp
-rf
+Xn
 yp
 yp
-rf
+Xn
 MN
 AL
 BK
@@ -42528,7 +41829,7 @@ pm
 eI
 cg
 IY
-re
+Xn
 Em
 vH
 xl
@@ -43132,9 +42433,9 @@ qd
 qd
 qd
 qd
-sW
+UV
 sv
-sW
+UV
 Un
 QH
 xo
@@ -43336,7 +42637,7 @@ pj
 qc
 Oq
 sE
-je
+UV
 vg
 wp
 xu
@@ -43536,7 +42837,7 @@ nt
 ol
 pk
 om
-lc
+UV
 Zv
 Ik
 py
@@ -43740,7 +43041,7 @@ Fr
 qd
 rr
 sG
-je
+UV
 vg
 Tv
 CQ
@@ -44142,7 +43443,7 @@ hA
 hA
 hA
 qd
-PX
+ji
 Wh
 ji
 RG
@@ -44346,7 +43647,7 @@ hA
 qd
 wB
 sJ
-sW
+UV
 RG
 wt
 xs
@@ -44548,7 +43849,7 @@ hA
 qd
 Wx
 sF
-Mi
+UV
 TR
 wu
 xt
@@ -44950,7 +44251,7 @@ hA
 hA
 hA
 qd
-lc
+UV
 Xv
 UV
 TR
@@ -45154,7 +44455,7 @@ hA
 qd
 ru
 Xv
-sW
+UV
 RG
 WT
 xt
@@ -45356,7 +44657,7 @@ hA
 qd
 WE
 Xv
-sW
+UV
 TE
 TE
 xx
@@ -45558,7 +44859,7 @@ hA
 qe
 lJ
 AR
-GC
+ZE
 TE
 wz
 OL
@@ -45760,7 +45061,7 @@ hA
 qd
 rw
 Xv
-je
+UV
 TE
 wA
 xy
@@ -46566,7 +45867,7 @@ ve
 wl
 WY
 qs
-TC
+lJ
 sU
 ZE
 YS

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -31,7 +31,7 @@
 	pixel_x = -32;
 	tag_door = "escape_pod_11_hatch"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "ad" = (
 /obj/machinery/fusion_fuel_injector/mapped{
@@ -1194,12 +1194,6 @@
 "ck" = (
 /obj/structure/closet/crate/medical,
 /obj/item/bodybag,
-/obj/random/firstaid,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
 /obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/central)
@@ -2332,7 +2326,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "eC" = (
 /obj/structure/cable/green{
@@ -2612,9 +2606,6 @@
 	},
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/item/cell/high,
 /obj/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
@@ -2623,10 +2614,7 @@
 "fc" = (
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
-/obj/random/powercell,
-/obj/random/powercell,
 /obj/floor_decal/corner/yellow/half,
-/obj/random/powercell,
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/storage)
 "fd" = (
@@ -2692,7 +2680,7 @@
 /area/maintenance/seconddeck/forestarboard)
 "fn" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "fp" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -3339,11 +3327,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "escape_pod_11_pump"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "gH" = (
 /obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "gI" = (
 /obj/floor_decal/industrial/warning{
@@ -3352,11 +3340,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod11/station)
 "gJ" = (
 /obj/machinery/atmospherics/unary/tank/air,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod11/station)
 "gK" = (
 /obj/structure/shuttle/engine/heater{
@@ -3621,7 +3609,7 @@
 	dir = 1;
 	id_tag = "escape_pod_10_pump"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "hy" = (
 /obj/structure/railing/mapped{
@@ -3636,7 +3624,7 @@
 /turf/simulated/floor/bluegrid,
 /area/engineering/bluespace)
 "hz" = (
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "hA" = (
 /obj/floor_decal/industrial/warning{
@@ -3645,13 +3633,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod11/station)
 "hB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod11/station)
 "hC" = (
 /obj/structure/table/rack,
@@ -3889,7 +3877,7 @@
 	dir = 1;
 	id_tag = "escape_pod_11_pump"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "ip" = (
 /obj/machinery/status_display{
@@ -3898,7 +3886,7 @@
 /obj/structure/bed/chair/shuttle{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "iq" = (
 /obj/structure/bed/chair/shuttle{
@@ -3908,7 +3896,7 @@
 	dir = 1;
 	id_tag = "escape_pod_11_pump"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "ir" = (
 /obj/floor_decal/industrial/warning{
@@ -3918,8 +3906,7 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/random/firstaid,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod11/station)
 "is" = (
 /obj/machinery/sleeper{
@@ -3930,7 +3917,7 @@
 	name = "Emergency NanoMed";
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod11/station)
 "it" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -5539,8 +5526,6 @@
 /area/engineering/engineering_bay)
 "mC" = (
 /obj/structure/table/steel,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
 /obj/structure/fireaxecabinet{
 	pixel_y = -32
 	},
@@ -6152,7 +6137,7 @@
 	pixel_x = -32;
 	tag_door = "escape_pod_10_hatch"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "on" = (
 /obj/structure/catwalk,
@@ -9122,24 +9107,24 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "escape_pod_10_pump"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "wj" = (
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
 /obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "wk" = (
 /obj/structure/bed/chair/shuttle,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "escape_pod_10_pump"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "wl" = (
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "wm" = (
 /obj/floor_decal/industrial/warning{
@@ -9151,8 +9136,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/random/firstaid,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod10/station)
 "wn" = (
 /obj/machinery/sleeper,
@@ -9160,7 +9144,7 @@
 	name = "Emergency NanoMed";
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod10/station)
 "wo" = (
 /obj/structure/shuttle/engine/heater{
@@ -9451,7 +9435,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "xf" = (
 /obj/floor_decal/industrial/warning{
@@ -9460,13 +9444,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod10/station)
 "xg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod10/station)
 "xh" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -9677,26 +9661,26 @@
 	dir = 1;
 	id_tag = "escape_pod_10_pump"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "xX" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "xY" = (
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod10/station)
 "xZ" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod10/station)
 "ya" = (
 /obj/random/torchcloset,
@@ -11546,9 +11530,6 @@
 "Dd" = (
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
-/obj/item/cell/high,
-/obj/random/powercell,
-/obj/random/powercell,
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/cargo)
 "De" = (
@@ -15311,7 +15292,7 @@
 /area/maintenance/incinerator)
 "OO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "OR" = (
 /obj/machinery/camera/network/second_deck{
@@ -15510,7 +15491,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "Pr" = (
 /obj/structure/disposalpipe/segment,
@@ -16275,7 +16256,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "RR" = (
 /obj/structure/window/reinforced{
@@ -16414,7 +16395,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod10/station)
 "Sn" = (
 /obj/machinery/meter,
@@ -16994,7 +16975,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "Uz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17316,7 +17297,8 @@
 /area/maintenance/seconddeck/central)
 "Wa" = (
 /obj/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/warhammer/freezer/rations,
+/obj/structure/closet/crate/warhammer/freezer,
+/obj/random/loot/randomsupply,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/central)
 "Wb" = (
@@ -17580,7 +17562,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "escape_pod_11_pump"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod11/station)
 "WF" = (
 /obj/structure/cable{

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1266,20 +1266,6 @@
 "acz" = (
 /turf/simulated/wall/prepainted,
 /area/medical/medicalhallway)
-"acB" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/steel_reinforced,
-/obj/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Emergency Armory Desk"
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutters"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
 "acC" = (
 /obj/structure/closet/firecloset,
 /obj/floor_decal/industrial/outline/grey,
@@ -1336,23 +1322,6 @@
 /obj/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/warhammer/metal,
 /area/assembly/robotics/laboratory)
-"acG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/table/reinforced,
-/obj/item/material/bell,
-/obj/machinery/door/window/southright{
-	name = "Fabricator Lab Desk"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/monotile,
-/area/rnd/development)
 "acH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
@@ -1380,9 +1349,6 @@
 /area/medical/medicalhallway)
 "acJ" = (
 /obj/structure/closet/crate/warhammer/freezer,
-/obj/random/firstaid,
-/obj/random/firstaid,
-/obj/random/medical,
 /obj/random/medical,
 /obj/decal/cleanable/dirt,
 /obj/floor_decal/industrial/outline/grey,
@@ -1397,7 +1363,7 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/firstdeck/aftstarboard)
 "acM" = (
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/closet/warhammer/secure_closet/personal/patient,
 /obj/random/maintenance/solgov,
 /obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -4025,7 +3991,6 @@
 "ahf" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/medical_diagnostics_manual,
-/obj/item/book/manual/military_law,
 /obj/floor_decal/corner/paleblue/mono,
 /obj/machinery/light_switch{
 	pixel_x = 6;
@@ -4307,11 +4272,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
-"ahL" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "ahM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5207,7 +5167,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_x = -32
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod12/station)
 "ake" = (
 /obj/machinery/power/breakerbox/activated{
@@ -5516,9 +5476,6 @@
 "all" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
 /obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 1;
@@ -5835,7 +5792,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_x = -32
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod13/station)
 "ang" = (
 /obj/structure/table/steel_reinforced,
@@ -6126,8 +6083,6 @@
 /area/assembly/robotics/laboratory)
 "apP" = (
 /obj/structure/table/rack/dark,
-/obj/random/firstaid,
-/obj/random/medical,
 /obj/random/medical,
 /obj/random/medical,
 /obj/random/medical/lite,
@@ -6512,10 +6467,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"asl" = (
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard)
 "asq" = (
 /obj/floor_decal/corner/blue/three_quarters{
 	dir = 4
@@ -6560,7 +6511,6 @@
 /area/security/brig)
 "asx" = (
 /obj/structure/table/standard,
-/obj/item/book/manual/solgov_law,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -7122,7 +7072,7 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/closet/warhammer/secure_closet/personal/patient,
 /turf/simulated/floor/newsteel/dark,
 /area/medical/exam_room)
 "avo" = (
@@ -7363,51 +7313,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"awI" = (
-/obj/floor_decal/industrial/loading{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Hallway - Emergency Armory"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
-"awJ" = (
-/obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
-"awL" = (
-/obj/machinery/button/blast_door{
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutter Control";
-	pixel_x = -24;
-	pixel_y = -6
-	},
-/obj/structure/table/steel,
-/obj/item/stamp/denied{
-	pixel_x = 5
-	},
-/obj/item/stamp,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
 "awM" = (
 /obj/floor_decal/corner/paleblue/half{
 	dir = 1
@@ -8023,39 +7928,6 @@
 /obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
-"ayJ" = (
-/obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
-"ayK" = (
-/obj/wallframe_spawn/reinforced,
-/obj/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutters"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/command/armoury/access)
-"ayL" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
 "ayP" = (
 /obj/structure/bed/chair/padded/red{
 	dir = 4
@@ -8172,18 +8044,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "azU" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
+/turf/simulated/wall/r_wall/hull,
+/area/hallway/primary/firstdeck/aft)
 "azV" = (
 /obj/shuttle_landmark/ert/deck2{
 	name = "1st Deck, Fore Port"
@@ -8250,21 +8112,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
-"aAJ" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/plating,
-/area/rnd/development)
 "aAK" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/cryo/aux)
@@ -8319,111 +8166,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"aAW" = (
-/obj/floor_decal/industrial/loading{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
-"aAX" = (
-/obj/floor_decal/industrial/warning/fulltile,
-/obj/machinery/door/airlock/command{
-	name = "Emergency Armory Access";
-	secured_wires = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury/access)
-"aAY" = (
-/obj/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury/access)
-"aAZ" = (
-/obj/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury/access)
-"aBa" = (
-/obj/floor_decal/industrial/warning/fulltile,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Emergency Armory"
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id_tag = "armory_entrylock";
-	name = "Armory Lockdown Shutters"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury)
 "aBb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/firstdeck/foreport)
-"aBc" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury/tactical)
 "aBd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8783,16 +8528,6 @@
 /obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftport)
-"aEG" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack/dark,
-/obj/item/clothing/shoes/dutyboots,
-/obj/item/clothing/accessory/storage/holster/thigh,
-/obj/item/clothing/glasses/tacgoggles,
-/obj/item/clothing/suit/armor/grim/medium/sol,
-/obj/item/clothing/head/helmet,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "aEH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9166,9 +8901,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
-"aGN" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury/access)
 "aGP" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/brig)
@@ -9270,9 +9002,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
-"aHT" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury)
 "aHX" = (
 /obj/catwalk_plated,
 /obj/structure/cable/green{
@@ -9543,20 +9272,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
-"aJl" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"aJm" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/camera/network/bridge{
-	c_tag = "Emergency Armory - Supplies";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "aJn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10091,30 +9806,6 @@
 /obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftport)
-"aMB" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/medical,
-/obj/item/storage/firstaid/fire{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/stack/nanopaste,
-/obj/item/bodybag/rescue/loaded,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "aMC" = (
 /obj/structure/table/rack/dark,
 /obj/floor_decal/industrial/outline/grey,
@@ -10342,11 +10033,6 @@
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftport)
-"aNE" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/warhammer/freezer/rations,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "aNG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -10566,10 +10252,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
-"aOK" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/prepainted,
-/area/security/wing)
 "aOL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -10992,33 +10674,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/thruster/d1port)
-"aQq" = (
-/obj/machinery/shieldwallgen,
-/obj/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"aQr" = (
-/obj/machinery/barrier,
-/obj/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"aQs" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"aQt" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"aQu" = (
-/obj/machinery/floodlight,
-/obj/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "aQx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -11283,15 +10938,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
-"aRm" = (
-/obj/machinery/barrier,
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/camera/network/bridge{
-	c_tag = "Bridge - Emergency Armory - Port";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "aRo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12154,9 +11800,6 @@
 "aTE" = (
 /obj/structure/closet/crate/warhammer/freezer,
 /obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/firstaid,
 /obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftport)
@@ -12205,7 +11848,6 @@
 /area/maintenance/firstdeck/aftport)
 "aTO" = (
 /obj/structure/closet/crate,
-/obj/random/powercell,
 /obj/random/powercell,
 /obj/random/powercell,
 /obj/floor_decal/industrial/outline/grey,
@@ -13639,16 +13281,6 @@
 /obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
-"bBv" = (
-/obj/floor_decal/techfloor,
-/obj/floor_decal/corner_techfloor_grid{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
 "bCb" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -13657,19 +13289,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/cell_1)
-"bCX" = (
-/obj/structure/table/steel,
-/obj/item/storage/box/cdeathalarm_kit,
-/obj/item/material/twohanded/ravenor/sword/cutro,
-/obj/item/melee/telebaton,
-/obj/item/melee/telebaton,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "bDb" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -13842,15 +13461,6 @@
 "bMb" = (
 /turf/simulated/wall/prepainted,
 /area/engineering/hardstorage/aux)
-"bMB" = (
-/obj/floor_decal/corner_techfloor_grid{
-	dir = 6
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
 "bNb" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -13861,7 +13471,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod12/station)
 "bNL" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -13878,7 +13488,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod13/station)
 "bOZ" = (
 /obj/structure/closet/emcloset,
@@ -13906,7 +13516,7 @@
 /obj/structure/bed/chair/shuttle{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod12/station)
 "bRb" = (
 /obj/item/device/radio/intercom{
@@ -13924,7 +13534,7 @@
 /obj/structure/bed/chair/shuttle{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod13/station)
 "bSz" = (
 /obj/wallframe_spawn/reinforced,
@@ -13968,7 +13578,7 @@
 	tag_door = "escape_pod_15_hatch"
 	},
 /obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod15/station)
 "bUb" = (
 /obj/item/device/radio/intercom{
@@ -13987,7 +13597,7 @@
 	tag_door = "escape_pod_16_hatch"
 	},
 /obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod16/station)
 "bUZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14028,7 +13638,7 @@
 	tag_door = "escape_pod_17_hatch"
 	},
 /obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod17/station)
 "bWb" = (
 /obj/machinery/status_display{
@@ -14038,7 +13648,7 @@
 	pixel_x = 32
 	},
 /obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod15/station)
 "bWw" = (
 /obj/machinery/power/apc{
@@ -14073,7 +13683,7 @@
 	pixel_x = 32
 	},
 /obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod16/station)
 "bXK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14092,41 +13702,19 @@
 	pixel_x = 32
 	},
 /obj/structure/bed/chair/shuttle,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod17/station)
-"bYj" = (
-/obj/machinery/button/blast_door{
-	id_tag = "armory_entrylock";
-	name = "Armory Entry Lockdown Shutter Control";
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutter Control";
-	pixel_x = 24;
-	pixel_y = -6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/button/blast_door{
-	id_tag = "operation_hallway_shutters";
-	name = "Hallway Checkpoint Shutters";
-	pixel_x = 35;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
 "bZb" = (
 /obj/machinery/cryopod{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod15/station)
 "cab" = (
 /obj/machinery/cryopod{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod16/station)
 "cap" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -14137,7 +13725,7 @@
 /obj/machinery/cryopod{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod17/station)
 "cbj" = (
 /obj/floor_decal/corner/paleblue/mono,
@@ -14359,10 +13947,8 @@
 /obj/structure/closet/medical_wall/filled{
 	pixel_y = 32
 	},
-/obj/random/firstaid,
-/obj/random/firstaid,
-/obj/random/medical,
 /obj/item/reagent_containers/food/snacks/proteinbar,
+/obj/random/loot/randomsupply,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
 "cwQ" = (
@@ -14455,12 +14041,6 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/medical)
-"cAh" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
 "cAO" = (
 /obj/structure/table/standard,
 /obj/random/clipboard,
@@ -14479,12 +14059,6 @@
 /obj/structure/closet/medical_wall{
 	pixel_y = 32
 	},
-/obj/random/firstaid,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
 /obj/random/medical,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
@@ -14637,18 +14211,6 @@
 	},
 /turf/simulated/floor/newsteel/dark,
 /area/medical/surgery2)
-"cOH" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
 "cPY" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -14778,18 +14340,6 @@
 	map_airless = 1
 	},
 /area/thruster/d1port)
-"cYB" = (
-/obj/structure/dispenser,
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "cZb" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -14799,14 +14349,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
-"cZd" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "cZi" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/barrier,
@@ -15212,24 +14754,6 @@
 /obj/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/firstdeck/aft)
-"dJv" = (
-/obj/floor_decal/techfloor/corner,
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "dJY" = (
 /obj/structure/sign/warning/hot_exhaust{
 	dir = 1
@@ -15249,9 +14773,6 @@
 	},
 /obj/random/soap,
 /obj/random/firstaid,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
 /obj/random/medical,
 /obj/random/medical,
 /obj/random/medical,
@@ -15410,9 +14931,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
-"dVw" = (
-/turf/simulated/wall/r_wall/hull,
-/area/command/armoury/tactical)
 "dWb" = (
 /obj/floor_decal/corner/paleblue{
 	dir = 5
@@ -16138,11 +15656,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/warhammer/metal,
 /area/medical/foyer/storeroom)
-"fll" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/flasher/portable,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "flB" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -16319,22 +15832,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
-"fIn" = (
-/obj/floor_decal/techfloor,
-/obj/floor_decal/corner_techfloor_grid{
-	dir = 5
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "fKb" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/newsteel/dark,
@@ -16358,32 +15855,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
-"fLg" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack/dark,
-/obj/item/stack/material/steel{
-	amount = 30
-	},
-/obj/item/stack/material/steel{
-	amount = 30
-	},
-/obj/item/stack/material/steel{
-	amount = 30
-	},
-/obj/item/stack/material/plasteel{
-	amount = 20
-	},
-/obj/item/stack/material/ocp{
-	amount = 10
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "fMr" = (
 /obj/wallframe_spawn/reinforced/no_grille,
 /obj/machinery/door/blast/shutters{
@@ -16410,18 +15881,6 @@
 /obj/structure/flora/pottedplant/flower,
 /turf/simulated/floor/newsteel/dark,
 /area/medical/medicalhallway)
-"fOr" = (
-/obj/structure/table/steel,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/machinery/recharger/wallcharger{
-	dir = 8;
-	pixel_x = 23;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
 "fOu" = (
 /obj/machinery/door/airlock/medical{
 	name = "Locker Room"
@@ -16474,7 +15933,6 @@
 /obj/item/device/radio/intercom/department/security{
 	pixel_y = 23
 	},
-/obj/item/book/manual/solgov_law,
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
 "fVb" = (
@@ -16565,16 +16023,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
-"fZn" = (
-/obj/floor_decal/techfloor,
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "gab" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1;
@@ -17346,28 +16794,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/security/opscheck)
-"hrk" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack/dark,
-/obj/item/clothing/shoes/dutyboots,
-/obj/item/clothing/accessory/storage/holster/thigh,
-/obj/item/clothing/glasses/tacgoggles,
-/obj/item/clothing/suit/armor/grim/medium/sol,
-/obj/item/clothing/head/helmet,
-/obj/machinery/rotating_alarm/security_alarm,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
-"hrE" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack/dark,
-/obj/item/storage/box/syringegun,
-/obj/item/gun/launcher/syringe,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "hsb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/opscheck)
@@ -17389,21 +16815,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"htK" = (
-/obj/structure/table/rack/dark,
-/obj/floor_decal/industrial/outline/grey,
-/obj/item/gun/projectile/automatic/autogun/a80,
-/obj/item/gun/projectile/automatic/autogun/a80,
-/obj/item/gun/projectile/automatic/autogun/a80,
-/obj/item/gun/projectile/automatic/autogun/a80,
-/obj/item/ammo_magazine/autogun/militarum,
-/obj/item/ammo_magazine/autogun/militarum,
-/obj/item/ammo_magazine/autogun/militarum,
-/obj/item/ammo_magazine/autogun/militarum,
-/obj/item/ammo_magazine/autogun/militarum,
-/obj/item/ammo_magazine/autogun/militarum,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "hub" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -17486,27 +16897,6 @@
 	},
 /turf/simulated/floor/newsteel/dark,
 /area/medical/sleeper)
-"hyb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/plating,
-/area/rnd/development)
 "hyj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17736,13 +17126,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
-"hOb" = (
-/obj/structure/table/rack/dark,
-/obj/floor_decal/industrial/outline/grey,
-/obj/item/gun/energy/plasma,
-/obj/item/gun/energy/plasma,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "hOZ" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -18167,10 +17550,6 @@
 /obj/random/obstruction,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/foreport)
-"ivh" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/prepainted,
-/area/rnd/misc_lab)
 "ivT" = (
 /obj/floor_decal/corner/paleblue{
 	dir = 5
@@ -18235,14 +17614,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
-"iAS" = (
-/obj/structure/table/rack/dark,
-/obj/floor_decal/industrial/outline/grey,
-/obj/item/shield/riot/metal,
-/obj/item/shield/riot/metal,
-/obj/item/shield/riot/metal,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "iAZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18261,24 +17632,6 @@
 /obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
-"iBb" = (
-/obj/structure/table/steel,
-/obj/machinery/cell_charger,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/item/screwdriver{
-	pixel_y = 15
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
 "iBT" = (
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1port)
@@ -18470,10 +17823,6 @@
 /obj/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/entry)
-"iRb" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/prepainted,
-/area/rnd/development)
 "iSb" = (
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
@@ -18815,38 +18164,6 @@
 /obj/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
-"jnd" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "job" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -18902,12 +18219,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
-"jrH" = (
-/obj/structure/sign/warning/secure_area/armory{
-	dir = 8
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury/access)
 "jsb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -19040,15 +18351,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/rnd/misc_lab)
-"jAl" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/floor_decal/corner/blue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
 "jAM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19268,36 +18570,6 @@
 	},
 /turf/simulated/floor/newsteel/dark,
 /area/rnd/research)
-"jPY" = (
-/obj/floor_decal/corner/blue,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
-"jQY" = (
-/obj/floor_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/bridge{
-	c_tag = "Emergency Armory - Tactical";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "jRb" = (
 /obj/machinery/light{
 	dir = 1
@@ -19379,10 +18651,7 @@
 /area/rnd/misc_lab)
 "kaS" = (
 /obj/structure/closet/crate/warhammer/freezer,
-/obj/random/medical,
 /obj/floor_decal/industrial/outline/grey,
-/obj/random/medical,
-/obj/random/medical,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "kbb" = (
@@ -19517,7 +18786,6 @@
 	pixel_x = -23;
 	pixel_y = -3
 	},
-/obj/item/book/manual/sol_sop,
 /obj/random_multi/single_item/memo_security,
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
@@ -19578,14 +18846,6 @@
 /obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
-"kmE" = (
-/obj/machinery/mech_recharger,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
 "knb" = (
 /obj/floor_decal/corner/yellow{
 	dir = 10
@@ -19671,26 +18931,6 @@
 	},
 /turf/simulated/floor/warhammer/metal/north,
 /area/security/storage)
-"ksK" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Tactical Armory"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "kvb" = (
 /obj/wallframe_spawn/reinforced/polarized/no_grille/regular{
 	id = "roboticlab_window"
@@ -19738,16 +18978,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/assembly/robotics/laboratory)
-"kyt" = (
-/obj/floor_decal/techfloor,
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "kzy" = (
 /obj/floor_decal/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19868,7 +19098,7 @@
 /turf/simulated/floor/warhammer/metal,
 /area/medical/staging)
 "kIb" = (
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/closet/warhammer/secure_closet/personal/patient,
 /obj/floor_decal/corner/pink/mono,
 /obj/machinery/body_scan_display{
 	pixel_y = 24
@@ -20317,17 +19547,6 @@
 /obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/entry)
-"lkp" = (
-/obj/floor_decal/industrial/outline/yellow,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "llb" = (
 /obj/machinery/fabricator,
 /obj/floor_decal/industrial/hatch/yellow,
@@ -20415,16 +19634,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
-"lst" = (
-/obj/floor_decal/corner_techfloor_grid{
-	dir = 6
-	},
-/obj/floor_decal/techfloor/corner,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
 "lsT" = (
 /obj/floor_decal/corner/paleblue{
 	dir = 1
@@ -20608,13 +19817,10 @@
 /obj/structure/closet/medical_wall/filled{
 	pixel_y = 32
 	},
-/obj/random/firstaid,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
+/obj/random/loot/randomsupply,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
 "lBb" = (
@@ -20660,23 +19866,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/newsteel/dark,
 /area/medical/equipstorage)
-"lGw" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/floor_decal/corner_techfloor_grid{
-	dir = 9
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/machinery/hologram/holopad,
-/obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "lHO" = (
 /turf/simulated/wall/prepainted,
 /area/medical/sleeper)
@@ -21046,18 +20235,6 @@
 "mpy" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftstarboard)
-"mrr" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "mrW" = (
 /obj/structure/closet/secure_closet/medical_torchsenior,
 /obj/floor_decal/corner/paleblue/mono,
@@ -21178,48 +20355,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"mwA" = (
-/obj/floor_decal/corner_techfloor_grid{
-	dir = 6
-	},
-/obj/floor_decal/techfloor/corner,
-/obj/floor_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
-"mwJ" = (
-/obj/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "mwV" = (
 /obj/floor_decal/floordetail/edgedrain{
 	dir = 6
@@ -21279,8 +20414,6 @@
 /area/security/detectives_office)
 "mCk" = (
 /obj/structure/table/steel,
-/obj/item/book/manual/sol_sop,
-/obj/item/book/manual/solgov_law,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -21363,22 +20496,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"mJJ" = (
-/obj/floor_decal/techfloor,
-/obj/floor_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "mJY" = (
 /obj/structure/closet/wardrobe/chemistry_white,
 /obj/floor_decal/corner/beige/mono,
@@ -21692,30 +20809,6 @@
 "njj" = (
 /turf/simulated/wall/prepainted,
 /area/command/conference)
-"njm" = (
-/obj/floor_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/floor_decal/techfloor/corner,
-/obj/floor_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "njQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21921,14 +21014,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
-"nvX" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
 "nxK" = (
 /obj/floor_decal/corner/yellow{
 	dir = 1
@@ -22296,23 +21381,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
-"nWP" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/recharger/wallcharger{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "nWV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22373,22 +21441,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
-"nZZ" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "obb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22577,10 +21629,6 @@
 	},
 /turf/simulated/floor/newsteel/dark,
 /area/medical/exam_room)
-"onM" = (
-/obj/floor_decal/corner/blue,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
 "oox" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -22588,10 +21636,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
-"ooN" = (
-/obj/floor_decal/techfloor,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
 "opg" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -22789,13 +21833,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
-"oBI" = (
-/obj/structure/table/rack/dark,
-/obj/floor_decal/industrial/outline/grey,
-/obj/item/gun/energy/lasgun/accatran,
-/obj/item/gun/energy/lasgun/accatran,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "oBZ" = (
 /obj/floor_decal/techfloor{
 	dir = 9
@@ -23366,11 +22403,6 @@
 /obj/structure/table/warhammer/reinf_table,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/armoury)
-"puw" = (
-/obj/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "puL" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -23841,24 +22873,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/newsteel/dark,
 /area/rnd/research)
-"pZj" = (
-/obj/floor_decal/techfloor,
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "pZy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -23897,29 +22911,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
-"qbH" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack/dark,
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/material/glass/boron_reinforced{
-	amount = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "qcb" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
 	external_pressure_bound = 0;
@@ -24453,18 +23444,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
-"qKQ" = (
-/obj/structure/table/rack/dark,
-/obj/floor_decal/industrial/outline/grey,
-/obj/item/storage/box/teargas{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/smokes,
-/obj/item/storage/box/handcuffs,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "qLb" = (
 /obj/machinery/portable_atmospherics/hydroponics{
 	closed_system = 1;
@@ -24578,30 +23557,6 @@
 /obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
-"qTX" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "qUb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -24651,7 +23606,6 @@
 	},
 /obj/structure/table/warhammer/shrine,
 /obj/random/loot/heavymelee,
-/obj/random/loot/swordmelee,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/armoury)
 "qYb" = (
@@ -25095,18 +24049,6 @@
 "ryb" = (
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
-"ryt" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "rzb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25224,9 +24166,10 @@
 /area/thruster/d1starboard)
 "rEK" = (
 /obj/floor_decal/industrial/outline/grey,
-/obj/random/loot/lasbundle,
-/obj/random/loot/lasbundle,
 /obj/structure/table/warhammer/reinf_table,
+/obj/item/gun/launcher/grenade,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/armoury)
 "rFb" = (
@@ -25235,13 +24178,6 @@
 	},
 /turf/simulated/floor/newsteel/dark,
 /area/rnd/xenobiology/xenoflora)
-"rFK" = (
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "rGb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -25266,11 +24202,6 @@
 /obj/structure/closet{
 	name = "Prisoner's Locker"
 	},
-/obj/item/book/manual/solgov_law{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/solgov_law,
 /turf/simulated/floor/tiled/monotile,
 /area/security/brig)
 "rHb" = (
@@ -25330,6 +24261,7 @@
 /obj/floor_decal/techfloor{
 	dir = 10
 	},
+/obj/structure/closet/secure_closet/guncabinet/lasgun,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/secure_storage)
 "rLb" = (
@@ -25613,9 +24545,7 @@
 "scd" = (
 /obj/structure/closet/crate/warhammer/freezer,
 /obj/random/medical,
-/obj/random/medical,
 /obj/floor_decal/industrial/outline/grey,
-/obj/random/medical,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "scr" = (
@@ -25882,10 +24812,6 @@
 /obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/center)
-"snG" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/prepainted,
-/area/hallway/primary/firstdeck/aft)
 "sob" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -25994,15 +24920,6 @@
 /obj/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/warhammer/metal,
 /area/rnd/xenobiology/xenoflora)
-"svH" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/floor_decal/techfloor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "swb" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
@@ -26018,23 +24935,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"swz" = (
-/obj/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "sxb" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 1
@@ -27445,15 +26345,6 @@
 	},
 /turf/simulated/floor/newsteel/dark,
 /area/medical/equipstorage)
-"uCe" = (
-/obj/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "uCA" = (
 /obj/machinery/papershredder,
 /obj/floor_decal/industrial/outline/yellow,
@@ -27575,39 +26466,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"uLQ" = (
-/obj/floor_decal/corner/blue,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
-"uMP" = (
-/obj/structure/closet/bombclosetsecurity,
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/recharger/wallcharger{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "uPc" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
@@ -27653,8 +26511,6 @@
 /area/security/brig)
 "uUK" = (
 /obj/structure/table/rack/dark,
-/obj/random/firstaid,
-/obj/item/storage/box/bodybags,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "uVf" = (
@@ -27748,15 +26604,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"uZO" = (
-/obj/structure/table/steel,
-/obj/machinery/recharger,
-/obj/item/pinpointer,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
 "uZY" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
@@ -27769,27 +26616,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
-"vcy" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"veT" = (
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "vfK" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
@@ -27817,49 +26643,6 @@
 /obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/warhammer/metal,
 /area/medical/locker)
-"vjY" = (
-/obj/structure/table/rack/dark,
-/obj/floor_decal/industrial/outline/grey,
-/obj/item/gun/projectile/pistol/stub,
-/obj/item/gun/projectile/pistol/stub,
-/obj/item/gun/projectile/pistol/stub,
-/obj/item/gun/projectile/pistol/stub,
-/obj/item/ammo_magazine/pistol,
-/obj/item/ammo_magazine/pistol,
-/obj/item/ammo_magazine/pistol,
-/obj/item/ammo_magazine/pistol,
-/obj/item/ammo_magazine/pistol,
-/obj/item/ammo_magazine/pistol,
-/obj/item/ammo_magazine/pistol,
-/obj/item/ammo_magazine/pistol,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
-"vkW" = (
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/floor_decal/corner_techfloor_grid{
-	dir = 10
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/floor_decal/techfloor/corner,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"vlw" = (
-/obj/floor_decal/techfloor,
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"vnz" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/light,
-/obj/machinery/flasher/portable,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "vnC" = (
 /obj/floor_decal/corner/paleblue/mono,
 /obj/machinery/power/apc{
@@ -27886,12 +26669,6 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/maintenance/firstdeck/foreport)
-"vtY" = (
-/obj/structure/sign/warning/high_voltage{
-	dir = 8
-	},
-/turf/simulated/wall/prepainted,
-/area/hallway/primary/firstdeck/aft)
 "vvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -28129,28 +26906,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
-"vUD" = (
-/obj/structure/closet/crate,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/storage/briefcase/inflatable,
-/obj/item/storage/briefcase/inflatable,
-/obj/floor_decal/industrial/outline/grey,
-/obj/item/storage/box/lights/tubes,
-/obj/item/storage/box/lights/bulbs,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "vVe" = (
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1starboard)
@@ -28224,23 +26979,6 @@
 /obj/random_multi/single_item/skelestand/maint,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
-"wjP" = (
-/obj/structure/table/rack/dark,
-/obj/floor_decal/industrial/outline/grey,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/toolbox/emergency,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "wkS" = (
 /obj/catwalk_plated,
 /obj/structure/cable/green{
@@ -28316,13 +27054,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "wtS" = (
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
 /obj/random/firstaid,
 /obj/item/device/scanner/health,
 /obj/structure/closet/medical_wall{
@@ -28405,15 +27136,9 @@
 "wEw" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/thruster/d1port)
-"wGe" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "wHE" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack/dark,
-/obj/random/firstaid,
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
@@ -28443,13 +27168,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
-"wRs" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
 "wUg" = (
 /obj/floor_decal/techfloor{
 	dir = 1
@@ -28532,20 +27250,6 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/rnd/xenobiology/cell_1)
-"xhX" = (
-/obj/structure/table/steel,
-/obj/random/clipboard,
-/obj/item/folder/red,
-/obj/item/hand_labeler,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
 "xjr" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 4
@@ -28589,14 +27293,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
-"xqk" = (
-/obj/floor_decal/industrial/outline/grey,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/suit_cycler/torch,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "xtq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
@@ -28738,11 +27434,7 @@
 	},
 /obj/structure/cable/green,
 /obj/structure/table/rack/dark,
-/obj/item/gun/launcher/grenade,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
+/obj/random/loot/swordmelee,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/secure_storage)
 "xFL" = (
@@ -39974,7 +38666,7 @@ aMK
 aNL
 afj
 afj
-aOK
+aNH
 aRs
 aSq
 sCb
@@ -40769,7 +39461,7 @@ mVb
 neb
 nob
 oyb
-aDN
+aDL
 aDL
 obZ
 pIA
@@ -45211,7 +43903,7 @@ uSl
 rsV
 ayg
 ure
-aAs
+aAK
 aAK
 aAK
 aAK
@@ -46221,7 +44913,7 @@ acE
 ycz
 ayj
 azp
-aAK
+aAs
 aAK
 aAK
 aAK
@@ -47231,7 +45923,7 @@ oJb
 koX
 ayg
 ure
-aAs
+aAK
 aAK
 aAK
 aAK
@@ -51074,7 +49766,7 @@ hIb
 hZb
 aFb
 iHb
-iRb
+aCf
 qrb
 mTb
 qtb
@@ -51473,7 +50165,7 @@ gXb
 lMD
 ayy
 iXb
-acG
+aCf
 hKb
 ibb
 isb
@@ -51675,7 +50367,7 @@ gXb
 ycz
 xmO
 gAU
-hyb
+aCf
 llb
 lpb
 itb
@@ -51877,7 +50569,7 @@ gXb
 ycz
 ayw
 iZb
-aAJ
+aCf
 lmb
 lqb
 ltb
@@ -54917,7 +53609,7 @@ aHi
 aHi
 aHi
 aHi
-ivh
+aHi
 aHi
 aHi
 aHi
@@ -55305,7 +53997,7 @@ alR
 sFb
 ask
 ato
-auk
+azU
 avy
 awH
 uoC
@@ -55503,19 +54195,19 @@ mpy
 mpy
 bBt
 xKq
-acL
+mpy
 xtq
 sCu
 usV
-auk
-vtY
-awI
-awJ
-awJ
-awJ
-aAW
-vtY
-auk
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+bDK
+aTK
 aTK
 vBV
 aTK
@@ -55706,17 +54398,17 @@ mpy
 mpy
 mpy
 mpy
-acL
-asl
-asl
-acL
-snG
-lkp
-puw
-ayJ
-ayJ
-mwJ
-snG
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+aTK
 aTK
 xxB
 aLu
@@ -55908,17 +54600,17 @@ mpy
 mpy
 mpy
 mpy
-uXe
-sde
-sde
-abL
-aGN
-aGN
-acB
-ayK
-jrH
-aAX
-aGN
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+aDB
 lLD
 aLu
 aLu
@@ -56108,25 +54800,25 @@ mpy
 mpy
 mpy
 mpy
-dVw
-dVw
-aBc
-aBc
-aBc
-aBc
-aGN
-awL
-wRs
-ayL
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
 azU
-aAY
-aGN
-aHT
-aHT
-aHT
-aHT
-eRU
-eRU
+azU
+azU
+azU
+azU
+azU
+aDB
+aDB
+aDB
+aDB
+aDB
+bDK
+bDK
 bDK
 bDK
 bDK
@@ -56309,27 +55001,27 @@ acd
 acd
 acd
 acd
-dVw
-dVw
-dVw
-aBc
-aBc
-aBc
-aBc
-aGN
-xhX
-fOr
-cOH
-bYj
-aAZ
-aGN
-aHT
-aHT
-aHT
-aHT
-eRU
-eRU
-eRU
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
 acd
 acd
 acd
@@ -56512,25 +55204,25 @@ acd
 acd
 acd
 acd
-dVw
-dVw
-htK
-vjY
-oBI
-hOb
-aBc
-aHT
-aHT
-aHT
-aHT
-aBa
-aHT
-uZO
-ooN
-aQr
-aRm
-eRU
-eRU
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
 acd
 acd
 acd
@@ -56714,25 +55406,25 @@ aaa
 aaa
 acd
 acd
-dVw
-dVw
-veT
-svH
-svH
-swz
-aBc
-iBb
-nvX
-kmE
-onM
-uLQ
-jPY
-onM
-ooN
-fll
-vnz
-eRU
-eRU
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
 acd
 acd
 aaa
@@ -56916,25 +55608,25 @@ aaa
 aaa
 acd
 acd
-dVw
-dVw
-hrk
-aEG
-aEG
-dJv
-aBc
-bMB
-lst
-cAh
-jAl
-mwA
-jAl
-jAl
-bBv
-aQs
-aQs
-eRU
-eRU
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
 acd
 acd
 aaa
@@ -57118,25 +55810,25 @@ aaa
 aaa
 acd
 acd
-dVw
-dVw
-ryt
-svH
-svH
-njm
-ksK
-nZZ
-mJJ
-cYB
-qTX
-pZj
-jnd
-vUD
-fZn
-aQq
-aQq
-eRU
-eRU
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
 acd
 acd
 aaa
@@ -57320,25 +56012,25 @@ aaa
 acd
 acd
 acd
-dVw
-dVw
-aEG
-aEG
-aEG
-jQY
-aBc
-xqk
-rFK
-aMB
-aNE
-vlw
-aMB
-ahL
-kyt
-aQt
-aQt
-eRU
-eRU
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
 acd
 acd
 acd
@@ -57522,25 +56214,25 @@ aaa
 acd
 acd
 acd
-dVw
-dVw
-mrr
-svH
-svH
-nWP
-aBc
-cZd
-vkW
-uCe
-uCe
-lGw
-uCe
-uCe
-fIn
-wGe
-vcy
-eRU
-eRU
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
 acd
 acd
 acd
@@ -57724,24 +56416,24 @@ aaa
 acd
 acd
 acd
-dVw
-dVw
-qKQ
-iAS
-bCX
-uMP
-aBc
-aJl
-rFK
-aJm
-wjP
-fLg
-qbH
-hrE
-vlw
-aQu
-aQu
-eRU
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
 eRU
 acd
 acd
@@ -57926,24 +56618,24 @@ aaa
 acd
 acd
 acd
-dVw
-dVw
-dVw
-dVw
-dVw
-dVw
-dVw
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
 eRU
 acd
 acd
@@ -58129,23 +56821,23 @@ aaa
 acd
 acd
 acd
-dVw
-dVw
-dVw
-dVw
-dVw
-dVw
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
+mpy
+mpy
+mpy
+mpy
+mpy
+mpy
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
+azU
 acd
 acd
 acd

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -230,15 +230,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"aB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
 "aC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -524,11 +515,11 @@
 /obj/structure/bed/chair/comfy/blue{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "be" = (
 /obj/machinery/computer/modular/preset/cardslot/command,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "bf" = (
 /obj/structure/closet/secure_closet/bridgeofficer,
@@ -845,14 +836,14 @@
 /obj/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
-"bN" = (
-/obj/floor_decal/spline/plain/beige{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
 "bO" = (
-/turf/simulated/floor/wood/walnut,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/bed/chair/comfy/blue,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "bP" = (
 /obj/wallframe_spawn/reinforced/polarized{
@@ -1090,28 +1081,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
 "co" = (
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
-"cp" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/reagent_containers/food/drinks/glass2/coffeecup/SCG{
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/obj/item/reagent_containers/food/drinks/glass2/coffeecup/SCG{
-	pixel_x = 8;
-	pixel_y = -3
+/turf/simulated/floor/warhammer/rectangles,
+/area/crew_quarters/heads/office/xo)
+"cp" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "cq" = (
-/obj/floor_decal/spline/plain/beige{
-	dir = 4
-	},
-/obj/structure/bed/chair/comfy/blue{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/wall/ocp_wall,
 /area/crew_quarters/heads/office/xo)
 "cr" = (
 /obj/structure/disposalpipe/segment{
@@ -1235,7 +1221,7 @@
 	pixel_x = -8;
 	pixel_y = 20
 	},
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -1246,7 +1232,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "cz" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
@@ -1579,14 +1565,8 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
-"cX" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/book/manual/solgov_law,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "cY" = (
 /obj/structure/table/woodentable/walnut,
-/obj/item/book/manual/sol_sop,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "cZ" = (
@@ -1644,7 +1624,7 @@
 /obj/random_multi/single_item/memo_supply,
 /obj/item/folder/envelope/dcorder,
 /obj/item/folder/envelope/csorder,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "de" = (
 /obj/structure/cable/green{
@@ -1688,7 +1668,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "dh" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -1914,22 +1894,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "dI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 21
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
-"dJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/bed/chair/comfy/blue{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+/turf/simulated/floor/warhammer/rectangles,
+/area/crew_quarters/heads/office/xo)
+"dJ" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/reagent_containers/food/drinks/glass2/coffeecup/SCG{
+	pixel_x = 8;
+	pixel_y = -3
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "dK" = (
 /obj/structure/table/woodentable/walnut,
@@ -1994,14 +1970,14 @@
 "dR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/floor_decal/spline/plain/beige{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "dS" = (
 /obj/machinery/requests_console{
@@ -2014,7 +1990,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "dT" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -2026,7 +2002,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "dU" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/machinery/button/blast_door{
 	id_tag = "bridge blast";
 	name = "Bridge Window Lockdown Control";
@@ -2042,7 +2018,7 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/auxsolarbridge)
 "dW" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/machinery/camera/network/bridge{
 	c_tag = "Bridge";
 	dir = 1
@@ -2064,7 +2040,7 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "ec" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/wall/titanium,
 /area/aquila/cockpit)
 "ed" = (
@@ -2144,7 +2120,8 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/fern,
-/turf/simulated/floor/wood/walnut,
+/obj/random_multi/single_item/runtime,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "eo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2162,19 +2139,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "eq" = (
-/obj/machinery/door/airlock/sol{
-	name = "XO's Quarters";
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
+/turf/simulated/wall/ocp_wall,
+/area/maintenance/bridge/forestarboard)
 "er" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2242,13 +2208,11 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/table/glass,
-/obj/item/book/manual/solgov_law,
-/obj/item/book/manual/sol_sop,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "ew" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "ex" = (
@@ -2409,13 +2373,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "eR" = (
 /obj/structure/disposalpipe/trunk{
@@ -2450,7 +2410,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/photocopier,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "eU" = (
 /obj/machinery/light{
@@ -2644,7 +2604,7 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "fl" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/random_multi/single_item/memo_research,
 /obj/random_multi/single_item/memo_exploration,
 /turf/simulated/floor/tiled,
@@ -2692,7 +2652,7 @@
 /obj/structure/sign/warning/high_voltage{
 	dir = 8
 	},
-/turf/simulated/wall/r_wall/hull,
+/turf/simulated/wall/ocp_wall,
 /area/maintenance/bridge/forestarboard)
 "fv" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -2735,9 +2695,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "fz" = (
-/obj/floor_decal/spline/plain/beige{
-	dir = 4
-	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -2749,7 +2706,7 @@
 	name = "XO Request Console";
 	pixel_y = 30
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "fA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2989,7 +2946,6 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cmo)
 "fX" = (
-/obj/paint/red,
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
@@ -3205,7 +3161,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "gw" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/wall/titanium,
 /area/aquila/storage)
 "gz" = (
@@ -3805,7 +3761,7 @@
 	opacity = 0
 	},
 /obj/wallframe_spawn/reinforced/titanium,
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/floor/plating,
 /area/aquila/air)
 "iA" = (
@@ -3813,35 +3769,17 @@
 /turf/simulated/floor/plating,
 /area/aquila/air)
 "iB" = (
-/obj/floor_decal/spline/plain/beige{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "iI" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wallframe_spawn/reinforced/polarized{
-	id = "bridge_starboard"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
+/turf/simulated/wall/r_wall/hull,
+/area/space)
 "iJ" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wallframe_spawn/reinforced/polarized{
-	id = "bridge_starboard"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
+/turf/simulated/floor/reinforced,
+/area/solar/bridge)
 "iP" = (
 /obj/machinery/recharger/wallcharger{
 	dir = 4;
@@ -4490,7 +4428,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
 "lt" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -4636,20 +4574,15 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
 "lL" = (
-/obj/wallframe_spawn/reinforced,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/ocp_wall,
 /area/bridge)
 "lN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4814,7 +4747,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "mx" = (
-/obj/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
@@ -4902,7 +4834,6 @@
 "mI" = (
 /obj/structure/closet/secure_closet/cos,
 /obj/floor_decal/industrial/outline/grey,
-/obj/item/book/manual/sol_sop,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -5195,7 +5126,7 @@
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/heads/office/cl)
 "nu" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/item/device/binoculars,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -5352,7 +5283,7 @@
 /obj/structure/cable/yellow,
 /obj/machinery/power/tracker,
 /turf/simulated/floor/reinforced,
-/area/space)
+/area/solar/bridge)
 "ob" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5440,31 +5371,17 @@
 /turf/simulated/wall/prepainted,
 /area/aux_eva)
 "ox" = (
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wallframe_spawn/reinforced/polarized{
-	id = "bridge_port"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/ocp_wall,
 /area/bridge)
 "oy" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wallframe_spawn/reinforced/polarized{
-	id = "bridge_port"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
+/obj/structure/sign/warning/lethal_turrets,
+/turf/simulated/wall/r_wall/hull,
+/area/maintenance/bridge/forestarboard)
 "oz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "oB" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -5494,7 +5411,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "oJ" = (
 /obj/machinery/door/blast/shutters{
@@ -5639,7 +5556,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
-/obj/paint/hull,
+/obj/paint/meatstation,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
@@ -5978,10 +5895,16 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/aquila/medical)
 "qa" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/turf/simulated/floor/carpet,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "qb" = (
 /obj/machinery/recharger/wallcharger{
@@ -6178,7 +6101,7 @@
 /area/crew_quarters/heads/office/cmo)
 "qv" = (
 /obj/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/pen/blue,
@@ -6198,7 +6121,7 @@
 /area/security/bridgecheck)
 "qx" = (
 /obj/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/item/reagent_containers/food/snacks/cookie,
 /obj/item/reagent_containers/food/snacks/cookie,
 /obj/item/reagent_containers/food/snacks/cookie,
@@ -6262,7 +6185,7 @@
 /turf/space,
 /area/space)
 "qO" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/ocp_wall,
 /area/bridge/storage)
 "qP" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -6600,10 +6523,8 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/obj/item/toy/torchmodel,
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/random_multi/single_item/runtime,
-/turf/simulated/floor/wood/walnut,
+/obj/machinery/computer/account_database,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "rI" = (
 /obj/structure/bed/chair/comfy/blue{
@@ -6798,27 +6719,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "si" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/hop,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "sl" = (
 /obj/structure/flora/pottedplant/shoot,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "sm" = (
 /obj/machinery/shipsensors/upgraded,
@@ -6852,12 +6764,6 @@
 /obj/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/aquila/storage)
-"sx" = (
-/obj/structure/sign/warning/high_voltage{
-	dir = 8
-	},
-/turf/simulated/wall/r_wall/hull,
-/area/maintenance/bridge/foreport)
 "sy" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -6899,10 +6805,7 @@
 /area/crew_quarters/heads/office/sea)
 "sC" = (
 /obj/structure/bookcase,
-/obj/item/book/manual/solgov_law,
-/obj/item/book/manual/sol_sop,
-/obj/item/book/manual/military_law,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "sF" = (
 /obj/structure/cable/green{
@@ -7169,9 +7072,6 @@
 /area/crew_quarters/heads/office/sgr)
 "tx" = (
 /obj/structure/bookcase,
-/obj/item/book/manual/solgov_law,
-/obj/item/book/manual/sol_sop,
-/obj/item/book/manual/military_law,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -7856,7 +7756,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall/hull,
 /area/space)
 "vE" = (
 /obj/structure/lattice,
@@ -8055,7 +7955,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "wh" = (
-/obj/item/book/manual/military_law,
 /obj/item/reagent_containers/food/drinks/glass2/square,
 /obj/structure/table/woodentable_reinforced/walnut,
 /turf/simulated/floor/tiled/dark,
@@ -8838,6 +8737,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"xV" = (
+/obj/floor_decal/corner/blue/half{
+	dir = 1
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "elevatorcmd";
+	name = "Lockdown";
+	pixel_x = 6;
+	pixel_y = 26;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/aft)
 "xW" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8906,17 +8818,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
-"yf" = (
-/obj/wallframe_spawn/reinforced/polarized{
-	id = "bridge_starboard"
-	},
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "yg" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
@@ -8928,7 +8829,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "yk" = (
-/obj/paint/red,
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
 "yl" = (
@@ -8945,7 +8845,7 @@
 /area/crew_quarters/heads/office/sea)
 "yw" = (
 /obj/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/item/sticky_pad/random,
 /obj/item/storage/box/cups,
 /obj/item/reagent_containers/food/drinks/bottle/orangejuice,
@@ -9001,17 +8901,15 @@
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/heads/office/cl)
 "yL" = (
-/obj/machinery/suit_storage_unit/standard_unit{
-	req_access = newlist()
-	},
 /obj/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/bridge)
 "yM" = (
 /obj/structure/sign/dedicationplaque{
 	desc = " Dauntless - Mako Class - Sol Explorator Registry 95519 - Shiva Imperial Navy Yards, Sancor - First Vessel To Bear The Name - Launched 2302 - Sol Central Government - 'Never was anything great achieved without danger.'"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/ocp_wall,
 /area/bridge/storage)
 "yR" = (
 /obj/machinery/door/airlock/security{
@@ -9042,7 +8940,6 @@
 "yU" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/sticky_pad/random,
-/obj/item/book/manual/nt_regs,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/heads/office/cl)
 "yV" = (
@@ -9058,7 +8955,7 @@
 "za" = (
 /obj/structure/closet/secure_closet/XO,
 /obj/random/drinkbottle,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "zb" = (
 /obj/shuttle_landmark/merc/deck1{
@@ -9094,12 +8991,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "zh" = (
-/obj/structure/cable/green,
-/obj/wallframe_spawn/reinforced/polarized{
-	id = "bridge_port"
+/obj/machinery/door/airlock/warhammer/command/ancient{
+	name = "Maintenance Hatch";
+	req_access = list("ACCESS_MECHANICUS")
 	},
-/turf/simulated/floor/plating,
-/area/bridge)
+/turf/simulated/floor/reinforced,
+/area/solar/bridge)
 "zo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9231,7 +9128,7 @@
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
 "zT" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "zV" = (
 /obj/wallframe_spawn/reinforced,
@@ -9284,7 +9181,7 @@
 /obj/structure/bed/chair/office/comfy/blue{
 	dir = 8
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "Ae" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -9294,7 +9191,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/storage)
 "Ag" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /obj/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
 	density = 0;
@@ -9454,15 +9351,19 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
 "AH" = (
-/obj/wallframe_spawn/reinforced/polarized{
-	id = "bridge_starboard"
+/obj/structure/catwalk,
+/obj/machinery/power/terminal{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/pointdefense{
+	initial_id_tag = "torch_primary_pd"
 	},
 /turf/simulated/floor/plating,
-/area/bridge)
+/area/space)
 "AI" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -9601,7 +9502,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "Bw" = (
 /obj/structure/disposalpipe/segment{
@@ -9621,7 +9522,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "BE" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/machinery/button/blast_door{
 	id_tag = "bridge blast";
 	name = "Bridge Window Lockdown Control";
@@ -9657,20 +9558,6 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
-"BI" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id_tag = "cap_window";
-	name = "CO's Quarters Shutters"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/co)
 "BO" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
 	dir = 4;
@@ -9680,7 +9567,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/power)
 "BR" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/item/paper_bin{
 	pixel_x = 1;
 	pixel_y = 9
@@ -9762,15 +9649,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
-"Ce" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
 "Cf" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9924,11 +9802,11 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/floor/plating,
 /area/aquila/airlock)
 "CE" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -10091,14 +9969,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
 "Dx" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wallframe_spawn/reinforced/polarized{
-	id = "co_windows"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/ocp_wall,
 /area/crew_quarters/heads/office/co)
 "DE" = (
 /obj/structure/cable/green,
@@ -10243,7 +10114,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "Ez" = (
-/obj/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
@@ -10270,7 +10140,6 @@
 /obj/floor_decal/corner/paleblue/diagonal,
 /obj/structure/closet/secure_closet/CMO_torch,
 /obj/item/storage/belt/medical,
-/obj/item/book/manual/sol_sop,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -10403,8 +10272,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "Fp" = (
+/obj/structure/sign/warning/lethal_turrets,
 /turf/simulated/wall/r_wall/hull,
-/area/bridge/storage)
+/area/maintenance/bridge/foreport)
 "Fz" = (
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
@@ -10429,10 +10299,10 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "FK" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/wall/titanium,
 /area/aquila/airlock)
 "FL" = (
@@ -10494,7 +10364,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Gc" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -10776,7 +10646,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "Hi" = (
 /obj/random/obstruction,
@@ -10978,8 +10848,9 @@
 /area/crew_quarters/heads/office/cl)
 "HI" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/command{
-	name = "Bridge Storage"
+/obj/machinery/door/airlock/warhammer/vaultold{
+	req_access = list("ACCESS_BRIDGE");
+	name = "Bridge - Saferoom"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -11074,15 +10945,10 @@
 	opacity = 0
 	},
 /obj/wallframe_spawn/reinforced/titanium,
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/floor/plating,
 /area/aquila/cockpit)
 "Id" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
 "Ie" = (
@@ -11187,9 +11053,6 @@
 /area/crew_quarters/heads/office/sea)
 "Iq" = (
 /obj/structure/bookcase,
-/obj/item/book/manual/solgov_law,
-/obj/item/book/manual/sol_sop,
-/obj/item/book/manual/military_law,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
 "Is" = (
@@ -11252,9 +11115,6 @@
 /area/crew_quarters/heads/cobed)
 "IB" = (
 /obj/structure/bookcase,
-/obj/item/book/manual/solgov_law,
-/obj/item/book/manual/sol_sop,
-/obj/item/book/manual/military_law,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "ID" = (
@@ -11313,7 +11173,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "IJ" = (
-/obj/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
@@ -11333,12 +11192,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/bridge/fore)
 "IL" = (
-/obj/paint/red,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
 /turf/simulated/wall/titanium,
 /area/aquila/power)
 "IT" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/machinery/keycard_auth/torch{
 	pixel_x = 26
 	},
@@ -11372,7 +11230,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "IY" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -11530,7 +11388,7 @@
 /area/bridge/storage)
 "Kf" = (
 /obj/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/random_multi/single_item/memo_medical,
 /obj/item/folder/envelope/cmoorder,
 /turf/simulated/floor/tiled/white,
@@ -11691,7 +11549,7 @@
 /area/aquila/medical)
 "KP" = (
 /obj/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/machinery/photocopier/faxmachine{
 	department = "Dauntless - Chief Medical Officer"
 	},
@@ -11818,7 +11676,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "Lv" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/item/stamp/rd,
 /obj/floor_decal/corner/research{
 	dir = 5
@@ -11892,7 +11750,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "LQ" = (
-/obj/paint/red,
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
@@ -12030,7 +11887,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "MK" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/wall/titanium,
 /area/aquila/air)
 "MU" = (
@@ -12244,7 +12101,7 @@
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "NL" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -12305,19 +12162,8 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "Od" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/floor_decal/spline/plain/beige{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/woodentable/walnut,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "Oe" = (
 /obj/machinery/requests_console{
@@ -12425,7 +12271,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/bridgecheck)
 "Oq" = (
-/obj/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
@@ -12574,13 +12419,13 @@
 /obj/structure/closet/medical_wall/filled{
 	pixel_x = -32
 	},
-/obj/random/firstaid,
-/obj/random/firstaid,
 /obj/random/medical,
 /obj/random/drinkbottle,
 /obj/floor_decal/techfloor{
 	dir = 10
 	},
+/obj/random/loot/randomsupply,
+/obj/random/loot/sidearmbundle,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/bridge)
 "Pg" = (
@@ -12626,7 +12471,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
 "PA" = (
-/obj/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
@@ -12753,10 +12597,7 @@
 	pixel_y = 6;
 	req_access = list("ACCESS_BRIDGE")
 	},
-/obj/floor_decal/spline/plain/beige{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "Qe" = (
 /obj/structure/cable/green{
@@ -12848,6 +12689,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"Qq" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id_tag = "elevatorcmd";
+	name = "Restricted Lockdown"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/aft)
 "Qv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12860,7 +12709,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "Qw" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12896,7 +12745,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "QF" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/wall/titanium,
 /area/aquila/suits)
 "QK" = (
@@ -12912,7 +12761,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/bridge/fore)
 "QL" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12937,7 +12786,6 @@
 	pixel_x = 25;
 	req_access = list("ACCESS_BRIDGE")
 	},
-/obj/item/stool/padded,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "QS" = (
@@ -12955,7 +12803,6 @@
 	pixel_x = -5;
 	pixel_y = -1
 	},
-/obj/item/book/manual/solgov_law,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "QW" = (
@@ -12987,7 +12834,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "QY" = (
 /obj/structure/railing/mapped{
@@ -13201,7 +13048,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "RH" = (
-/obj/paint/red,
 /turf/simulated/wall/titanium,
 /area/aquila/storage)
 "RK" = (
@@ -13215,7 +13061,7 @@
 /obj/structure/bed/chair/comfy/blue{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "RQ" = (
 /obj/machinery/firealarm{
@@ -13247,20 +13093,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "RV" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor,
-/obj/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id_tag = "cap_window";
-	name = "CO's Quarters Shutters"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/co)
+/obj/machinery/status_display,
+/turf/simulated/wall/ocp_wall,
+/area/bridge)
 "RX" = (
 /obj/structure/sign/warning/fall,
 /turf/simulated/wall/r_wall/hull,
@@ -13367,7 +13202,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/floor/plating,
 /area/aquila/cockpit)
 "SB" = (
@@ -13675,8 +13510,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "TP" = (
-/obj/structure/curtain/open/bed,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/warhammer/vaultold{
+	req_access = list("ACCESS_BRIDGE");
+	name = "Bridge - Saferoom"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "TQ" = (
@@ -13808,7 +13646,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/crew)
 "Uy" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -13863,7 +13701,6 @@
 /turf/space,
 /area/space)
 "UW" = (
-/obj/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
@@ -13883,7 +13720,12 @@
 /area/aquila/medical)
 "Vc" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood/walnut,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "Vf" = (
 /obj/structure/cable/green{
@@ -14046,26 +13888,16 @@
 	},
 /obj/structure/table/woodentable/walnut,
 /obj/item/sticky_pad/random,
-/turf/simulated/floor/carpet,
+/obj/item/toy/torchmodel,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "VL" = (
 /obj/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "VN" = (
-/obj/wallframe_spawn/reinforced/polarized{
-	id = "bridge_port"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
+/turf/simulated/wall/r_wall/hull,
+/area/solar/bridge)
 "VP" = (
 /obj/floor_decal/corner/paleblue{
 	dir = 10
@@ -14133,7 +13965,7 @@
 /area/bridge/meeting_room)
 "Wg" = (
 /obj/wallframe_spawn/reinforced/titanium,
-/obj/paint/hull,
+/obj/paint/meatstation,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14153,7 +13985,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/bridgecheck)
 "Wi" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/machinery/photocopier/faxmachine{
 	department = "Dauntless - Chief Science Officer"
 	},
@@ -14178,7 +14010,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "Ws" = (
-/obj/paint/red,
 /turf/simulated/wall/titanium,
 /area/aquila/power)
 "Wt" = (
@@ -14196,7 +14027,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "Ww" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/wall/titanium,
 /area/aquila/power)
 "WL" = (
@@ -14204,10 +14035,10 @@
 	dir = 8;
 	icon_state = "console"
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "WW" = (
-/obj/structure/table/glass,
+/obj/structure/table/steel,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -14237,7 +14068,6 @@
 /area/bridge/meeting_room)
 "Xa" = (
 /obj/structure/closet/firecloset,
-/obj/item/storage/briefcase/inflatable,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/apc/high{
 	dir = 8;
@@ -14306,7 +14136,7 @@
 /area/hallway/primary/bridge/fore)
 "Xp" = (
 /obj/structure/sign/solgov,
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/wall/titanium,
 /area/aquila/airlock)
 "Xq" = (
@@ -14350,7 +14180,7 @@
 /area/crew_quarters/heads/office/cmo)
 "Xz" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/guncabinet/PPE,
+/obj/structure/closet/secure_closet/guncabinet/lasgun,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "XB" = (
@@ -14430,7 +14260,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "Yb" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
 "Yd" = (
@@ -14440,13 +14270,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "Ye" = (
 /obj/machinery/button/blast_door{
@@ -14548,7 +14376,7 @@
 	icon_state = "console"
 	},
 /obj/item/modular_computer/tablet/lease/preset/command,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "YC" = (
 /obj/machinery/door/airlock/sol{
@@ -14719,18 +14547,19 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "Zj" = (
-/obj/paint/hull,
+/obj/paint/meatstation,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/suits)
 "Zs" = (
-/obj/machinery/computer/account_database,
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
 	},
-/turf/simulated/floor/carpet,
+/obj/structure/bed/padded,
+/obj/item/bedsheet/brown,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "Zt" = (
 /obj/floor_decal/corner/red{
@@ -14774,7 +14603,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
 "ZB" = (
-/obj/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
@@ -14834,7 +14662,7 @@
 /obj/structure/dogbed,
 /obj/random/plushie,
 /mob/living/simple_animal/passive/corgi/Ian,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/rectangles,
 /area/crew_quarters/heads/office/xo)
 "ZX" = (
 /obj/floor_decal/corner/paleblue/diagonal,
@@ -21789,6 +21617,7 @@ aa
 aa
 aa
 aa
+oy
 af
 af
 af
@@ -21798,7 +21627,16 @@ af
 af
 af
 af
-af
+aa
+aa
+aa
+aa
+AH
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -21808,16 +21646,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-zx
-aa
-aa
-aa
-aa
 tg
 tg
 tg
@@ -21827,7 +21655,7 @@ tg
 tg
 tg
 tg
-tg
+Fp
 aa
 aa
 aa
@@ -22004,8 +21832,9 @@ af
 af
 aa
 aa
-aa
+iI
 vA
+iI
 aa
 aa
 aa
@@ -22013,10 +21842,9 @@ aa
 aa
 aa
 aa
-aa
-aa
+iI
 vA
-aa
+iI
 aa
 aa
 tg
@@ -22198,12 +22026,12 @@ af
 af
 af
 af
-af
-af
-af
-af
-af
-af
+eq
+eq
+eq
+eq
+eq
+eq
 fu
 XQ
 XQ
@@ -22218,9 +22046,9 @@ Aw
 KG
 Hz
 Es
-aa
-aa
-sx
+iI
+iI
+tg
 tg
 tg
 tg
@@ -22409,7 +22237,7 @@ NL
 DE
 TB
 sm
-HE
+RV
 Ra
 CE
 BE
@@ -22420,8 +22248,8 @@ dU
 WW
 FE
 HE
-BI
-RV
+Mz
+Mz
 Mz
 Yz
 Pt
@@ -22608,10 +22436,10 @@ qO
 Gr
 rz
 Xz
-Fp
+qO
 eM
 DE
-Ie
+ox
 nf
 If
 lt
@@ -22813,7 +22641,7 @@ Hf
 bf
 ee
 Wv
-eP
+ox
 cy
 HC
 hn
@@ -23015,7 +22843,7 @@ eN
 Ke
 Ks
 TI
-eP
+ox
 cz
 HC
 hn
@@ -23429,7 +23257,7 @@ Kt
 Lw
 fN
 HW
-ck
+ox
 qQ
 rJ
 Ii
@@ -23621,20 +23449,20 @@ Du
 qO
 qO
 yM
-eP
+ox
 hV
-eP
+ox
 nu
 hn
 HC
 hn
 dW
-eP
+ox
 HX
-eP
+ox
 Dx
 rK
-bq
+Dx
 bq
 bq
 bq
@@ -23815,17 +23643,17 @@ al
 aO
 aO
 aO
-aO
-aO
-aO
-aO
-aO
-aO
+cq
+cq
+cq
+cq
+cq
+cq
 bM
 ci
 ct
 cA
-iI
+ox
 HF
 qf
 Zg
@@ -24018,7 +23846,7 @@ aO
 sC
 Bs
 qa
-aO
+zT
 sl
 si
 VF
@@ -24027,13 +23855,13 @@ bR
 cl
 cu
 cB
-iJ
+ox
 jz
 dT
 dh
 IY
 nJ
-oy
+ox
 eD
 eW
 fw
@@ -24218,24 +24046,24 @@ VB
 JF
 aO
 Zs
-co
+zT
 cp
-aO
 dI
-aB
+dI
+zT
 za
 fx
 bS
 cl
 cv
 cC
+ox
+ox
+ox
 eP
-AH
-yf
-eP
-VN
-zh
-eP
+ox
+ox
+ox
 eC
 eX
 fy
@@ -24420,12 +24248,12 @@ VB
 xN
 aO
 fz
-bN
-cq
-aO
-aO
-eq
-aO
+zT
+bO
+co
+Od
+zT
+zT
 yg
 cl
 cl
@@ -24622,11 +24450,11 @@ VB
 xN
 aO
 en
-bO
+zT
 bO
 Od
 dJ
-Ce
+zT
 ZT
 bQ
 cl
@@ -25027,7 +24855,7 @@ xN
 aO
 QX
 dd
-bO
+zT
 iB
 oz
 zT
@@ -25229,7 +25057,7 @@ YL
 aO
 rC
 Ad
-bO
+zT
 Qd
 be
 NH
@@ -25440,7 +25268,7 @@ aO
 eU
 qg
 Vn
-cX
+cY
 dl
 Xe
 dK
@@ -29280,7 +29108,7 @@ gm
 gm
 gm
 gm
-jV
+Qq
 jV
 YS
 VP
@@ -29482,7 +29310,7 @@ gm
 gm
 gm
 gm
-jV
+Qq
 jV
 YS
 VP
@@ -29684,7 +29512,7 @@ gm
 gm
 gm
 gm
-jV
+Qq
 kN
 lH
 mV
@@ -29887,7 +29715,7 @@ gm
 gm
 gm
 fI
-kM
+xV
 El
 mW
 kJ
@@ -30112,7 +29940,7 @@ xD
 CN
 CN
 CN
-ad
+iI
 aa
 aa
 aa
@@ -30314,7 +30142,7 @@ CN
 CN
 CN
 CN
-ad
+iI
 aa
 aa
 aa
@@ -30515,8 +30343,8 @@ CN
 CN
 CN
 ad
-ad
-ad
+iI
+iI
 aa
 aa
 aa
@@ -30717,8 +30545,8 @@ CN
 ad
 ad
 ad
-ad
-ad
+iI
+iI
 aa
 aa
 aa
@@ -30919,8 +30747,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+iI
+iI
 aa
 aa
 aa
@@ -31121,8 +30949,8 @@ ad
 ad
 ad
 ad
+iI
 ad
-aa
 aa
 aa
 aa
@@ -31323,8 +31151,8 @@ ad
 ad
 ad
 ad
+iI
 ad
-aa
 aa
 aa
 aa
@@ -31484,12 +31312,12 @@ aa
 aa
 aa
 ad
-ad
-ad
-ad
-ad
-ad
-ad
+VN
+VN
+VN
+VN
+zh
+VN
 bD
 bD
 bD
@@ -31519,14 +31347,14 @@ dV
 dV
 ws
 dV
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+zh
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-aa
 aa
 aa
 aa
@@ -31686,7 +31514,7 @@ aa
 aa
 ad
 ad
-ad
+VN
 au
 aH
 aH
@@ -31727,7 +31555,7 @@ aH
 aH
 xR
 oa
-ad
+VN
 ad
 aa
 aa
@@ -31929,8 +31757,8 @@ ad
 ah
 av
 aI
+VN
 ad
-aa
 aa
 aa
 aa

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -1275,7 +1275,7 @@
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_boxingcourt)
 "agp" = (
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/closet/warhammer/secure_closet/personal/patient,
 /turf/unsimulated/floor{
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
@@ -2258,7 +2258,7 @@
 	},
 /area/centcom/living)
 "atv" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/warhammer/secure_closet/personal,
 /turf/unsimulated/floor{
 	icon_state = "carpet"
 	},


### PR DESCRIPTION
Edited changeling transformation sting to 10 seconds while they are immobile. I think 15 seconds is too long for a player to wait.

Renamed bluespace drive to archeotech warp engine.

Removed access requirements on turret control panels. They can be set in map only now. This way anyone can build a control panel if they want to do turrets.

Added 40k trash and canned items, plus sound code and fixes for icon states.

Turned all secure closets into warhammer closets.

Fixed throne icons. Added some alt imperial thrones.

Added fountain water icon to puddles, so that it can be used for the 40k fountains.

Edited fusion core to be void fusion core.

Added calibrated and calibration penalty to weapons. This ensures that guns require you to calibrate them via the object tab in order to avoid jam_chance. This effect is incredibly minor and only matters for energy weapons which have higher penalties for not calibrating them.

Slight edits to the maps, fixing up the Decks and planning the design of the Dauntless.