### PR TITLE
RogueTrader - V1.0.12.3 - Misc/Mapping

### DIFF
--- a/code/datums/trading/ai.dm
+++ b/code/datums/trading/ai.dm
@@ -36,7 +36,7 @@ They sell generic supplies and ask for generic supplies.
 								/obj/item/modular_computer/pda                     = TRADER_BLACKLIST_SUB,
 								/obj/item/device/uplink                  = TRADER_BLACKLIST)
 	possible_trading_items = list(/obj/item/storage/bag                       = TRADER_SUBTYPES_ONLY,
-								/obj/item/storage/bag/cash/infinite           = TRADER_BLACKLIST,
+								/obj/item/storage/bag/cash/massivebundle           = TRADER_BLACKLIST,
 								/obj/item/storage/backpack                    = TRADER_ALL,
 								/obj/item/storage/backpack/cultpack           = TRADER_BLACKLIST,
 								/obj/item/storage/backpack/holding            = TRADER_BLACKLIST,

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -9,7 +9,7 @@
 	var/spawn_positions = 0               // How many players can spawn in as this job. Set to -1 for unlimited.
 	var/current_positions = 0             // How many players have this job
 	var/availablity_chance = 100          // Percentage chance job is available each round
-
+	var/datum/antag_skill_setter/skill_setter = /datum/antag_skill_setter/generic
 	var/supervisors = null                // Supervisors, who this person answers to directly
 	var/selection_color = "#515151"       // Selection screen color
 	var/list/alt_titles                   // List of alternate titles, if any and any potential alt. outfits as assoc values.
@@ -104,6 +104,8 @@
 	if(faction)
 		H.faction = faction
 		H.last_faction = faction
+	if(ispath(skill_setter))
+		skill_setter = new skill_setter
 
 /datum/job/proc/get_outfit(mob/living/carbon/human/H, alt_title, datum/mil_branch/branch, datum/mil_rank/grade)
 	if(alt_title && alt_titles)

--- a/code/game/machinery/suit_storage_units.dm
+++ b/code/game/machinery/suit_storage_units.dm
@@ -34,9 +34,10 @@
 	islocked = 0
 
 /obj/machinery/suit_storage_unit/engineering/alt
-	suit= /obj/item/clothing/suit/space/void/engineering/alt
-	helmet = /obj/item/clothing/head/helmet/space/void/engineering/alt
-	mask = /obj/item/clothing/mask/breath
+	name = "hazard suit storage"
+	suit = /obj/item/clothing/suit/armor/grim/storage/hooded/mechanicus/bondsman
+	helmet = null
+	mask = /obj/item/clothing/mask/gas/explorer
 
 /obj/machinery/suit_storage_unit/engineering/salvage
 	suit= /obj/item/clothing/suit/space/void/engineering/salvage

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -256,6 +256,20 @@
 	ruin_template = null
 	. = ..()
 
+/obj/random/randomchaos
+	name = "random chaos daemon"
+	desc = "Spawns a random chaos daemon."
+	icon = 'icons/map_project/fluff_items.dmi'
+	icon_state = "paper3"
+
+/obj/random/exploration/spawn_choices()
+	return list(/mob/living/simple_animal/hostile/daemon/headcrab/infestor = 1,
+				/mob/living/simple_animal/hostile/daemon/minion = 1,
+				/mob/living/simple_animal/hostile/daemon/hulk = 1,
+				/mob/living/simple_animal/hostile/daemon/large = 1)
+
+
+
 /obj/random/exploration
 	name = "random exploration loot"
 	desc = "Low grade loot that is often around 50-100 thrones worth."
@@ -503,6 +517,7 @@
 		/obj/landmark/rav/sawnshotgun = 2,
 		/obj/landmark/rav/imperialsniper = 5,
 		/obj/landmark/rav/cruciblesniper = 2,
+		/obj/item/gun/magnetic/railgun = 2,
 		/obj/landmark/rav/triangongsniper = 2,
 	)
 	var/list/picked_choice = pickweight(choices)
@@ -776,19 +791,22 @@
 	icon_state = "randomsupply"
 
 /obj/random/loot/randomcolonyitems/spawn_choices()
-	return list(/obj/item/device/eftpos = 2,
-				/obj/landmark/rav/colitems3 = 2,
-				/obj/item/device/binoculars = 2,
-				/obj/item/stack/material/steel/twenty = 4,
-				/obj/item/stack/material/glass/fifty = 3,
-				/obj/item/device/bot_kit = 1,
-				/obj/landmark/rav/colitems4 = 1,
+	return list(/obj/item/device/eftpos = 6,
+				/obj/landmark/rav/colitems3 = 4,
+				/obj/item/grenade/frag/homemade = 2,
+				/obj/item/grenade/frag/high_yield = 1,
+				/obj/item/grenade/frag/high_yield/krak = 1,
+				/obj/item/device/binoculars = 4,
+				/obj/item/stack/material/steel/twenty = 6,
+				/obj/item/stack/material/glass/fifty = 5,
+				/obj/item/device/bot_kit = 2,
+				/obj/landmark/rav/colitems4 = 3,
 				/obj/item/device/synthesized_instrument/guitar = 1,
 				/obj/item/device/synthesized_instrument/violin = 1,
 				/obj/item/device/synthesized_instrument/trumpet = 1,
 				/obj/item/clothing/accessory/armor_plate/bodyglove2 = 1,
-				/obj/landmark/rav/colitems2 = 1,
-				/obj/landmark/rav/colitems1 = 3)
+				/obj/landmark/rav/colitems2 = 3,
+				/obj/landmark/rav/colitems1 = 6)
 
 /obj/landmark/rav/colitems1/New()
 	new /obj/item/device/geiger(src.loc)
@@ -818,16 +836,18 @@
 	icon_state = "randomsupply" // Add explosives like grenades. also fix grenades.
 
 /obj/random/loot/randomsupply/engineering/spawn_choices()
-	return list(/obj/item/stack/material/steel/fifty = 3,
-				/obj/landmark/rav/engitems1 = 3,
-				/obj/landmark/rav/engitems2 = 1,
-				/obj/landmark/rav/engitems3 = 2,
-				/obj/landmark/rav/engitems4 = 2,
-				/obj/landmark/rav/engitems5 = 1,
-				/obj/landmark/rav/engitems6 = 1,
-				/obj/landmark/rav/engitems7 = 1,
-				/obj/landmark/rav/engitems8 = 1,
-				/obj/item/cell/alien = 1)
+	return list(/obj/item/stack/material/steel/fifty = 6,
+				/obj/landmark/rav/engitems1 = 6,
+				/obj/landmark/rav/engitems2 = 2,
+				/obj/landmark/rav/engitems3 = 4,
+				/obj/landmark/rav/engitems4 = 4,
+				/obj/landmark/rav/engitems5 = 2,
+				/obj/landmark/rav/engitems6 = 2,
+				/obj/landmark/rav/engitems7 = 2,
+				/obj/item/grenade/frag/high_yield/plasma = 1,
+				/obj/item/grenade/frag/high_yield/krak = 2,
+				/obj/landmark/rav/engitems8 = 2,
+				/obj/item/cell/alien = 2)
 
 /obj/landmark/rav/engitems1/New()
 	new /obj/item/stack/barbwire(src.loc)

--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -28,6 +28,25 @@
 	//The radius of the circle used to launch projectiles. Lower values mean less projectiles are used but if set too low gaps may appear in the spread pattern
 	var/spread_range = 7 //leave as is, for some reason setting this higher makes the spread pattern have gaps close to the epicenter
 
+/obj/item/grenade/frag/attack_self(mob/living/user)
+	if(!active)
+		if(clown_check(user))
+			to_chat(user, SPAN_WARNING("You prime \the [name]! [det_time/10] seconds!"))
+			activater(user)
+			add_fingerprint(user)
+			if(iscarbon(user))
+				var/mob/living/carbon/C = user
+				C.throw_mode_on()
+
+/obj/item/grenade/frag/proc/activater(mob/living/user)
+	if (active)
+		return
+	if (user)
+		msg_admin_attack("[user.name] ([user.ckey]) primed \a [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	active = TRUE
+	playsound(loc, arm_sound, 75, 0, -3)
+	addtimer(new Callback(src, .proc/detonate, user), det_time)
+
 /obj/item/grenade/frag/detonate(mob/living/user)
 	..()
 

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -10,8 +10,8 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT
 	var/active = 0
-	var/det_time = 50
-	var/fail_det_time = 5 // If you are clumsy and fail, you get this time.
+	var/det_time = 40
+	var/fail_det_time = 25 // If you are clumsy and fail, you get this time.
 	var/arm_sound = 'sound/weapons/armbomb.ogg'
 
 

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -107,13 +107,13 @@
 	icon_state = "hcell"
 
 /obj/random/powercell/spawn_choices()
-	return list(/obj/item/cell/crap = 1,
+	return list(/obj/item/cell/device/high/laspack = 3,
 				/obj/item/cell/standard = 8,
 				/obj/item/cell/high = 5,
 				/obj/item/cell/super = 2,
 				/obj/item/cell/hyper = 1,
 				/obj/item/cell/device/standard = 7,
-				/obj/item/cell/device/high = 5)
+				/obj/item/cell/device/high/laspack/hotshot = 1)
 
 /obj/random/bomb_supply
 	name = "bomb supply"
@@ -135,9 +135,9 @@
 	icon_state = "red"
 
 /obj/random/toolbox/spawn_choices()
-	return list(/obj/item/storage/toolbox/mechanical = 30,
-				/obj/item/storage/toolbox/electrical = 20,
-				/obj/item/storage/toolbox/emergency = 20,
+	return list(/obj/item/storage/toolbox/mechanical = 5,
+				/obj/item/storage/toolbox/electrical = 5,
+				/obj/item/storage/toolbox/emergency = 5,
 				/obj/item/storage/toolbox/syndicate = 1)
 
 /obj/random/tech_supply
@@ -170,11 +170,11 @@
 	icon_state = "pack0"
 
 /obj/random/medical/spawn_choices()
-	return list(/obj/random/medical/lite = 21,
-				/obj/item/bodybag = 2,
+	return list(/obj/random/medical/lite = 10,
+				/obj/item/bodybag = 4,
 				/obj/item/reagent_containers/glass/bottle/inaprovaline = 2,
 				/obj/item/reagent_containers/glass/bottle/antitoxin = 2,
-				/obj/item/storage/pill_bottle = 2,
+				/obj/item/storage/pill_bottle = 8,
 				/obj/item/storage/pill_bottle/tramadol = 1,
 				/obj/item/storage/pill_bottle/citalopram = 2,
 				/obj/item/storage/pill_bottle/dexalin_plus = 1,
@@ -195,6 +195,7 @@
 
 /obj/random/medical/lite/spawn_choices()
 	return list(/obj/item/stack/medical/bruise_pack = 4,
+				/obj/item/storage/pill_bottle = 12,
 				/obj/item/stack/medical/ointment = 4,
 				/obj/item/storage/pill_bottle/antidexafen = 2,
 				/obj/item/storage/pill_bottle/paracetamol = 2,

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -18,9 +18,9 @@
 	name = "emergency closet"
 	desc = "It's a storage unit for emergency breathmasks and o2 tanks."
 	icon = 'icons/map_project/furniture_and_decor.dmi'
-	icon_state = "metal_locker_closed"
-	icon_opened = "metal_locker_open"
-	icon_closed = "metal_locker_closed"
+	icon_state = "temergency"
+	icon_opened = "temergency_open"
+	icon_closed = "temergency"
 
 /obj/structure/closet/warhammer/emcloset/WillContain()
 	return list(/obj/item/tank/oxygen_emergency = 2,
@@ -28,7 +28,6 @@
 				/obj/item/storage/toolbox/emergency,
 				/obj/item/inflatable/wall = 1,
 				/obj/item/device/oxycandle,
-				/obj/item/storage/med_pouch/oxyloss = 1,
 				/obj/item/clothing/suit/space/emergency,
 				/obj/item/clothing/head/helmet/space/emergency
 	)
@@ -44,7 +43,6 @@
 
 /obj/structure/closet/firecloset/WillContain()
 	return list(
-		/obj/item/storage/med_pouch/burn,
 		/obj/item/storage/backpack/dufflebag/firefighter,
 		/obj/item/clothing/mask/gas,
 		/obj/item/device/flashlight
@@ -54,7 +52,6 @@
 
 /obj/structure/closet/firecloset/chief/WillContain()
 	return list(
-		/obj/item/storage/med_pouch/burn,
 		/obj/item/clothing/suit/fire/firefighter,
 		/obj/item/clothing/mask/gas,
 		/obj/item/device/flashlight,
@@ -73,8 +70,6 @@
 
 /obj/structure/closet/toolcloset/New()
 	..()
-	if(prob(40))
-		new /obj/item/clothing/suit/armor/grim/storage/hazardvest(src)
 	if(prob(70))
 		new /obj/item/device/flashlight(src)
 	if(prob(70))
@@ -184,7 +179,7 @@
 
 /obj/structure/closet/medical_wall/filled/WillContain()
 	return list(
-		/obj/random/medical/lite = 4)
+		/obj/random/medical/lite = 1)
 
 /obj/structure/closet/toolcloset/excavation/awaysite //no teleport beacons
 	name = "excavation equipment closet"

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -799,13 +799,13 @@
 	name = "grey ceramic flooring"
 	icon = 'icons/turf/flooring/plating.dmi'
 	icon_state = "surgery"
-	initial_flooring = /singleton/flooring/warhammer/ceramic/surgery
+	initial_flooring = /singleton/flooring/warhammer/surgerynew
 
 /turf/simulated/floor/warhammer/ceramic/surgery2
 	name = "grey ceramic flooring"
 	icon = 'icons/turf/flooring/decals.dmi'
 	icon_state = "surgery2"
-	initial_flooring = /singleton/flooring/warhammer/ceramic/surgery2
+	initial_flooring = /singleton/flooring/warhammer/surgerynew
 
 /turf/simulated/floor/warhammer/ceramic/old
 	name = "ceramic flooring"

--- a/code/modules/client/preference_setup/loadout/lists/xenowear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear.dm
@@ -80,7 +80,7 @@
 	allowed_roles = list(/datum/job/guard_captain, /datum/job/enforcer_sergeant, /datum/job/enforcer, /datum/job/guardsman)
 
 /datum/gear/accessory/skrell_badge
-	display_name = "Tau SDTF badge"
+	display_name = "Tau Empire badge"
 	path = /obj/item/clothing/accessory/badge/tags/skrell
 	whitelisted = list(SPECIES_TAU)
 	sort_category = "Xenowear"

--- a/code/modules/clothing/suits/grimarmor.dm
+++ b/code/modules/clothing/suits/grimarmor.dm
@@ -668,6 +668,7 @@
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE+100
 	slowdown_general = 0.055
+	action_button_name = "Toggle Hood"
 	hoodtype = /obj/item/clothing/head/hardhat/bondsman
 	armor = list(
 		melee = ARMOR_MELEE_FLAK,

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -231,7 +231,7 @@
 
 
 /obj/item/clothing/accessory/badge/tags/skrell/verb/set_sdtf()
-	set name = "Set SDTF Name"
+	set name = "Set Empire Name"
 	set category = "Object"
 	set src in usr
 	if (!ishuman(usr) || usr.stat)
@@ -244,7 +244,7 @@
 	if (usr.get_active_hand() != B)
 		to_chat(usr, SPAN_WARNING("You must be holding \the [src] to modify it."))
 		return
-	var/value = input(usr, "Input your SDTF.", "SDTF Holobadge") as null | text
+	var/value = input(usr, "Input your Empire.", "Empire Holobadge") as null | text
 	if (isnull(value))
 		return
 	if (usr.stat || usr.get_active_hand() != B)

--- a/code/modules/mob/skills/antag_skill_setter.dm
+++ b/code/modules/mob/skills/antag_skill_setter.dm
@@ -17,7 +17,7 @@
 //This is the generic antag skill setter, used for most antag types.
 /datum/antag_skill_setter/generic
 	nm_type = /datum/nano_module/skill_ui/antag
-	default_value = SKILL_BASIC
+	default_value = SKILL_UNSKILLED
 
 /datum/antag_skill_setter/generic/initialize_skills(datum/skillset/skillset)
 	..()

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -73,7 +73,7 @@
 	icon_state = "skrell_carbine"
 	item_state = "skrell_carbine"
 	slot_flags = SLOT_BACK|SLOT_BELT
-	desc = "The Vuu'Xqu*ix T-3, known as 'VT-3' by SolGov. Rarely seen out in the wild by anyone outside of a Tau SDTF."
+	desc = "The Vuu'Xqu*ix T-3, known as 'VT-3' by SolGov. Rarely seen out in the wild by anyone outside of a Tau Empire."
 	cell_type = /obj/item/cell/high
 	self_recharge = 1
 	move_delay = 2

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -18,11 +18,16 @@
 	var/list/grenades = list()
 	var/max_grenades = 5 //holds this + one in the chamber
 	var/whitelisted_grenades = list(
-		/obj/item/grenade/frag/shell)
+		/obj/item/grenade/frag/shell,
+		/obj/item/grenade/frag,
+		/obj/item/grenade/frag/high_yield,
+		/obj/item/grenade/frag/homemade)
 
 	var/blacklisted_grenades = list(
 		/obj/item/grenade/flashbang/clusterbang,
-		/obj/item/grenade/frag)
+		/obj/item/grenade/frag/high_yield/krak,
+		/obj/item/grenade/frag/high_yield/krak2,
+		/obj/item/grenade/frag/high_yield/plasma)
 
 	matter = list(MATERIAL_STEEL = 2000)
 

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -13,6 +13,7 @@
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK
 	loaded = /obj/item/rcd_ammo/large // ~30 shots
+	removable_components = TRUE
 	combustion = 1
 	bulk = GUN_BULK_RIFLE
 
@@ -107,9 +108,8 @@
 	desc = "The Vostroyan Arms LMRA-14A Meteor. Originally a vehicle-mounted turret weapon used by the Tau in the Ultramar Conflict for anti-vehicular operations, the fact that it was made man-portable is mindboggling in itself."
 	icon = 'icons/obj/guns/railgun_heavy.dmi'
 	icon_state = "heavy_railgun"
-	removable_components = FALSE // Absolutely not. This has an infinity cell.
 
-	cell = /obj/item/cell/infinite
+	cell = /obj/item/cell/hyper
 	capacitor = /obj/item/stock_parts/capacitor/super
 
 	fire_delay =  5
@@ -163,7 +163,7 @@
 
 /obj/item/gun/magnetic/railgun/flechette/skrell
 	name = "Tau rifle"
-	desc = "The Zquiv*Tzuuli-8, or ZT-8, is a railgun rarely seen by anyone other than those within Tau SDTF ranks. The rotary magazine houses a cylinder with individual chambers, that press against the barrel when loaded."
+	desc = "The Zquiv*Tzuuli-8, or ZT-8, is a railgun rarely seen by anyone other than those within Tau Empire ranks. The rotary magazine houses a cylinder with individual chambers, that press against the barrel when loaded."
 	icon = 'icons/obj/guns/skrell_rifle.dmi'
 	icon_state = "skrell_rifle"
 	item_state = "skrell_rifle"

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -10,7 +10,7 @@
 	throw_range = 3
 	force = 15
 	var/list/potentials = list(
-		SPECIES_HUMAN = /obj/item/storage/bag/cash/infinite,
+		SPECIES_HUMAN = /obj/item/storage/bag/cash/massivebundle,
 		SPECIES_VOX = /spell/targeted/shapeshift/true_form,
 		SPECIES_KROOT = /spell/moghes_blessing,
 		SPECIES_DIONA = /spell/aoe_turf/conjure/grove/gestalt,
@@ -38,16 +38,8 @@
 	to_chat(user, "\The [src] crumbles in your hands.")
 	qdel(src)
 
-/obj/item/storage/bag/cash/infinite
-	startswith = list(/obj/item/spacecash/bundle/c100 = 1)
-
-//HUMAN
-/obj/item/storage/bag/cash/infinite/remove_from_storage(obj/item/W as obj, atom/new_location)
-	. = ..()
-	if(.)
-		if(istype(W,/obj/item/spacecash)) //only matters if its spacecash.
-			var/obj/item/I = new /obj/item/spacecash/bundle/c100()
-			src.handle_item_insertion(I,1)
+/obj/item/storage/bag/cash/massivebundle
+	startswith = list(/obj/item/spacecash/bundle/c100 = 20)
 
 /spell/messa_shroud/choose_targets()
 	return list(get_turf(holder))

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -6,3 +6,49 @@
 ######################################################################
 
 TheBananaBunch - DevAdmin
+Alanii - Host
+WoodenTucker - Host
+
+Somenerd - RetiredAdmin
+Rushodan - RetiredAdmin
+okithedoki - RetiredAdmin
+blankcat - RetiredAdmin
+Alexeivichi - RetiredAdmin
+budgetcommander - RetiredAdmin
+
+thebananabunch - HeadDeveloper
+Hans Nacht - Developer
+Daelso - Developer
+Scott45 - Developer
+
+Koshi Kaiser - Mentor
+Lord inquisitor plasmaman - Mentor
+
+#Fauxvail - Mentor
+
+Atomic Galaxy - Mentor
+
+Antifort - Mentor
+
+Invyicta - Mentor
+
+EclipseNutellabrot - Mentor
+
+Mwhite11 - GameAdmin
+
+Magisterium - GameAdmin
+
+Oprime - HeadAdmin
+
+
+Schwimmbadpommes - Moderator
+
+Mamuliano - Moderator
+
+Yacobpo157 - Moderator
+
+Blackwombat - Moderator
+
+Gruesomeborg68915 - Moderator
+Mishuliny - Moderator
+PlagueOfTime - Moderator

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -10,24 +10,15 @@
 /area/map_template/rescue_base/base)
 "ae" = (
 /obj/machinery/computer/teleporter,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "af" = (
 /obj/machinery/tele_projector,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ag" = (
 /obj/machinery/tele_pad,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ah" = (
 /turf/unsimulated/wall{
@@ -40,73 +31,48 @@
 "ai" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/clothing/shoes/magboots/rig/combat,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aj" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/regular,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ak" = (
 /obj/machinery/floodlight,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "al" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/bodybags,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "am" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/surgery,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "an" = (
 /turf/simulated/floor/wood/mahogany,
-/area/map_template/rescue_base/base)
-"ao" = (
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
 /area/map_template/rescue_base/base)
 "ap" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Emergency Insertion"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aq" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/taperecorder,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ar" = (
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "as" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/bikehorn/rubberducky,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "at" = (
 /turf/simulated/floor/wood/maple,
@@ -115,55 +81,38 @@
 /obj/structure/hygiene/toilet{
 	pixel_y = 16
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "av" = (
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aw" = (
 /obj/item/soap,
 /obj/structure/hygiene/shower{
 	pixel_y = 32
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ax" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/assembly/mousetrap,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ay" = (
 /obj/structure/bed/chair,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "az" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/material/twohanded/baseballbat/metal,
 /obj/item/material/hatchet,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aA" = (
 /turf/simulated/floor/wood/walnut,
-/area/map_template/rescue_base/base)
-"aB" = (
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
 /area/map_template/rescue_base/base)
 "aC" = (
 /obj/item/aiModule/reset,
@@ -173,67 +122,62 @@
 /obj/item/aiModule/paladin,
 /obj/item/aiModule/robocop,
 /obj/item/aiModule/safeguard,
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/aiModule/solgov,
 /obj/item/aiModule/solgov_aggressive,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aD" = (
-/obj/structure/table/rack,
-/obj/item/plastique,
-/obj/item/plastique,
-/obj/item/plastique,
-/obj/item/plastique,
-/obj/item/plastique,
-/obj/item/plastique,
-/obj/item/plastique,
-/obj/item/plastique,
-/obj/item/plastique,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/plastique,
+/obj/item/plastique,
+/obj/item/plastique,
+/obj/item/plastique,
+/obj/item/plastique,
+/obj/item/plastique,
+/obj/item/plastique,
+/obj/item/plastique,
+/obj/item/plastique,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aE" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/gun/projectile/shotgun/pump/voxlegis,
 /obj/item/gun/projectile/shotgun/pump/voxlegis,
 /obj/item/device/radio/intercom/specops{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aF" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/ammo/stunshells,
-/obj/item/storage/box/ammo/stunshells,
-/obj/item/storage/box/ammo/beanbags,
-/obj/item/storage/box/ammo/beanbags,
-/obj/item/storage/box/ammo/shotgunammo,
-/obj/item/storage/box/ammo/shotgunammo,
-/obj/item/storage/box/ammo/shotgunshells,
-/obj/item/storage/box/ammo/shotgunshells,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/storage/box/ammo/stunshells,
+/obj/item/storage/box/ammo/stunshells,
+/obj/item/storage/box/ammo/beanbags,
+/obj/item/storage/box/ammo/beanbags,
+/obj/item/storage/box/ammo/shotgunammo,
+/obj/item/storage/box/ammo/shotgunammo,
+/obj/item/storage/box/ammo/shotgunshells,
+/obj/item/storage/box/ammo/shotgunshells,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aG" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/tau/pulserifle,
-/obj/item/gun/energy/tau/pulserifle,
-/obj/item/gun/energy/tau/pulserifle,
-/obj/item/gun/energy/tau/pulserifle,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/gun/energy/tau/pulserifle,
+/obj/item/gun/energy/tau/pulserifle,
+/obj/item/gun/energy/tau/pulserifle,
+/obj/item/gun/energy/tau/pulserifle,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aH" = (
 /obj/structure/table/steel_reinforced,
@@ -249,17 +193,13 @@
 	pixel_x = 3;
 	pixel_y = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aI" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/belt/utility/full,
 /obj/item/device/assembly/igniter,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aJ" = (
 /turf/simulated/floor/wood/ebony,
@@ -271,9 +211,7 @@
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = 21
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aL" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -281,53 +219,45 @@
 /obj/item/device/radio/intercom/specops{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aM" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/machinery/chemical_dispenser/bar_soft/full,
 /obj/floor_decal/corner/blue/diagonal,
 /obj/item/device/radio/intercom/specops{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aN" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/machinery/chemical_dispenser/bar_alc/full,
 /obj/floor_decal/corner/blue/diagonal,
 /obj/machinery/vending/boozeomat{
 	pixel_y = 32
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aO" = (
 /obj/structure/closet/fridge,
 /obj/floor_decal/corner/blue/diagonal,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aP" = (
 /obj/floor_decal/corner/blue/diagonal,
 /obj/structure/closet/fridge/meat,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aQ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Stall"
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aR" = (
 /obj/item/storage/mirror,
@@ -337,178 +267,150 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Showers"
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aT" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/box/machinegun,
-/obj/item/ammo_magazine/box/machinegun,
-/obj/item/ammo_magazine/box/machinegun,
-/obj/item/ammo_magazine/box/machinegun,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/ammo_magazine/box/machinegun,
+/obj/item/ammo_magazine/box/machinegun,
+/obj/item/ammo_magazine/box/machinegun,
+/obj/item/ammo_magazine/box/machinegun,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aU" = (
 /obj/item/device/radio/intercom/specops{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aV" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/stock_parts/circuitboard/borgupload,
 /obj/item/stock_parts/circuitboard/aiupload{
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aW" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/autogun/valhalla,
-/obj/item/gun/projectile/automatic/autogun/valhalla,
-/obj/item/gun/projectile/automatic/autogun/valhalla,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/gun/projectile/automatic/autogun/valhalla,
+/obj/item/gun/projectile/automatic/autogun/valhalla,
+/obj/item/gun/projectile/automatic/autogun/valhalla,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aX" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Processing"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "aY" = (
 /turf/simulated/floor/wood/bamboo,
 /area/map_template/rescue_base/base)
 "aZ" = (
 /obj/floor_decal/corner/blue/diagonal,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ba" = (
 /obj/floor_decal/corner/blue/diagonal,
 /obj/machinery/door/airlock/centcom{
 	name = "Storage"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Head"
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bc" = (
 /obj/structure/hygiene/sink{
 	dir = 1;
 	pixel_y = 16
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bd" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/slugrifle,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/gun/projectile/automatic/slugrifle,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "be" = (
-/obj/structure/table/rack,
-/obj/item/clothing/head/helmet/ablative,
-/obj/item/clothing/head/helmet/ablative,
-/obj/item/clothing/head/helmet/ablative,
-/obj/item/clothing/head/helmet/ablative,
-/obj/item/clothing/head/helmet/ablative,
-/obj/item/clothing/head/helmet/ablative,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/clothing/suit/armor/laserproof,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bf" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
-/obj/item/ammo_magazine/smg_top/rubber,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/ammo_magazine/smg_top/rubber,
+/obj/item/ammo_magazine/smg_top/rubber,
+/obj/item/ammo_magazine/smg_top/rubber,
+/obj/item/ammo_magazine/smg_top/rubber,
+/obj/item/ammo_magazine/smg_top/rubber,
+/obj/item/ammo_magazine/smg_top/rubber,
+/obj/item/ammo_magazine/smg_top/rubber,
+/obj/item/ammo_magazine/smg_top/rubber,
+/obj/item/ammo_magazine/smg_top/rubber,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bg" = (
 /obj/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bh" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/handcuffs,
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/storage/box/handcuffs,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bi" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
 /obj/item/device/radio/intercom/specops{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bj" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bk" = (
 /obj/structure/hygiene/toilet{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bl" = (
 /turf/simulated/floor/wood/yew,
@@ -516,86 +418,68 @@
 "bm" = (
 /obj/machinery/vending/dinnerware,
 /obj/floor_decal/corner/blue/diagonal,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bo" = (
-/obj/structure/table/rack,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bp" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/smg_top,
-/obj/item/ammo_magazine/smg_top,
-/obj/item/ammo_magazine/smg_top,
-/obj/item/ammo_magazine/smg_top,
-/obj/item/ammo_magazine/smg_top,
-/obj/item/ammo_magazine/smg_top,
-/obj/item/ammo_magazine/smg_top,
-/obj/item/ammo_magazine/smg_top,
-/obj/item/ammo_magazine/smg_top,
-/obj/item/ammo_magazine/smg_top,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
-/area/map_template/rescue_base/base)
-"bq" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/obj/item/ammo_magazine/smg_top,
+/obj/item/ammo_magazine/smg_top,
+/obj/item/ammo_magazine/smg_top,
+/obj/item/ammo_magazine/smg_top,
+/obj/item/ammo_magazine/smg_top,
+/obj/item/ammo_magazine/smg_top,
+/obj/item/ammo_magazine/smg_top,
+/obj/item/ammo_magazine/smg_top,
+/obj/item/ammo_magazine/smg_top,
+/obj/item/ammo_magazine/smg_top,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "br" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/item/device/flash,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/map_template/rescue_base/base)
-"bs" = (
-/turf/unsimulated/floor{
-	dir = 9;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bt" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Cell 2"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bu" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/device/lightreplacer,
 /obj/item/device/lightreplacer,
 /obj/floor_decal/corner/blue/diagonal,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bv" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/clothing/shoes/galoshes,
 /obj/item/clothing/head/bio_hood/janitor,
 /obj/item/clothing/suit/armor/grim/bio_suit/janitor,
@@ -612,20 +496,20 @@
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/floor_decal/corner/blue/diagonal,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bw" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/floor_decal/corner/blue/diagonal,
 /obj/machinery/microwave,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bx" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/floor_decal/corner/blue/diagonal,
 /obj/item/reagent_containers/food/condiment/small/saltshaker{
 	pixel_x = -3
@@ -633,51 +517,30 @@
 /obj/item/reagent_containers/food/condiment/small/peppermill{
 	pixel_x = 3
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "by" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/floor_decal/corner/blue/diagonal,
 /obj/random/donkpocket_box,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bz" = (
 /obj/floor_decal/corner/blue/diagonal,
 /obj/item/storage/box/donkpocket_premium,
 /obj/structure/closet/kitchen,
 /obj/item/reagent_containers/food/condiment/enzyme,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/map_template/rescue_base/base)
-"bA" = (
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
-/area/map_template/rescue_base/base)
-"bB" = (
-/turf/unsimulated/floor{
-	icon_state = "asteroidplating"
-	},
-/area/map_template/rescue_base/base)
-"bC" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/unsimulated/floor{
-	icon_state = "asteroidplating"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bD" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/autogun/krieg,
-/obj/item/gun/projectile/automatic/autogun/krieg,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/gun/projectile/automatic/autogun/krieg,
+/obj/item/gun/projectile/automatic/autogun/krieg,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bE" = (
 /obj/machinery/door/airlock/centcom{
@@ -687,88 +550,73 @@
 	id_tag = "heavyrescue";
 	name = "Restricted Equipment"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bF" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/storage/box/smokes,
 /obj/item/storage/box/smokes,
 /obj/item/storage/box/flashbangs,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bG" = (
-/obj/structure/table/reinforced,
-/obj/item/device/camera,
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/device/camera,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bH" = (
 /obj/item/stool,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bI" = (
 /obj/structure/table/standard,
 /obj/item/paper,
 /obj/item/pen,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Galley"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bK" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bL" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/mil_rifle/heavy,
-/obj/item/ammo_magazine/mil_rifle/heavy,
-/obj/item/ammo_magazine/mil_rifle/heavy,
-/obj/item/ammo_magazine/mil_rifle/heavy,
-/obj/item/ammo_magazine/mil_rifle/heavy,
-/obj/item/ammo_magazine/mil_rifle/heavy,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/ammo_magazine/mil_rifle/heavy,
+/obj/item/ammo_magazine/mil_rifle/heavy,
+/obj/item/ammo_magazine/mil_rifle/heavy,
+/obj/item/ammo_magazine/mil_rifle/heavy,
+/obj/item/ammo_magazine/mil_rifle/heavy,
+/obj/item/ammo_magazine/mil_rifle/heavy,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bM" = (
-/obj/structure/table/rack,
-/obj/item/gun/launcher/grenade,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/gun/launcher/grenade,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bN" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/emps,
 /obj/item/storage/box/emps,
 /obj/item/storage/box/frags,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bO" = (
 /obj/structure/closet{
@@ -777,18 +625,12 @@
 /obj/item/clothing/accessory/solgov/fleet_patch/fifth,
 /obj/item/clothing/head/solgov/utility/fleet,
 /obj/item/clothing/accessory/badge/solgov/tags,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bP" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/captain,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bQ" = (
 /obj/structure/bed/padded,
@@ -796,19 +638,13 @@
 /obj/item/device/radio/intercom/specops{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bR" = (
 /obj/machinery/vending/coffee{
 	prices = list()
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bS" = (
 /obj/machinery/door/airlock/centcom{
@@ -818,57 +654,39 @@
 	id_tag = "standardrescue";
 	name = "Heavy Equipment"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Detention"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bU" = (
 /obj/machinery/acting/changer,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bV" = (
 /obj/landmark{
 	name = "Response Team"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bW" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Squad Bay"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bX" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Cell 1"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bY" = (
 /obj/structure/undies_wardrobe,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "bZ" = (
 /obj/item/clothing/shoes/orange,
@@ -876,31 +694,27 @@
 /obj/structure/closet{
 	name = "Prisoner's Locker"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ca" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Ready Room"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cc" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/storage/box/handcuffs,
 /obj/item/storage/box/handcuffs,
 /obj/item/storage/box/teargas,
@@ -921,94 +735,122 @@
 	},
 /obj/item/taperoll/enforcer,
 /obj/item/taperoll/enforcer,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cd" = (
-/obj/structure/table/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/tacgoggles,
-/obj/item/clothing/glasses/tacgoggles,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/tacgoggles,
+/obj/item/clothing/glasses/tacgoggles,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ce" = (
-/obj/structure/table/rack,
-/obj/item/storage/backpack/tau/security,
-/obj/item/storage/backpack/tau/security,
-/obj/item/storage/belt/holster/security/tactical,
-/obj/item/storage/belt/holster/security/tactical,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/suit/armor/grim/agent,
+/obj/item/clothing/suit/armor/grim/agent,
+/obj/item/clothing/suit/armor/grim/agent,
+/obj/item/clothing/head/helmet/inquisition,
+/obj/item/clothing/head/helmet/inquisition,
+/obj/item/clothing/head/helmet/inquisition/acolyte,
+/obj/item/clothing/head/helmet/inquisition/acolyte,
+/obj/item/clothing/head/helmet/inquisition/stealth,
+/obj/item/clothing/head/helmet/inquisition/stealth,
+/obj/item/clothing/shoes/jackboots/inquisitor/acolyte,
+/obj/item/clothing/shoes/jackboots/inquisitor/acolyte,
+/obj/item/clothing/shoes/jackboots/inquisitor/acolyte,
+/obj/item/clothing/shoes/jackboots/inquisitor/acolyte,
+/obj/item/clothing/under/inquisitor,
+/obj/item/clothing/under/inquisitor,
+/obj/item/clothing/under/inquisitor,
+/obj/item/clothing/under/inquisitor,
+/obj/item/clothing/under/inquisitor,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cf" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/tau/pulserifle,
-/obj/item/gun/energy/tau/pulserifle,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/random/loot/raregunslug,
+/obj/random/loot/raregunslug,
+/obj/random/loot/raregunslug,
+/obj/random/loot/raregunslug,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cg" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
 	pixel_y = 32
 	},
-/obj/item/clothing/suit/armor/grim/medium,
-/obj/item/clothing/suit/armor/grim/medium,
-/obj/item/clothing/head/helmet,
-/obj/item/clothing/head/helmet,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/obj/item/clothing/shoes/scion,
+/obj/item/clothing/shoes/scion,
+/obj/item/clothing/shoes/scion,
+/obj/item/clothing/shoes/scion,
+/obj/item/clothing/suit/armor/stormtrooper/scion,
+/obj/item/clothing/suit/armor/stormtrooper/scion,
+/obj/item/clothing/suit/armor/stormtrooper/scion,
+/obj/item/clothing/suit/armor/stormtrooper/scion,
+/obj/item/clothing/gloves/thick/swat/cadian/scion,
+/obj/item/clothing/gloves/thick/swat/cadian/scion,
+/obj/item/clothing/gloves/thick/swat/cadian/scion,
+/obj/item/clothing/gloves/thick/swat/cadian/scion,
+/obj/item/clothing/under/guard/uniform/scion,
+/obj/item/clothing/under/guard/uniform/scion,
+/obj/item/clothing/under/guard/uniform/scion,
+/obj/item/clothing/under/guard/uniform/scion,
+/obj/item/clothing/glasses/scion,
+/obj/item/clothing/glasses/scion,
+/obj/item/clothing/glasses/scion,
+/obj/item/clothing/glasses/scion,
+/obj/item/clothing/head/helmet/flak/tempestus,
+/obj/item/clothing/head/helmet/flak/tempestus,
+/obj/item/clothing/head/helmet/flak/tempestus,
+/obj/item/clothing/head/helmet/flak/tempestus,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ch" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/grim/medium,
-/obj/item/clothing/suit/armor/grim/medium,
-/obj/item/clothing/head/helmet,
-/obj/item/clothing/head/helmet,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/suit/armor/grim/cult/bloodpact,
+/obj/item/clothing/suit/armor/grim/cult/bloodpact,
+/obj/item/clothing/suit/armor/grim/cult/bloodpact,
+/obj/item/clothing/suit/armor/grim/cult/bloodpact,
+/obj/item/clothing/mask/gas/security/bloodpact,
+/obj/item/clothing/mask/gas/security/bloodpact,
+/obj/item/clothing/mask/gas/security/bloodpact,
+/obj/item/clothing/mask/gas/security/bloodpact,
+/obj/item/clothing/head/helmet/flak/chaos/bloodpact,
+/obj/item/clothing/head/helmet/flak/chaos/bloodpact,
+/obj/item/clothing/head/helmet/flak/chaos/bloodpact,
+/obj/item/clothing/head/helmet/flak/chaos/bloodpact,
+/obj/item/clothing/under/cadian_uniform,
+/obj/item/clothing/under/cadian_uniform,
+/obj/item/clothing/under/cadian_uniform,
+/obj/item/clothing/under/cadian_uniform,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ci" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/gun/energy/lasgun/laspistol/militarum,
 /obj/item/gun/energy/lasgun/laspistol/militarum,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
-/area/map_template/rescue_base/base)
-"cj" = (
-/obj/structure/table/rack,
-/obj/item/storage/backpack/tau/medical,
-/obj/item/storage/backpack/tau/medical,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical/emt,
-/obj/item/storage/belt/medical/emt,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ck" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/glasses/hud/health,
@@ -1016,40 +858,38 @@
 /obj/item/storage/box/latexgloves,
 /obj/item/storage/box/nitrilegloves,
 /obj/item/storage/box/masks,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cl" = (
-/obj/structure/table/rack,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/autoinjectors,
-/obj/item/storage/box/autoinjectors,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/syringegun,
-/obj/item/storage/box/syringegun,
-/obj/item/storage/box/syringegun,
-/obj/item/storage/box/syringegun,
-/obj/item/gun/launcher/syringe/rapid,
-/obj/item/gun/launcher/syringe/rapid,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/autoinjectors,
+/obj/item/storage/box/autoinjectors,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/syringegun,
+/obj/item/storage/box/syringegun,
+/obj/item/storage/box/syringegun,
+/obj/item/storage/box/syringegun,
+/obj/item/gun/launcher/syringe/rapid,
+/obj/item/gun/launcher/syringe/rapid,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cm" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/item/reagent_containers/hypospray,
 /obj/item/reagent_containers/hypospray,
 /obj/item/reagent_containers/hypospray,
@@ -1060,13 +900,12 @@
 /obj/item/reagent_containers/glass/bottle/inaprovaline,
 /obj/item/reagent_containers/glass/bottle/inaprovaline,
 /obj/item/reagent_containers/glass/bottle/inaprovaline,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cn" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/rig/ert/medical,
 /obj/structure/window/reinforced/crescent{
 	dir = 1
@@ -1074,24 +913,22 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "co" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/rig/ert/medical,
 /obj/structure/window/reinforced/crescent{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cp" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/rig_module/mounted/energy/taser,
 /obj/item/rig_module/mounted/energy/taser,
 /obj/item/rig_module/maneuvering_jets,
@@ -1108,13 +945,12 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cq" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/cell/high,
 /obj/item/cell/high,
 /obj/item/cell/high,
@@ -1124,20 +960,18 @@
 /obj/item/device/radio/intercom/specops{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cr" = (
-/obj/structure/table/rack,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cs" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/rig_module/mounted/energy/taser,
 /obj/item/rig_module/mounted/energy/taser,
 /obj/item/rig_module/maneuvering_jets,
@@ -1157,24 +991,22 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ct" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/rig/ert/security,
 /obj/structure/window/reinforced/crescent{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cu" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/rig/ert/security,
 /obj/structure/window/reinforced/crescent{
 	dir = 1
@@ -1182,19 +1014,16 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cv" = (
 /obj/machinery/hologram/holopad/longrange,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cw" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/stack/material/glass{
 	amount = 50
 	},
@@ -1227,29 +1056,22 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cx" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/lasgun/accatran,
-/obj/item/gun/energy/lasgun/accatran,
-/obj/item/gun/energy/lasgun/accatran,
-/obj/item/gun/energy/lasgun/accatran,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/gun/energy/lasgun/hotshot/masterwork,
+/obj/item/gun/energy/lasgun/hotshot/volkite,
+/obj/item/gun/energy/lasgun/hotshot/volkite,
+/obj/item/gun/energy/lasgun/hotshot/masterwork,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cy" = (
 /obj/machinery/chemical_dispenser/ert,
 /obj/item/reagent_containers/glass/beaker/large,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cz" = (
 /obj/structure/window/reinforced/crescent{
@@ -1258,71 +1080,67 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 1
 	},
-/obj/structure/table/rack,
-/obj/item/rig/ert/janitor,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/rig/ert/janitor,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cA" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cB" = (
-/obj/structure/table/reinforced,
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cC" = (
-/obj/structure/table/reinforced,
-/obj/item/tableflag,
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/tableflag,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cD" = (
 /obj/machinery/fabricator/hacked,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cE" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/plasma,
-/obj/item/gun/energy/plasma,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/random/loot/raregunsenergy,
+/obj/random/loot/raregunsenergy,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cF" = (
-/obj/structure/table/rack,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cG" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/item/reagent_containers/ivbag/nanoblood,
 /obj/item/reagent_containers/ivbag/nanoblood,
 /obj/item/reagent_containers/ivbag/blood/human/oneg,
@@ -1341,23 +1159,19 @@
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
 /obj/item/defibrillator/compact/loaded,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cH" = (
-/obj/structure/table/reinforced,
-/obj/item/roller_bed,
-/obj/item/roller_bed,
-/obj/item/roller_bed,
-/obj/item/roller_bed,
-/obj/item/roller_bed,
-/obj/item/roller_bed,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/roller_bed,
+/obj/item/roller_bed,
+/obj/item/roller_bed,
+/obj/item/roller_bed,
+/obj/item/roller_bed,
+/obj/item/roller_bed,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cI" = (
 /obj/structure/closet{
@@ -1371,82 +1185,70 @@
 /obj/item/clothing/head/beret/solgov/fleet/medical,
 /obj/item/clothing/head/beret/solgov/fleet/medical,
 /obj/item/clothing/head/beret/solgov/fleet/medical,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cJ" = (
 /obj/machinery/chem_master,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cK" = (
 /obj/structure/window/reinforced/crescent{
 	dir = 4
 	},
 /obj/structure/window/reinforced/crescent,
-/obj/structure/table/rack,
-/obj/item/rig/ert/janitor,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/rig/ert/janitor,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cL" = (
-/obj/structure/table/reinforced,
-/obj/item/device/paicard,
-/obj/item/device/paicard,
-/obj/item/device/paicard,
-/obj/item/device/paicard,
-/obj/item/device/paicard,
-/obj/item/device/paicard,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/device/paicard,
+/obj/item/device/paicard,
+/obj/item/device/paicard,
+/obj/item/device/paicard,
+/obj/item/device/paicard,
+/obj/item/device/paicard,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cM" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/lasgun/laspistol/militarum,
-/obj/item/gun/energy/lasgun/laspistol/militarum,
-/obj/item/gun/energy/lasgun/laspistol/militarum,
-/obj/item/gun/energy/lasgun/laspistol/militarum,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/gun/energy/lasgun/laspistol/militarum,
+/obj/item/gun/energy/lasgun/laspistol/militarum,
+/obj/item/gun/energy/lasgun/laspistol/militarum,
+/obj/item/gun/energy/lasgun/laspistol/militarum,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cN" = (
-/obj/structure/table/rack,
-/obj/item/shield/riot/metal,
-/obj/item/shield/riot/metal,
-/obj/item/shield/riot/metal,
-/obj/item/shield/riot/metal,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/shield/riot/metal,
+/obj/item/shield/riot/metal,
+/obj/item/shield/riot/metal,
+/obj/item/shield/riot/metal,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cO" = (
 /obj/machinery/reagentgrinder,
 /obj/item/reagent_containers/glass/beaker/large,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cP" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cQ" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/item/device/megaphone,
 /obj/item/device/megaphone,
 /obj/item/device/megaphone,
@@ -1456,10 +1258,7 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cR" = (
 /obj/structure/closet{
@@ -1473,20 +1272,16 @@
 /obj/item/clothing/head/beret/solgov/fleet/security,
 /obj/item/clothing/head/beret/solgov/fleet/security,
 /obj/item/clothing/head/beret/solgov/fleet/security,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cS" = (
 /obj/structure/iv_stand,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cT" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/sterilizine,
@@ -1496,82 +1291,73 @@
 /obj/item/tape/medical,
 /obj/item/device/flashlight/pen,
 /obj/item/device/flashlight/pen,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cU" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/radiation,
-/obj/item/storage/firstaid/radiation,
-/obj/item/storage/firstaid/radiation,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/radiation,
+/obj/item/storage/firstaid/radiation,
+/obj/item/storage/firstaid/radiation,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cV" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cW" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cX" = (
 /obj/structure/window/reinforced/crescent,
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/rig/ert,
 /obj/structure/window/reinforced/crescent{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cY" = (
 /obj/structure/window/reinforced/crescent,
-/obj/structure/table/rack,
-/obj/item/rig_module/mounted/taser,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/rig_module/vision/nvg,
 /obj/item/rig_module/device/flash,
 /obj/structure/window/reinforced/crescent{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "cZ" = (
 /obj/structure/window/reinforced/crescent,
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/rig_module/mounted/energy/taser,
 /obj/item/rig_module/mounted/energy/taser,
 /obj/item/rig_module/maneuvering_jets,
@@ -1587,31 +1373,26 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "da" = (
 /obj/structure/window/reinforced/crescent,
-/obj/structure/table/rack,
-/obj/item/rig/ert/engineer,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/rig/ert/engineer,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "db" = (
 /obj/structure/window/reinforced/crescent,
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/rig/ert/engineer,
 /obj/structure/window/reinforced/crescent{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dc" = (
 /turf/unsimulated/wall{
@@ -1619,19 +1400,6 @@
 	icon = 'icons/obj/doors/centcomm/door.dmi';
 	icon_state = "door_closed";
 	name = "Foxtrot Barracks"
-	},
-/area/map_template/rescue_base/base)
-"dd" = (
-/obj/structure/flora/ausbushes/palebush,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
-/area/map_template/rescue_base/base)
-"de" = (
-/obj/structure/table/reinforced,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
 	},
 /area/map_template/rescue_base/base)
 "df" = (
@@ -1642,19 +1410,13 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Security"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dh" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Medical"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "di" = (
 /obj/machinery/vending/medical,
@@ -1672,38 +1434,26 @@
 	id_tag = "standardrescue";
 	name = "EVA"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dl" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Unit Area"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dm" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
 	pixel_y = 32
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dn" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Echo Barracks"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "do" = (
 /turf/unsimulated/wall{
@@ -1716,91 +1466,78 @@
 /area/map_template/rescue_base/base)
 "dp" = (
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dq" = (
-/obj/structure/table/reinforced,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dr" = (
 /obj/machinery/recharge_station,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ds" = (
-/obj/structure/table/rack,
-/obj/item/clothing/accessory/storage/white_vest,
-/obj/item/clothing/accessory/storage/white_vest,
-/obj/item/clothing/accessory/storage/white_vest,
-/obj/item/clothing/accessory/storage/white_vest,
-/obj/item/clothing/accessory/storage/white_vest,
-/obj/item/clothing/accessory/storage/white_vest,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/accessory/storage/white_vest,
+/obj/item/clothing/accessory/storage/white_vest,
+/obj/item/clothing/accessory/storage/white_vest,
+/obj/item/clothing/accessory/storage/white_vest,
+/obj/item/clothing/accessory/storage/white_vest,
+/obj/item/clothing/accessory/storage/white_vest,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dt" = (
-/obj/structure/table/rack,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "du" = (
-/obj/structure/table/rack,
-/obj/item/clothing/accessory/storage/brown_vest,
-/obj/item/clothing/accessory/storage/brown_vest,
-/obj/item/clothing/accessory/storage/brown_vest,
-/obj/item/clothing/accessory/storage/brown_vest,
-/obj/item/clothing/accessory/storage/brown_vest,
-/obj/item/clothing/accessory/storage/brown_vest,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/accessory/storage/brown_vest,
+/obj/item/clothing/accessory/storage/brown_vest,
+/obj/item/clothing/accessory/storage/brown_vest,
+/obj/item/clothing/accessory/storage/brown_vest,
+/obj/item/clothing/accessory/storage/brown_vest,
+/obj/item/clothing/accessory/storage/brown_vest,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dv" = (
-/obj/structure/table/rack,
-/obj/item/clothing/accessory/storage/holster/thigh,
-/obj/item/clothing/accessory/storage/holster/thigh,
-/obj/item/clothing/accessory/storage/holster/thigh,
-/obj/item/clothing/accessory/storage/holster/thigh,
-/obj/item/clothing/accessory/storage/holster/thigh,
-/obj/item/clothing/accessory/storage/holster/thigh,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dw" = (
 /obj/item/device/radio/intercom/specops{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dx" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
@@ -1809,37 +1546,25 @@
 	pixel_x = 5;
 	pixel_y = -25
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dy" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Squad Leader's Office"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dz" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Command"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dA" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Engineering"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dB" = (
 /obj/machinery/vending/engineering,
@@ -1851,86 +1576,64 @@
 	id_tag = "rescue_base_hatch";
 	name = "Landing Pad"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dD" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/item/storage/box/trackimp,
 /obj/item/storage/box/cdeathalarm_kit,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dE" = (
-/obj/structure/table/reinforced,
-/obj/prefab/hand_teleporter,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/prefab/hand_teleporter,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dF" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/item/aicard,
 /obj/item/pinpointer/advpinpointer,
 /obj/item/device/radio/intercom/specops{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dG" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/machinery/cell_charger,
 /obj/item/cell/hyper,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dH" = (
 /obj/machinery/vending/engivend,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dI" = (
 /obj/machinery/vending/tool,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dJ" = (
 /obj/machinery/vending/generic,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dK" = (
 /obj/machinery/pipedispenser,
 /obj/item/device/radio/intercom/specops{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dL" = (
 /obj/machinery/pipedispenser/disposal,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dM" = (
 /obj/structure/closet{
@@ -1944,29 +1647,15 @@
 /obj/item/clothing/head/beret/solgov/fleet/engineering,
 /obj/item/clothing/head/beret/solgov/fleet/engineering,
 /obj/item/clothing/head/beret/solgov/fleet/engineering,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dN" = (
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dO" = (
 /obj/structure/bed/chair/office/dark,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/map_template/rescue_base/base)
-"dP" = (
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dQ" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -1974,9 +1663,7 @@
 	frequency = 1331;
 	id_tag = "rescue_base_hatch"
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dR" = (
 /obj/machinery/door/airlock/centcom{
@@ -1986,73 +1673,43 @@
 	id_tag = "standardrescue";
 	name = "Garage"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dS" = (
 /obj/structure/table/steel,
 /obj/item/device/radio/intercom/specops,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dT" = (
 /obj/structure/table/steel,
 /obj/item/stamp/solgov,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dU" = (
 /obj/structure/table/steel,
 /obj/item/storage/fancy/smokable/cigar,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/map_template/rescue_base/base)
-"dV" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Command"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dW" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dX" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dY" = (
 /obj/machinery/shieldgen,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "dZ" = (
 /obj/floor_decal/industrial/outline/yellow,
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ea" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/floor_decal/industrial/warning/corner,
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eb" = (
 /obj/machinery/button/blast_door{
@@ -2061,129 +1718,118 @@
 	pixel_x = -24;
 	pixel_y = -4
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/map_template/rescue_base/base)
-"ec" = (
-/obj/structure/table/reinforced,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ed" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/item/device/radio/intercom/specops{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ee" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/machinery/cell_charger,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ef" = (
 /obj/structure/table/steel,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eg" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eh" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/handcuffs,
 /obj/item/melee/baton/loaded,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ei" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/glasses/tacgoggles,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ej" = (
-/obj/structure/table/rack,
-/obj/item/storage/backpack/tau/commander,
-/obj/item/storage/belt/holster/security/tactical,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/suit/armor/kasrkin,
+/obj/item/clothing/suit/armor/kasrkin,
+/obj/item/clothing/suit/armor/kasrkin,
+/obj/item/clothing/suit/armor/kasrkin,
+/obj/item/clothing/head/helmet/flak/kasrkin,
+/obj/item/clothing/head/helmet/flak/kasrkin,
+/obj/item/clothing/head/helmet/flak/kasrkin,
+/obj/item/clothing/head/helmet/flak/kasrkin,
+/obj/item/clothing/gloves/thick/swat/cadian,
+/obj/item/clothing/gloves/thick/swat/cadian,
+/obj/item/clothing/gloves/thick/swat/cadian,
+/obj/item/clothing/gloves/thick/swat/cadian,
+/obj/item/clothing/shoes/jackboots/cadian,
+/obj/item/clothing/shoes/jackboots/cadian,
+/obj/item/clothing/shoes/jackboots/cadian,
+/obj/item/clothing/shoes/jackboots/cadian,
+/obj/item/clothing/under/cadian_uniform,
+/obj/item/clothing/under/cadian_uniform,
+/obj/item/clothing/under/cadian_uniform,
+/obj/item/clothing/under/cadian_uniform,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ek" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/lasgun/laspistol/militarum,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/gun/energy/lasgun/laspistol/militarum,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "el" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/grim/medium/command,
-/obj/item/clothing/head/helmet/solgov/command,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/gun/energy/lasgun/laspistol/militarum/bloodpact,
+/obj/item/gun/energy/lasgun/laspistol/militarum/bloodpact,
+/obj/item/gun/energy/lasgun/laspistol/militarum/bloodpact,
+/obj/item/gun/energy/lasgun/laspistol/militarum/bloodpact,
+/obj/item/gun/energy/plasma/pistol/chaos,
+/obj/item/gun/energy/plasma/pistol/chaos,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "em" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "en" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eo" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ep" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "rescuegarage";
 	name = "Garage Exit"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eq" = (
 /obj/machinery/mech_recharger,
@@ -2195,32 +1841,23 @@
 	icon_state = "console"
 	},
 /obj/item/card/id/centcom,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "es" = (
 /obj/structure/closet/secure_closet/cos,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "et" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/storage/secure/briefcase,
 /obj/item/clothing/head/beret/centcom/captain,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eu" = (
 /obj/machinery/power/emitter,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ev" = (
 /obj/structure/table/woodentable{
@@ -2232,10 +1869,7 @@
 	pixel_x = -5;
 	pixel_y = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ew" = (
 /obj/structure/table/woodentable{
@@ -2245,10 +1879,7 @@
 	desc = "Should anything ever go wrong...";
 	frequency = 1345
 	},
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ex" = (
 /obj/structure/table/woodentable{
@@ -2260,41 +1891,38 @@
 	pixel_x = 5;
 	pixel_y = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ey" = (
-/obj/structure/table/rack,
-/obj/item/storage/backpack/tau/engineer,
-/obj/item/storage/backpack/tau/engineer,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/clothing/gloves/insulated,
-/obj/item/clothing/gloves/insulated,
-/obj/item/clothing/gloves/insulated,
-/obj/item/clothing/gloves/insulated,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/storage/backpack/tau/engineer,
+/obj/item/storage/backpack/tau/engineer,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/clothing/gloves/insulated,
+/obj/item/clothing/gloves/insulated,
+/obj/item/clothing/gloves/insulated,
+/obj/item/clothing/gloves/insulated,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "ez" = (
-/obj/structure/table/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/welding/superior,
-/obj/item/clothing/glasses/welding/superior,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/rack{
+	color = "grey"
 	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/welding/superior,
+/obj/item/clothing/glasses/welding/superior,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eA" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/device/flash,
 /obj/item/device/flash,
 /obj/item/melee/baton/loaded,
@@ -2327,57 +1955,54 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eB" = (
-/obj/structure/table/reinforced,
-/obj/item/taperoll/engineering,
-/obj/item/taperoll/engineering,
-/obj/item/taperoll/atmos,
-/obj/item/taperoll/atmos,
-/obj/item/device/multitool,
-/obj/item/device/multitool,
-/obj/item/tape_roll,
-/obj/item/tape_roll,
-/obj/item/tape_roll,
-/obj/item/tape_roll,
-/obj/item/cell/high,
-/obj/item/cell/high,
-/obj/item/cell/high,
-/obj/item/cell/high,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/atmos,
+/obj/item/taperoll/atmos,
+/obj/item/device/multitool,
+/obj/item/device/multitool,
+/obj/item/tape_roll,
+/obj/item/tape_roll,
+/obj/item/tape_roll,
+/obj/item/tape_roll,
+/obj/item/cell/high,
+/obj/item/cell/high,
+/obj/item/cell/high,
+/obj/item/cell/high,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eC" = (
-/obj/structure/table/reinforced,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd,
-/obj/item/rcd,
-/obj/item/rcd,
-/obj/item/rcd,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd,
+/obj/item/rcd,
+/obj/item/rcd,
+/obj/item/rcd,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eD" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	color = "grey"
+	},
 /obj/item/stack/material/glass{
 	amount = 50
 	},
@@ -2458,40 +2083,25 @@
 /obj/item/stack/material/glass/boron_reinforced{
 	amount = 20
 	},
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eE" = (
-/obj/structure/table/reinforced,
-/obj/item/stock_parts/circuitboard/smes,
-/obj/item/stock_parts/circuitboard/smes,
-/obj/item/stock_parts/smes_coil,
-/obj/item/stock_parts/smes_coil,
-/obj/item/stock_parts/smes_coil/super_capacity,
-/obj/item/stock_parts/smes_coil/super_capacity,
-/obj/item/stock_parts/smes_coil/super_io,
-/obj/item/stock_parts/smes_coil/super_io,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
+/obj/structure/table/reinforced{
+	color = "grey"
 	},
+/obj/item/stock_parts/circuitboard/smes,
+/obj/item/stock_parts/circuitboard/smes,
+/obj/item/stock_parts/smes_coil,
+/obj/item/stock_parts/smes_coil,
+/obj/item/stock_parts/smes_coil/super_capacity,
+/obj/item/stock_parts/smes_coil/super_capacity,
+/obj/item/stock_parts/smes_coil/super_io,
+/obj/item/stock_parts/smes_coil/super_io,
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eF" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "vault"
-	},
-/area/map_template/rescue_base/base)
-"eG" = (
-/obj/item/device/radio/intercom/specops{
-	pixel_y = 22
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eH" = (
 /obj/structure/table/woodentable{
@@ -2499,29 +2109,20 @@
 	},
 /obj/item/material/ashtray/bronze,
 /obj/item/trash/cigbutt/cigarbutt,
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eI" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eJ" = (
 /obj/structure/table/woodentable{
 	dir = 5
 	},
 /obj/item/clothing/head/beret/solgov/marcom,
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eK" = (
 /obj/machinery/door/airlock/centcom{
@@ -2531,77 +2132,53 @@
 	id_tag = "heavyrescue";
 	name = "Combat Exosuit"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eL" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eM" = (
 /obj/floor_decal/industrial/warning{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eN" = (
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eO" = (
 /obj/floor_decal/industrial/warning{
 	dir = 5
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eP" = (
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
-/area/map_template/rescue_base/base)
-"eQ" = (
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eR" = (
 /obj/floor_decal/industrial/loading,
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eS" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eT" = (
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/porta_turret/crescent,
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "eU" = (
 /obj/paint/hull,
@@ -2861,9 +2438,7 @@
 /area/map_template/rescue_base/start)
 "fB" = (
 /obj/structure/flora/ausbushes/palebush,
-/turf/unsimulated/floor{
-	icon_state = "asteroidplating"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "fC" = (
 /obj/machinery/door/blast/regular{
@@ -2883,7 +2458,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "fE" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/item/device/radio,
@@ -2953,7 +2530,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "fM" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/clothing/mask/gas/half,
 /obj/item/clothing/mask/gas/half,
 /obj/item/clothing/mask/gas/half,
@@ -2991,7 +2570,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "fQ" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/item/tank/oxygen_emergency_double,
 /obj/item/tank/oxygen_emergency_double,
 /turf/simulated/floor/tiled/dark,
@@ -3044,7 +2625,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "fY" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/machinery/light,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
@@ -3163,7 +2746,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "gr" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack{
+	color = "grey"
+	},
 /obj/random/solgov,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/rescue_base/start)
@@ -3355,9 +2940,7 @@
 /area/map_template/rescue_base/start)
 "gT" = (
 /obj/item/device/flashlight/lantern,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "gU" = (
 /obj/wallframe_spawn/reinforced/titanium,
@@ -3427,9 +3010,7 @@
 /area/map_template/rescue_base/start)
 "hc" = (
 /obj/item/pickaxe/diamonddrill,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "hd" = (
 /obj/structure/bed/chair{
@@ -3478,23 +3059,17 @@
 /obj/floor_decal/industrial/warning{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "hk" = (
 /obj/floor_decal/industrial/warning,
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "hl" = (
 /obj/floor_decal/industrial/warning{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroidfloor"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/rescue_base/base)
 "DF" = (
 /obj/structure/handrail{
@@ -3591,11 +3166,11 @@ ac
 ac
 ac
 ac
-bA
-bB
+ar
+ar
 ac
-bA
-bB
+ar
+ar
 dp
 ac
 ac
@@ -3655,12 +3230,12 @@ ac
 ac
 ac
 bK
-bA
-bA
-bA
-dd
-bA
-bA
+ar
+ar
+ar
+fB
+ar
+ar
 ac
 ac
 ac
@@ -3717,14 +3292,14 @@ ac
 ac
 ac
 ac
-bB
-bA
-bA
-bC
-bA
-bA
-bA
-bB
+ar
+ar
+ar
+bK
+ar
+ar
+ar
+ar
 bK
 ac
 ac
@@ -3756,8 +3331,8 @@ ac
 ac
 ac
 ac
-bA
-bA
+ar
+ar
 ac
 ac
 ac
@@ -3781,16 +3356,16 @@ ad
 ad
 ad
 ad
-bA
-bA
-bA
-bA
-bB
-bB
+ar
+ar
+ar
+ar
+ar
+ar
 bK
-bA
-bA
-bA
+ar
+ar
+ar
 ac
 ac
 ac
@@ -3821,8 +3396,8 @@ ac
 ac
 ac
 gT
-bA
-bB
+ar
+ar
 ac
 ac
 ac
@@ -3865,8 +3440,8 @@ ad
 ac
 ac
 ac
-bA
-bA
+ar
+ar
 ac
 ac
 ac
@@ -3884,9 +3459,9 @@ ac
 ac
 ac
 ac
-bB
-bB
-bA
+ar
+ar
+ar
 ac
 ac
 ac
@@ -3906,8 +3481,8 @@ aZ
 bu
 ad
 bO
-ao
-ao
+ar
+ar
 bO
 ad
 ar
@@ -3928,10 +3503,10 @@ ad
 ad
 ac
 ac
-bA
-bA
-bA
-bA
+ar
+ar
+ar
+ar
 ac
 ac
 ac
@@ -3948,9 +3523,9 @@ ac
 ac
 ac
 ac
-bB
-bA
-bB
+ar
+ar
+ar
 ac
 ac
 ac
@@ -3993,30 +3568,30 @@ ac
 ac
 ac
 ac
-bB
-bA
+ar
+ar
 ac
-bB
-bA
-bC
-bB
-bB
-ac
-ac
+ar
+ar
+bK
+ar
+ar
 ac
 ac
 ac
 ac
 ac
-bB
-bB
-bB
-bB
-bB
-bB
+ac
+ac
+ar
+ar
+ar
+ar
+ar
+ar
 fB
-bB
-bB
+ar
+ar
 ac
 ac
 ac
@@ -4034,8 +3609,8 @@ ad
 ad
 ad
 bO
-ao
-ao
+ar
+ar
 bO
 ad
 cv
@@ -4057,31 +3632,31 @@ ac
 ac
 ac
 ac
-bB
-bB
-bB
-bB
-bB
-bA
-bA
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 fB
-bB
-bB
+ar
+ar
 ac
 ac
-bB
-bB
-bB
-bA
-bC
-bB
-bC
-bB
-bA
-bA
-bB
-bB
-bB
+ar
+ar
+ar
+ar
+bK
+ar
+bK
+ar
+ar
+ar
+ar
+ar
+ar
 ac
 ac
 ac
@@ -4119,34 +3694,34 @@ ad
 ac
 ac
 ac
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bA
-bB
-bB
-bB
-bB
-bA
-bB
-bB
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 ac
 ac
 ac
@@ -4162,8 +3737,8 @@ aZ
 bx
 ad
 bO
-ao
-ao
+ar
+ar
 bO
 ad
 ar
@@ -4183,7 +3758,7 @@ ad
 ac
 ac
 ac
-bB
+ar
 eM
 eP
 eP
@@ -4210,7 +3785,7 @@ eP
 eP
 eP
 hj
-bB
+ar
 ac
 ac
 ac
@@ -4246,36 +3821,36 @@ ar
 ad
 ac
 ac
-bB
-bB
+ar
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -4290,42 +3865,42 @@ aZ
 aZ
 bJ
 ar
-ao
-ao
-ao
+ar
+ar
+ar
 cb
-ao
-ao
-ao
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 dy
-ao
-ao
+ar
+ar
 dU
-ao
+ar
 es
 ad
 ac
 ac
-bB
-bA
+ar
+ar
 eN
-eQ
+ar
 eT
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 eU
 eU
@@ -4336,10 +3911,10 @@ gU
 eU
 gX
 gX
-eQ
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -4362,34 +3937,34 @@ cw
 cD
 cL
 cQ
-de
-ao
-ao
+cB
+ar
+ar
 bg
 ar
-ao
-ao
-ao
+ar
+ar
+ar
 et
 ad
 ac
 ac
 ac
-bB
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 gh
 gp
@@ -4400,10 +3975,10 @@ gV
 hd
 gY
 hf
-eQ
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -4411,9 +3986,9 @@ ac
 ac
 ad
 au
-aB
+ar
 aQ
-aB
+ar
 ad
 ad
 ad
@@ -4432,28 +4007,28 @@ dl
 ad
 bg
 bg
-dV
+dz
 ad
 ad
 ad
 ac
 ac
 ac
-bB
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 gi
 fn
@@ -4464,11 +4039,11 @@ fn
 fn
 gY
 hf
-eQ
+ar
 hk
-bB
-bC
-bB
+ar
+bK
+ar
 ac
 "}
 (16,1,1) = {"
@@ -4479,8 +4054,8 @@ ad
 aR
 bc
 ad
-bA
-bB
+ar
+ar
 bg
 ar
 ar
@@ -4491,8 +4066,8 @@ cE
 cM
 cR
 bg
-ao
-ao
+ar
+ar
 bg
 dD
 ar
@@ -4502,22 +4077,22 @@ ad
 ac
 ac
 ac
-bB
-bB
+ar
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 gj
 gq
@@ -4528,11 +4103,11 @@ gW
 he
 gY
 hf
-eQ
+ar
 hk
-bB
-bB
-bB
+ar
+ar
+ar
 ac
 "}
 (17,1,1) = {"
@@ -4543,7 +4118,7 @@ av
 aR
 bc
 ad
-bB
+ar
 bK
 bg
 ar
@@ -4555,21 +4130,21 @@ ar
 ar
 ar
 bg
-ao
-ao
+ar
+ar
 bg
 dE
 ar
 ar
 ei
 bg
-bB
-bB
-bB
-bB
-bA
+ar
+ar
+ar
+ar
+ar
 eN
-eQ
+ar
 eU
 eU
 eU
@@ -4581,7 +4156,7 @@ fC
 fC
 eU
 eU
-eQ
+ar
 eU
 eU
 eU
@@ -4592,10 +4167,10 @@ eU
 eU
 gX
 gX
-eQ
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -4603,12 +4178,12 @@ ac
 ac
 ad
 aw
-aB
+ar
 aS
-aB
+ar
 ad
-bC
-bA
+bK
+ar
 bg
 ar
 ar
@@ -4619,7 +4194,7 @@ ar
 ar
 ar
 df
-ao
+ar
 dw
 ad
 dF
@@ -4627,13 +4202,13 @@ ar
 ar
 ej
 bg
-bB
-bA
-bB
-bA
-bB
+ar
+ar
+ar
+ar
+ar
 eN
-eQ
+ar
 eV
 eY
 ff
@@ -4645,21 +4220,21 @@ fK
 fO
 fD
 eU
-eQ
-eQ
-eQ
+ar
+ar
+ar
 eU
 fn
 fn
 eU
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
 hk
-bB
-bA
+ar
+ar
 ac
 ac
 "}
@@ -4678,26 +4253,26 @@ ar
 ar
 bg
 cf
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
 dg
-ao
-ao
+ar
+ar
 dz
-ao
-ao
-ao
+ar
+ar
+ar
 ek
 bg
-bB
-bC
-bB
-bB
-bB
+ar
+bK
+ar
+ar
+ar
 eN
-eQ
+ar
 eV
 eZ
 fg
@@ -4716,14 +4291,14 @@ eU
 ge
 gI
 eU
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -4742,26 +4317,26 @@ ar
 ar
 ad
 cg
-ao
+ar
 cF
 cN
-ao
+ar
 dg
-ao
-ao
+ar
+ar
 dz
-ao
-ao
-ao
-el
+ar
+ar
+ar
+cr
 bg
-bB
-bB
-bB
-bA
-bB
+ar
+ar
+ar
+ar
+ar
 eN
-eQ
+ar
 eV
 fa
 fh
@@ -4780,14 +4355,14 @@ fn
 fn
 fX
 eU
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
 hk
-bA
-bB
+ar
+ar
 ac
 ac
 "}
@@ -4797,10 +4372,10 @@ ac
 ac
 ad
 aU
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
 ad
 ar
 ar
@@ -4812,7 +4387,7 @@ bg
 ad
 ad
 dm
-ao
+ar
 ad
 ad
 bg
@@ -4821,11 +4396,11 @@ bg
 ad
 ad
 ad
-bB
-bB
-bB
+ar
+ar
+ar
 eN
-eQ
+ar
 eV
 fb
 fi
@@ -4844,14 +4419,14 @@ gr
 gr
 gJ
 eU
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -4860,36 +4435,36 @@ ac
 ac
 ac
 ad
-ao
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
+ar
 ad
 ar
 ar
 ad
-ch
-ao
-ao
-ao
-ao
+cr
+ar
+ar
+ar
+ar
 dh
-ao
-ao
+ar
+ar
 dA
-ao
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
+ar
 ch
 ad
-bB
-bB
-dd
+ar
+ar
+fB
 eN
-eQ
+ar
 eU
 eU
 eU
@@ -4910,12 +4485,12 @@ eU
 eU
 gX
 gX
-eQ
-eQ
-eQ
+ar
+ar
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -4934,34 +4509,34 @@ ar
 ar
 bg
 ci
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
 dh
-ao
-ao
+ar
+ar
 dA
-ao
-ao
-ao
-ao
-ao
-ci
+ar
+ar
+ar
+ar
+ar
+el
 bg
-bB
-bA
-bB
+ar
+ar
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 fT
 ga
@@ -4974,11 +4549,11 @@ gt
 gQ
 gY
 hf
-eQ
-eQ
-eQ
+ar
+ar
+ar
 hk
-bB
+ar
 ac
 ac
 ac
@@ -4991,20 +4566,20 @@ aC
 aV
 be
 bo
-ao
+ar
 ar
 ad
 ar
 ar
 bg
-cj
+cr
 ar
 cG
 ar
 ar
 di
-ao
-ao
+ar
+ar
 dB
 ar
 ar
@@ -5013,19 +4588,19 @@ em
 ar
 ey
 bg
-bB
-bB
-bA
+ar
+ar
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 fU
 gb
@@ -5038,11 +4613,11 @@ gt
 gQ
 gY
 hf
-eQ
-eQ
-eQ
+ar
+ar
+ar
 hk
-bC
+bK
 ac
 ac
 ac
@@ -5052,14 +4627,14 @@ ad
 ad
 ad
 aD
-ao
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
+ar
 bS
-ao
-ao
+ar
+ar
 bg
 ck
 ar
@@ -5067,8 +4642,8 @@ cH
 ar
 cS
 dj
-ao
-ao
+ar
+ar
 bg
 dG
 ar
@@ -5077,19 +4652,19 @@ en
 ar
 ez
 bg
-bB
-bB
-bB
+ar
+ar
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 ff
 gb
@@ -5102,28 +4677,28 @@ gt
 gt
 gY
 hf
-eQ
-eQ
-eQ
+ar
+ar
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
 (26,1,1) = {"
 ae
-ao
+ar
 ad
 aE
-ao
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
+ar
 bS
-ao
-ao
+ar
+ar
 bg
 cl
 ar
@@ -5131,8 +4706,8 @@ cI
 ar
 cT
 dj
-ao
-ao
+ar
+ar
 bg
 dH
 ar
@@ -5141,19 +4716,19 @@ en
 ar
 eA
 bg
-bA
-bC
-bB
+ar
+bK
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 fV
 gc
@@ -5166,28 +4741,28 @@ gK
 Es
 gY
 hf
-eQ
-eQ
-eQ
+ar
+ar
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
 (27,1,1) = {"
 af
-ao
+ar
 ad
 aF
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
 bM
 ad
-ao
-ao
+ar
+ar
 bg
 cm
 ar
@@ -5195,8 +4770,8 @@ ar
 ar
 cU
 dj
-ao
-ao
+ar
+ar
 bg
 dI
 ar
@@ -5205,11 +4780,11 @@ en
 ar
 eB
 ad
-bB
-bB
-bB
+ar
+ar
+ar
 eN
-eQ
+ar
 eU
 eU
 eU
@@ -5230,18 +4805,18 @@ eU
 eU
 gX
 gX
-eQ
-eQ
-eQ
+ar
+ar
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
 (28,1,1) = {"
 ag
-ao
+ar
 ad
 aG
 aW
@@ -5251,7 +4826,7 @@ bF
 bN
 ad
 aU
-ao
+ar
 ad
 cm
 cy
@@ -5259,8 +4834,8 @@ cJ
 cO
 cV
 dj
-ao
-ao
+ar
+ar
 ad
 dJ
 ar
@@ -5269,11 +4844,11 @@ en
 ar
 eC
 ad
-bB
-bB
-bB
+ar
+ar
+ar
 eN
-eQ
+ar
 eU
 fc
 fj
@@ -5292,13 +4867,13 @@ gv
 gB
 gL
 eU
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
 hk
-bB
+ar
 ac
 ac
 ac
@@ -5314,8 +4889,8 @@ ad
 ad
 ad
 ad
-ao
-ao
+ar
+ar
 ad
 ad
 bg
@@ -5324,7 +4899,7 @@ bg
 ad
 ad
 aU
-ao
+ar
 ad
 dK
 ar
@@ -5356,39 +4931,39 @@ gw
 gw
 gM
 eU
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
 hk
-bB
+ar
 ac
 ac
 ac
 "}
 (30,1,1) = {"
 ah
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 ad
 dL
 ar
@@ -5420,42 +4995,42 @@ eU
 gC
 gN
 eU
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
 hk
-bB
+ar
 ac
 ac
 ac
 "}
 (31,1,1) = {"
 ah
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 ad
 dM
-dP
+ar
 dY
 dY
 eu
@@ -5463,9 +5038,9 @@ eF
 ad
 dZ
 dZ
-bB
+ar
 eN
-eQ
+ar
 eU
 fe
 fl
@@ -5477,21 +5052,21 @@ fN
 fN
 fY
 eU
-eQ
-eQ
-eQ
+ar
+ar
+ar
 eU
 gD
 gw
 eU
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -5515,7 +5090,7 @@ ad
 ad
 ad
 ad
-ao
+ar
 dx
 ad
 ad
@@ -5527,9 +5102,9 @@ ad
 ad
 dZ
 dZ
-bB
+ar
 eN
-eQ
+ar
 eU
 eU
 eU
@@ -5541,7 +5116,7 @@ fJ
 fJ
 eU
 eU
-eQ
+ar
 eU
 eU
 eU
@@ -5552,10 +5127,10 @@ eU
 eU
 gX
 gX
-eQ
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -5566,7 +5141,7 @@ ax
 aH
 ad
 bh
-bq
+eg
 ar
 ar
 ar
@@ -5574,13 +5149,13 @@ ar
 bZ
 ad
 cn
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
 dk
-ao
-ao
+ar
+ar
 dC
 dN
 dQ
@@ -5591,21 +5166,21 @@ dZ
 dZ
 dZ
 dZ
-bB
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 gm
 gx
@@ -5616,10 +5191,10 @@ gZ
 hg
 gY
 hf
-eQ
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -5638,13 +5213,13 @@ ar
 bZ
 ad
 co
-ao
 ar
-ao
-ao
+ar
+ar
+ar
 dk
-ao
-ao
+ar
+ar
 dC
 dN
 dQ
@@ -5655,21 +5230,21 @@ eo
 eo
 eL
 dZ
-bA
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 gn
 gy
@@ -5680,10 +5255,10 @@ gw
 hh
 gY
 hf
-eQ
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -5702,13 +5277,13 @@ ar
 ar
 ad
 cp
-ao
 ar
-ao
+ar
+ar
 cW
 ad
-ao
-ao
+ar
+ar
 ad
 ad
 ad
@@ -5719,21 +5294,21 @@ ep
 ep
 ad
 ad
-bB
+ar
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 go
 gw
@@ -5744,10 +5319,10 @@ ha
 hi
 gY
 hf
-eQ
+ar
 hk
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -5758,46 +5333,46 @@ ar
 ar
 ad
 ar
-bs
 ar
 ar
 ar
-bs
+ar
+ar
 ar
 ad
 cq
-ao
 ar
-ao
+ar
+ar
 cX
 ad
-ao
-ao
-ao
-ao
+ar
+ar
+ar
+ar
 dR
 eb
-ao
-ao
-ao
-ao
-ec
+ar
+ar
+ar
+ar
+cB
 ad
-bB
+ar
 eN
-eQ
+ar
 eT
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 eU
 eU
 eU
@@ -5808,9 +5383,9 @@ hb
 eU
 gX
 gX
-eQ
+ar
 hk
-bB
+ar
 ac
 ac
 ac
@@ -5830,51 +5405,51 @@ bX
 bg
 ad
 cr
-ao
 ar
-ao
+ar
+ar
 cY
 ad
 aU
-ao
-ao
-ao
+ar
+ar
+ar
 dR
-ao
-ao
-ao
-ao
-ao
-ec
+ar
+ar
+ar
+ar
+ar
+cB
 ad
-bC
+bK
 eN
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 hk
-bB
+ar
 ac
 ac
 ac
@@ -5894,24 +5469,24 @@ ar
 bj
 ad
 cs
-ao
 ar
-ao
+ar
+ar
 cZ
 ad
-ao
-ao
+ar
+ar
 ad
 ad
 ad
-ec
-ao
-ao
-ao
-ao
-ec
+cB
+ar
+ar
+ar
+ar
+cB
 ad
-bA
+ar
 eO
 eS
 eS
@@ -5938,8 +5513,8 @@ eS
 eS
 eS
 hl
-bB
-bB
+ar
+ar
 ac
 ac
 "}
@@ -5958,51 +5533,51 @@ ar
 bk
 ad
 ct
-ao
 ar
-ao
+ar
+ar
 da
 ad
-ao
-ao
+ar
+ar
 ad
 ac
 ad
 ed
-ao
-ao
-ao
-ao
-ec
+ar
+ar
+ar
+ar
+cB
 ad
-bA
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bA
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bA
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
-bB
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 ac
 ac
 ac
@@ -6022,9 +5597,9 @@ ad
 ad
 ad
 cu
-ao
-ao
-ao
+ar
+ar
+ar
 db
 ad
 dn
@@ -6036,36 +5611,36 @@ ee
 eq
 eq
 eq
-ao
-ec
+ar
+cB
 ad
-bB
-bC
-bB
-bA
-bB
-bB
+ar
+bK
+ar
+ar
+ar
+ar
 ac
 ac
-bA
-bB
-bB
-bA
-bB
-bA
-bA
-bB
-bB
-bB
-bB
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 fB
-bB
-bA
-bB
-bB
-bB
-bC
-bA
+ar
+ar
+ar
+ar
+ar
+bK
+ar
 ac
 ac
 ac
@@ -6091,8 +5666,8 @@ cK
 ad
 ad
 ad
-ao
-ao
+ar
+ar
 ad
 ac
 ad
@@ -6103,8 +5678,8 @@ ad
 eK
 ad
 ad
-bA
-bA
+ar
+ar
 ac
 ac
 ac
@@ -6113,23 +5688,23 @@ ac
 ac
 ac
 ac
-bB
-bB
-bA
-bB
+ar
+ar
+ar
+ar
 ac
 ac
-bB
-bB
-bB
-bA
-bB
-bB
-bB
-bB
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
 ac
-bB
-bB
+ar
+ar
 ac
 ac
 ac
@@ -6154,20 +5729,20 @@ ad
 ad
 ad
 dc
-ao
-ao
-ao
-ad
-ac
-ac
-ac
-ac
-ad
-eG
-ao
+ar
+ar
 ar
 ad
-bB
+ac
+ac
+ac
+ac
+ad
+aU
+ar
+ar
+ad
+ar
 ac
 ac
 ac
@@ -6178,8 +5753,8 @@ ac
 ac
 ac
 ac
-bB
-bB
+ar
+ar
 ac
 ac
 ac
@@ -6189,10 +5764,10 @@ ac
 ac
 ac
 ac
-bB
-bB
-bB
-bB
+ar
+ar
+ar
+ar
 ac
 ac
 ac
@@ -6218,18 +5793,18 @@ ac
 ac
 ad
 dc
-ao
-ao
-ao
+ar
+ar
+ar
 ad
 ac
 ac
 ac
 ac
 ad
-ec
+cB
 eq
-ec
+cB
 ad
 ac
 ac
@@ -6253,7 +5828,7 @@ ac
 ac
 ac
 ac
-bB
+ar
 ac
 ac
 ac
@@ -6283,8 +5858,8 @@ ac
 ad
 ad
 ad
-ao
-ao
+ar
+ar
 ad
 ac
 ac
@@ -6316,8 +5891,8 @@ ac
 ac
 ac
 ac
-bA
-bA
+ar
+ar
 ac
 ac
 ac

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -14,67 +14,32 @@
 "ae" = (
 /turf/unsimulated/wall,
 /area/map_template/syndicate_mothership/raider_base)
-"af" = (
-/obj/random/junk,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/map_template/syndicate_mothership/raider_base)
 "ag" = (
 /obj/structure/closet/kitchen,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ah" = (
 /obj/structure/table/reinforced,
 /obj/item/tray{
 	pixel_y = 5
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ai" = (
 /obj/structure/table/standard,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"aj" = (
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ak" = (
 /obj/structure/closet/fridge,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"al" = (
-/obj/random/trash,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "am" = (
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/bar_soft/full,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"an" = (
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ao" = (
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ap" = (
 /obj/structure/table/reinforced,
@@ -82,107 +47,63 @@
 	pixel_x = -1;
 	pixel_y = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"aq" = (
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ar" = (
 /obj/machinery/door/airlock/hatch{
 	name = "\improper NO DUST BREATHER ALLOWED"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "as" = (
 /obj/machinery/vending/snack{
 	name = "Getmore Chocolate Corp";
 	prices = list()
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "at" = (
 /obj/structure/kitchenspike,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"aw" = (
-/obj/random/trash,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ax" = (
 /obj/item/device/radio/intercom/raider{
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"ay" = (
-/obj/random/junk,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "az" = (
 /obj/random/trash,
 /obj/item/reagent_containers/glass/bucket,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aA" = (
 /obj/structure/aliumizer,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aB" = (
 /obj/random/coin,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aC" = (
 /turf/simulated/mineral,
 /area/map_template/syndicate_mothership/raider_base)
 "aD" = (
 /obj/machinery/door/airlock/hatch,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aE" = (
 /obj/decal/cleanable/blood,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aF" = (
 /obj/machinery/gibber,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aG" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aH" = (
 /obj/structure/hygiene/urinal{
@@ -194,26 +115,20 @@
 	},
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aI" = (
 /obj/structure/hygiene/urinal{
 	pixel_y = 32
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aJ" = (
 /obj/structure/hygiene/urinal{
 	pixel_y = 32
 	},
 /obj/random/trash,
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aK" = (
 /obj/structure/bed,
@@ -233,10 +148,7 @@
 	},
 /obj/item/bedsheet/green,
 /obj/structure/curtain/open/bed,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aL" = (
 /obj/landmark{
@@ -245,29 +157,20 @@
 /obj/floor_decal/carpet{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aM" = (
 /obj/floor_decal/carpet{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aN" = (
 /obj/floor_decal/carpet{
 	dir = 1
 	},
 /obj/random/trash,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aO" = (
 /obj/structure/bed,
@@ -282,57 +185,28 @@
 	},
 /obj/item/bedsheet/rd,
 /obj/structure/curtain/open/bed,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"aP" = (
-/obj/machinery/door/airlock/hatch,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aQ" = (
 /obj/random/junk,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aR" = (
 /obj/random/ammo,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"aS" = (
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"aT" = (
-/obj/decal/cleanable/blood,
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aU" = (
 /obj/machinery/door/airlock/hatch{
 	name = "\improper LITTLE VOX ROOM"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aV" = (
 /obj/item/device/radio/intercom/raider{
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aW" = (
 /obj/structure/bed,
@@ -341,25 +215,13 @@
 	},
 /obj/item/bedsheet/hos,
 /obj/structure/curtain/open/bed,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aX" = (
 /obj/landmark{
 	name = "voxstart"
 	},
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"aY" = (
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "aZ" = (
 /obj/structure/bed,
@@ -368,10 +230,7 @@
 	},
 /obj/item/bedsheet/rainbow,
 /obj/structure/curtain/open/bed,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ba" = (
 /obj/structure/hygiene/sink{
@@ -382,9 +241,7 @@
 /obj/item/vox_changer/raider{
 	pixel_x = -28
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bb" = (
 /obj/structure/bed,
@@ -393,10 +250,7 @@
 	},
 /obj/item/bedsheet/clown,
 /obj/structure/curtain/open/bed,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bc" = (
 /obj/structure/bed,
@@ -405,33 +259,21 @@
 	},
 /obj/item/bedsheet/orange,
 /obj/structure/curtain/open/bed,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bd" = (
 /obj/decal/cleanable/cobweb,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "be" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bf" = (
 /obj/decal/cleanable/dirt,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bg" = (
 /obj/structure/sign/warning/nosmoking_1{
@@ -439,39 +281,26 @@
 	pixel_y = 32
 	},
 /obj/item/storage/fancy/smokable/dromedaryco,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bh" = (
 /obj/decal/cleanable/blood/oil,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bi" = (
 /obj/decal/cleanable/cobweb2{
 	icon_state = "spiderling";
 	name = "dead spider"
 	},
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bj" = (
 /obj/item/clothing/head/xenos,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bk" = (
 /obj/random/trash,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bl" = (
 /obj/structure/hygiene/sink{
@@ -483,26 +312,13 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"bm" = (
-/obj/structure/hygiene/shower{
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bn" = (
 /obj/structure/hygiene/shower{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bo" = (
 /obj/structure/table/woodentable,
@@ -511,10 +327,7 @@
 	},
 /obj/random/junk,
 /obj/random/maintenance,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bp" = (
 /obj/structure/table/woodentable,
@@ -524,42 +337,21 @@
 /obj/floor_decal/carpet{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bq" = (
 /obj/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"br" = (
-/obj/item/device/radio/intercom/raider{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bs" = (
 /obj/decal/cleanable/spiderling_remains,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bu" = (
 /obj/structure/window/reinforced{
@@ -569,10 +361,7 @@
 	dir = 8
 	},
 /obj/random/toolbox,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bv" = (
 /obj/decal/cleanable/dirt,
@@ -581,42 +370,29 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bw" = (
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bx" = (
 /obj/decal/cleanable/dirt,
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "by" = (
 /obj/item/clothing/mask/gas/swat{
 	desc = "A close-fitting mask clearly not made for a human face.";
 	name = "\improper alien mask"
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bz" = (
 /obj/item/xenos_claw,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bA" = (
 /obj/structure/table/rack,
@@ -625,9 +401,7 @@
 /obj/item/clothing/shoes/magboots/vox,
 /obj/item/clothing/gloves/vox,
 /obj/item/clothing/under/vox/vox_casual,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bB" = (
 /obj/structure/table/rack,
@@ -637,18 +411,7 @@
 /obj/item/clothing/gloves/vox,
 /obj/item/clothing/under/vox/vox_robes,
 /obj/item/gun/energy/darkmatter,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"bC" = (
-/obj/decal/cleanable/cobweb2{
-	icon_state = "spiderling";
-	name = "dead spider"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bD" = (
 /obj/item/device/radio/intercom/raider{
@@ -662,17 +425,11 @@
 /obj/floor_decal/carpet{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bE" = (
 /obj/floor_decal/carpet,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bF" = (
 /obj/structure/closet{
@@ -684,26 +441,22 @@
 /obj/item/clothing/under/rank/mailman,
 /obj/item/clothing/accessory/storage/webbing_large,
 /obj/item/clothing/under/rank/dispatch,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/obj/random/loot/randomsupply/engineering,
+/obj/random/loot/randomsupply,
+/obj/random/loot/randomsupply/tech,
+/obj/random/loot/randomsupply/tech,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bG" = (
 /obj/structure/undies_wardrobe,
 /obj/floor_decal/carpet,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bH" = (
 /obj/random/junk,
 /obj/floor_decal/carpet,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bI" = (
 /obj/floor_decal/carpet{
@@ -713,21 +466,7 @@
 /obj/floor_decal/carpet{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"bJ" = (
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"bK" = (
-/turf/unsimulated/floor{
-	icon = 'icons/turf/flooring/wood.dmi';
-	icon_state = "wood_broken2"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bL" = (
 /obj/structure/table/woodentable,
@@ -735,42 +474,30 @@
 	pixel_y = 5
 	},
 /obj/random/backpack,
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bM" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/glasses/rocks,
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
+/obj/random/loot/rarearmorbundle,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bN" = (
 /obj/structure/table/woodentable,
 /obj/machinery/chemical_dispenser/bar_soft/full,
-/turf/unsimulated/floor{
-	icon = 'icons/turf/flooring/wood.dmi';
-	icon_state = "wood_broken6"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bO" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/washing_machine,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bP" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bQ" = (
 /obj/machinery/atmospherics/omni/mixer{
@@ -783,10 +510,7 @@
 	tag_west_con = 0.5;
 	use_power = 0
 	},
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bR" = (
 /obj/structure/window/reinforced{
@@ -796,25 +520,17 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bS" = (
 /obj/decal/cleanable/dirt,
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bT" = (
 /obj/item/pizzabox/meat,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bU" = (
 /obj/structure/table/rack,
@@ -825,22 +541,12 @@
 /obj/item/clothing/under/vox/vox_robes,
 /obj/item/gun/projectile/dartgun/vox/raider,
 /obj/item/gun/energy/sonic,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"bV" = (
-/obj/item/stool/padded,
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bW" = (
 /obj/decal/cleanable/generic,
 /obj/item/stool/padded,
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bX" = (
 /obj/structure/table/rack,
@@ -850,9 +556,7 @@
 /obj/item/clothing/gloves/vox,
 /obj/item/clothing/under/vox/vox_casual,
 /obj/item/gun/projectile/dartgun/vox/raider,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bY" = (
 /obj/structure/table/rack,
@@ -863,38 +567,32 @@
 /obj/random/glasses,
 /obj/item/clothing/under/vox/vox_robes,
 /obj/item/gun/projectile/dartgun/vox/medical,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "bZ" = (
 /obj/machinery/acting/changer,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ca" = (
 /obj/structure/table/woodentable,
 /obj/item/pizzabox/meat,
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
+/obj/random/loot/basicarmorbundle,
+/obj/random/loot/basicarmorbundle,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cb" = (
 /obj/structure/table/woodentable,
 /obj/item/material/ashtray/bronze,
 /obj/item/trash/cigbutt/cigarbutt,
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
+/obj/random/loot/rarearmorbundle,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cc" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/glass/rag,
 /obj/random/ammo,
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
+/obj/random/loot/rarearmorbundle,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cd" = (
 /obj/machinery/vending/cigarette{
@@ -902,42 +600,25 @@
 	prices = list();
 	products = list(/obj/item/storage/fancy/smokable/transstellar=10,/obj/item/storage/fancy/matches/matchbox=10,/obj/item/flame/lighter/zippo/random=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ce" = (
-/obj/item/tank/nitrogen,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/obj/item/tank/oxygen_emergency_extended,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cf" = (
 /obj/random/backpack,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cg" = (
 /obj/structure/sign/poster{
 	pixel_y = -32
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"ch" = (
-/turf/unsimulated/floor{
-	icon = 'icons/turf/flooring/wood.dmi';
-	icon_state = "wood_broken1"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ci" = (
 /obj/item/stool/padded,
-/turf/unsimulated/floor{
-	icon = 'icons/turf/flooring/wood.dmi';
-	icon_state = "wood_broken1"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cj" = (
 /mob/living/simple_animal/hostile/retaliate/parrot{
@@ -945,9 +626,7 @@
 	name = "\proper Meatbag";
 	say_list_type = /datum/say_list/parrot/heist
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ck" = (
 /obj/structure/grille,
@@ -960,9 +639,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cm" = (
 /obj/item/device/radio/intercom/raider{
@@ -974,16 +651,11 @@
 	icon_state = "plant-25";
 	name = "Jamie"
 	},
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cn" = (
 /obj/structure/reagent_dispensers/beerkeg,
-/turf/unsimulated/floor{
-	icon = 'icons/turf/flooring/wood.dmi';
-	icon_state = "wood_broken1"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "co" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
@@ -992,39 +664,31 @@
 	pixel_x = -25;
 	pixel_y = -5
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cp" = (
 /obj/structure/closet/crate,
-/obj/item/tank/nitrogen,
-/obj/item/tank/nitrogen,
-/obj/item/tank/nitrogen,
-/obj/item/tank/nitrogen,
-/obj/item/tank/nitrogen,
-/obj/item/tank/nitrogen,
+/obj/item/tank/oxygen_emergency_extended,
+/obj/item/tank/oxygen_emergency_extended,
+/obj/item/tank/oxygen_emergency_extended,
+/obj/item/tank/oxygen_emergency_extended,
+/obj/item/tank/oxygen_emergency_extended,
+/obj/item/tank/oxygen_emergency_extended,
 /obj/item/clothing/mask/gas/swat/vox,
 /obj/item/clothing/mask/gas/swat/vox,
 /obj/item/clothing/mask/gas/swat/vox,
 /obj/item/clothing/mask/gas/swat/vox,
 /obj/item/clothing/mask/gas/swat/vox,
 /obj/item/clothing/mask/gas/swat/vox,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cq" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
-/area/map_template/syndicate_mothership/raider_base)
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/shuttle/black,
+/area/map_template/skipjack_station/start)
 "cr" = (
 /obj/item/clothing/head/philosopher_wig,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cs" = (
 /obj/structure/lattice,
@@ -1032,18 +696,14 @@
 /area/space)
 "ct" = (
 /obj/machinery/door/airlock/external,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cu" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	id_tag = "skipjack_base_hatch"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "cv" = (
 /obj/item/trash/cheesie,
@@ -1261,6 +921,7 @@
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
 /obj/random/glasses,
+/obj/random/loot/raresidearmbundle,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "cU" = (
@@ -1279,6 +940,7 @@
 /obj/random/raider/hardsuit,
 /obj/item/clothing/head/pirate,
 /obj/item/gun/launcher/money,
+/obj/random/loot/raresidearmbundle,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "cY" = (
@@ -1309,7 +971,7 @@
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
 /obj/item/material/harpoon,
-/obj/random/lilgun,
+/obj/random/loot/sidearmbundle,
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
 "db" = (
@@ -1346,6 +1008,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/random/loot/raresidearmbundle,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "df" = (
@@ -1362,6 +1025,7 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
+/obj/random/loot/raresidearmbundle,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "dg" = (
@@ -1404,7 +1068,7 @@
 /obj/item/tank/oxygen,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/obj/random/biggun,
+/obj/random/loot/raresidearmbundle,
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
 "dk" = (
@@ -1453,16 +1117,9 @@
 /obj/item/tank/oxygen,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/obj/random/lilgun,
+/obj/random/loot/sidearmbundle,
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
-"dr" = (
-/obj/random/ammo,
-/turf/unsimulated/floor{
-	icon_state = "carpet";
-	name = "carpet"
-	},
-/area/map_template/syndicate_mothership/raider_base)
 "ds" = (
 /obj/item/robot_parts/head,
 /turf/simulated/floor/plating,
@@ -1540,7 +1197,8 @@
 /obj/item/grenade/empgrenade,
 /obj/item/grenade/flashbang,
 /obj/item/grenade/spawnergrenade/viscerator,
-/obj/random/biggun,
+/obj/random/loot/raregunsenergy,
+/obj/random/loot/raregunslug,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "dD" = (
@@ -1590,10 +1248,7 @@
 /obj/random/donkpocket_box,
 /obj/item/reagent_containers/food/snacks/tastybread,
 /obj/item/reagent_containers/food/snacks/tastybread,
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/skipjack_station/start)
 "dL" = (
 /obj/machinery/door/airlock/hatch,
@@ -1676,6 +1331,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/shuttle/black,
 /area/map_template/skipjack_station/start)
 "dW" = (
@@ -1692,7 +1348,7 @@
 "dY" = (
 /obj/item/deck/cards,
 /obj/structure/table/steel,
-/obj/random/lilgun,
+/obj/random/loot/lasbundle,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "dZ" = (
@@ -1727,7 +1383,7 @@
 /area/map_template/skipjack_station/start)
 "ee" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/item/tank/nitrogen,
+/obj/item/tank/oxygen_emergency_extended,
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
 "ef" = (
@@ -1754,7 +1410,7 @@
 /area/map_template/skipjack_station/start)
 "ei" = (
 /obj/structure/table/steel,
-/obj/random/lilgun,
+/obj/random/loot/lasbundle,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "ej" = (
@@ -1918,10 +1574,7 @@
 /obj/machinery/telecomms/allinone{
 	intercept = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 "ho" = (
 /obj/machinery/constructable_frame/computerframe,
@@ -1939,9 +1592,7 @@
 /obj/item/clothing/gloves/vox,
 /obj/item/clothing/under/vox/vox_casual,
 /obj/item/gun/launcher/alien/slugsling,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/syndicate_mothership/raider_base)
 
 (1,1,1) = {"
@@ -2762,10 +2413,10 @@ ab
 ab
 ab
 aQ
-aq
+ao
 bz
-aq
-aq
+ao
+ao
 ce
 bk
 ab
@@ -2834,13 +2485,13 @@ ab
 ab
 ab
 aR
-aq
+ao
 VK
 bU
 bX
-aq
-aq
-aq
+ao
+ao
+ao
 ab
 ab
 ab
@@ -2903,14 +2554,14 @@ ab
 ab
 ab
 aA
-aq
+ao
 aQ
-aq
+ao
 bk
-aq
-aq
-aq
-aq
+ao
+ao
+ao
+ao
 aQ
 cp
 ab
@@ -2972,19 +2623,19 @@ ab
 ab
 ab
 ab
-an
-aq
-aq
-aq
-aq
-aq
-aq
+ao
+ao
+ao
+ao
+ao
+ao
+ao
 bB
 bA
 bY
-aq
-aq
-cq
+ao
+ao
+ao
 ab
 ab
 ab
@@ -3044,16 +2695,16 @@ ab
 ab
 ab
 ab
-aq
-aq
+ao
+ao
 aB
 aC
-aq
-aq
-aq
+ao
+ao
+ao
 aR
-aq
-aq
+ao
+ao
 cf
 cj
 cr
@@ -3116,17 +2767,17 @@ ab
 ab
 ab
 ab
-aq
-aq
+ao
+ao
 aC
 aC
-aq
-aq
+ao
+ao
 ab
-aq
+ao
 aQ
-aq
-aq
+ao
+ao
 ab
 ab
 ab
@@ -3188,11 +2839,11 @@ ab
 ab
 ab
 ab
-aj
-aq
+ao
+ao
 aC
 aC
-aq
+ao
 ab
 ab
 ab
@@ -3260,11 +2911,11 @@ ab
 ab
 ab
 ab
-aj
-aw
+ao
+bk
 aC
 aC
-aq
+ao
 ab
 ab
 ab
@@ -3332,11 +2983,11 @@ ab
 ab
 ab
 ab
-af
-aj
+aQ
+ao
 ae
 ae
-aj
+ao
 ae
 ae
 ae
@@ -3404,11 +3055,11 @@ ab
 ab
 ab
 ad
-an
-an
+ao
+ao
 ae
 aH
-aS
+ao
 ba
 bl
 ae
@@ -3480,9 +3131,9 @@ ar
 ar
 ae
 aI
-aT
-aj
-bm
+aE
+ao
+bn
 ae
 ab
 aa
@@ -3548,12 +3199,12 @@ ab
 ab
 ab
 ad
-aj
-an
+ao
+ao
 ae
 aJ
-aS
-aS
+ao
+ao
 bn
 ae
 aC
@@ -3620,8 +3271,8 @@ ab
 ab
 ab
 ad
-an
-aj
+ao
+ao
 ae
 ae
 aU
@@ -3692,14 +3343,14 @@ ab
 ab
 ab
 ad
-af
-an
-an
-an
-an
-an
-an
-bC
+aQ
+ao
+ao
+ao
+ao
+ao
+ao
+bi
 aC
 aC
 aa
@@ -3764,14 +3415,14 @@ ab
 ab
 ab
 ad
-an
-an
-an
-an
+ao
+ao
+ao
+ao
 aV
-af
-an
-aj
+aQ
+ao
+ao
 aC
 aC
 aC
@@ -3836,8 +3487,8 @@ ab
 ab
 ab
 ad
-an
-an
+ao
+ao
 ae
 ae
 ae
@@ -3908,8 +3559,8 @@ ab
 ab
 ab
 ad
-an
-an
+ao
+ao
 ae
 aK
 aW
@@ -3918,11 +3569,11 @@ bo
 bD
 ae
 bZ
-aj
+ao
 cl
 ct
-an
-an
+ao
+ao
 ct
 cx
 cB
@@ -3980,21 +3631,21 @@ ab
 ab
 ab
 ad
-an
-an
+ao
+ao
 ae
 aL
 aX
 aX
-aY
+ao
 bE
 bq
-an
-aj
-aj
+ao
+ao
+ao
 ct
-an
-an
+ao
+ao
 bq
 cy
 cC
@@ -4052,16 +3703,16 @@ ad
 ad
 ad
 ad
-aj
-an
+ao
+ao
 aD
 aM
-aY
-aY
-aY
+ao
+ao
+ao
 bF
 bq
-an
+ao
 cg
 ae
 ae
@@ -4121,20 +3772,20 @@ ab
 ab
 ab
 ab
-af
-aj
-an
-an
-an
+aQ
+ao
+ao
+ao
+ao
 aD
 aN
-aY
-aY
-dr
+ao
+ao
+aR
 bG
 bq
-af
-an
+aQ
+ao
 bq
 aa
 aa
@@ -4195,18 +3846,18 @@ ab
 ab
 ab
 ab
-aj
-an
-an
+ao
+ao
+ao
 ae
 aL
 aX
 aX
-aY
+ao
 bH
 bq
-aj
-an
+ao
+ao
 bq
 aa
 cv
@@ -4268,8 +3919,8 @@ ae
 ae
 ae
 ae
-an
-an
+ao
+ao
 ae
 aO
 aZ
@@ -4277,8 +3928,8 @@ bc
 bp
 bI
 ae
-an
-an
+ao
+ao
 bq
 aa
 aa
@@ -4340,8 +3991,8 @@ ab
 ab
 ab
 ae
-af
-an
+aQ
+ao
 ae
 ae
 ae
@@ -4365,7 +4016,7 @@ do
 cU
 dB
 cR
-dU
+cq
 dU
 dU
 er
@@ -4412,17 +4063,17 @@ ab
 ab
 ab
 ae
-an
-an
-an
-an
-an
-an
+ao
+ao
+ao
+ao
+ao
+ao
 aD
-bJ
-bJ
-bJ
-ch
+ao
+ao
+ao
+ao
 cm
 ae
 aa
@@ -4485,17 +4136,17 @@ ae
 ae
 ae
 as
-an
-an
-an
-an
-an
+ao
+ao
+ao
+ao
+ao
 ae
-bK
-bV
+ao
+ci
 ca
-bV
-bJ
+ci
+ao
 bq
 aa
 aa
@@ -4560,14 +4211,14 @@ ae
 ae
 ae
 ae
-an
-an
+ao
+ao
 ae
 bL
 bW
 cb
 ci
-bJ
+ao
 bq
 aa
 aa
@@ -4626,20 +4277,20 @@ ab
 ab
 ae
 ah
-al
+bk
 ao
 ao
 ax
 aE
 aD
-an
-an
+ao
+ao
 bq
 bM
-bV
+ci
 cc
-bV
-bJ
+ci
+ao
 bq
 aa
 aa
@@ -4701,16 +4352,16 @@ ai
 am
 ap
 ao
-ay
+aQ
 ao
 aD
-af
-an
+aQ
+ao
 bq
 bN
-bJ
-bJ
-bJ
+ao
+ao
+ao
 cn
 ae
 aa
@@ -4776,8 +4427,8 @@ ao
 ao
 aF
 ae
-an
-an
+ao
+ao
 ae
 bq
 bq
@@ -4848,13 +4499,13 @@ at
 at
 ae
 ae
-an
-aj
-br
-an
-an
-an
-an
+ao
+ao
+ax
+ao
+ao
+ao
+ao
 bq
 aa
 aa
@@ -4919,14 +4570,14 @@ ae
 ae
 ae
 ae
-an
-an
-an
-aj
-aj
-aj
-an
-af
+ao
+ao
+ao
+ao
+ao
+ao
+ao
+aQ
 bq
 aa
 aa
@@ -4991,14 +4642,14 @@ ae
 ae
 ae
 ae
-aP
+aD
 ae
 ae
-aP
+aD
 ae
 ae
-an
-an
+ao
+ao
 bq
 aa
 aa
@@ -5060,17 +4711,17 @@ ab
 ab
 ab
 ae
-aw
-aj
-aj
-aw
+bk
+ao
+ao
+bk
 ae
 bd
-aj
+ao
 bO
 ae
-an
-an
+ao
+ao
 ae
 ae
 bq
@@ -5132,21 +4783,21 @@ ab
 ab
 ab
 ae
-aj
-aj
+ao
+ao
 aG
-aj
+ao
 ae
 be
 bs
 bP
 ae
-an
-af
+ao
+aQ
 co
 cu
-an
-an
+ao
+ao
 bq
 cw
 cG
@@ -5204,21 +4855,21 @@ ab
 ab
 ab
 ae
-aj
+ao
 az
-aj
-aj
+ao
+ao
 ae
 bf
 bt
 bQ
 ae
 cd
-an
-an
+ao
+ao
 cu
-an
-an
+ao
+ao
 cu
 cA
 cH
@@ -5277,9 +4928,9 @@ ab
 ab
 ae
 eI
-aj
-aj
-aj
+ao
+ao
+ao
 ae
 bg
 bu

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -9,7 +9,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "ac" = (
 /obj/floor_decal/industrial/warning{
@@ -18,7 +18,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "ad" = (
 /obj/shuttle_landmark/merc/nav3,
@@ -31,7 +31,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "af" = (
 /obj/shuttle_landmark/merc/nav2,
@@ -45,12 +45,12 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "ah" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "aj" = (
 /obj/paint/silver,
@@ -61,11 +61,11 @@
 /obj/machinery/vending/coffee{
 	prices = list()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "al" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "am" = (
 /obj/structure/hygiene/sink{
@@ -77,11 +77,11 @@
 	name = "Grimy Mirror";
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "an" = (
 /obj/structure/curtain/open/shower,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "ao" = (
 /obj/structure/hygiene/toilet{
@@ -91,13 +91,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "ap" = (
 /obj/structure/bed,
 /obj/structure/curtain/open/bed,
 /obj/item/bedsheet/hos,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "at" = (
 /obj/structure/table/steel_reinforced,
@@ -123,7 +123,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "av" = (
 /obj/structure/closet/crate,
@@ -138,7 +138,7 @@
 /obj/item/stock_parts/smes_coil,
 /obj/item/stock_parts/smes_coil,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "aw" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -163,13 +163,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = 25
 	},
-/turf/simulated/floor/tiled/white,
-/area/map_template/merc_spawn)
-"bj" = (
-/obj/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "bx" = (
 /obj/structure/cable{
@@ -198,7 +192,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "bW" = (
 /obj/floor_decal/industrial/warning{
@@ -207,11 +201,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/merc_spawn)
-"bZ" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "ck" = (
 /obj/structure/kitchenspike,
@@ -220,7 +210,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "cB" = (
 /obj/machinery/power/smes/buildable/preset{
@@ -235,7 +225,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "cC" = (
 /obj/paint/sun,
@@ -334,7 +324,7 @@
 /obj/floor_decal/techfloor{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "dc" = (
 /obj/floor_decal/industrial/warning{
@@ -346,7 +336,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "dn" = (
 /obj/machinery/disperser/middle{
@@ -359,16 +349,15 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "dt" = (
 /obj/random/junk,
 /obj/floor_decal/borderfloorwhite/full,
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "dv" = (
-/obj/floor_decal/corner/red,
 /obj/floor_decal/corner/black{
 	dir = 8
 	},
@@ -376,7 +365,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "dT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -385,13 +374,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "dY" = (
 /obj/floor_decal/techfloor{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "eh" = (
 /obj/floor_decal/techfloor{
@@ -400,7 +389,7 @@
 /obj/structure/bed/chair/shuttle/blue{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "em" = (
 /obj/structure/table/steel_reinforced,
@@ -446,11 +435,8 @@
 /obj/floor_decal/techfloor/corner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
-"ex" = (
-/turf/simulated/floor/tiled/steel_ridged,
-/area/map_template/merc_spawn)
 "ey" = (
 /obj/structure/bed/chair/shuttle/blue{
 	dir = 4
@@ -461,7 +447,7 @@
 /obj/floor_decal/techfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "eG" = (
 /obj/machinery/disperser/back{
@@ -479,7 +465,6 @@
 /obj/structure/table/rack{
 	pixel_x = -1
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/item/storage/box/handcuffs{
 	pixel_x = 4;
 	pixel_y = 2
@@ -517,13 +502,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "fi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "fB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -532,7 +517,7 @@
 /obj/floor_decal/techfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -547,7 +532,7 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "fW" = (
 /obj/floor_decal/industrial/warning{
@@ -559,11 +544,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/map_template/merc_spawn)
-"ga" = (
-/obj/floor_decal/corner/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "gc" = (
 /obj/structure/handrail{
@@ -575,7 +556,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "gd" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -608,11 +589,11 @@
 /obj/floor_decal/techfloor/corner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "gF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "gK" = (
 /obj/machinery/door/airlock/external{
@@ -635,7 +616,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_spawn)
 "gX" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "gY" = (
 /obj/structure/cable{
@@ -649,7 +630,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "hr" = (
 /obj/structure/bed/chair/shuttle/blue{
@@ -702,7 +683,8 @@
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "hR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -717,7 +699,7 @@
 /obj/floor_decal/industrial/loading{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "hU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -735,7 +717,8 @@
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "ia" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -744,7 +727,7 @@
 /obj/floor_decal/techfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "ib" = (
 /obj/machinery/door/airlock/glass/civilian{
@@ -762,16 +745,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "it" = (
-/obj/floor_decal/corner/red{
-	dir = 9
-	},
 /obj/floor_decal/corner/black{
 	dir = 6
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "iP" = (
 /obj/machinery/vending/snack{
@@ -814,7 +794,7 @@
 /obj/floor_decal/techfloor/corner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "jt" = (
 /obj/machinery/shipsensors,
@@ -837,12 +817,9 @@
 /obj/structure/hygiene/shower{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "jJ" = (
-/obj/floor_decal/corner/orange/border{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -851,12 +828,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "jK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "jQ" = (
 /obj/machinery/power/terminal{
@@ -887,20 +864,17 @@
 	pixel_x = 22;
 	pixel_y = -11
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
-"kb" = (
-/turf/simulated/floor/tiled/dark,
-/area/map_template/merc_spawn)
 "kg" = (
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "kx" = (
 /obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "kF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -914,13 +888,13 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_SYNDICATE")
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "kQ" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "kR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -943,19 +917,16 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "kV" = (
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
 /obj/floor_decal/corner/black{
 	dir = 9
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "kW" = (
 /obj/machinery/atmospherics/unary/tank/air{
@@ -965,7 +936,7 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "kZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -979,7 +950,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "ld" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1000,8 +971,7 @@
 /area/map_template/merc_shuttle)
 "lg" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "lh" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -1014,12 +984,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "lo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "lq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1066,15 +1036,12 @@
 /obj/floor_decal/techfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "lX" = (
-/obj/floor_decal/corner/blue{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "md" = (
 /obj/wallframe_spawn/reinforced/titanium,
@@ -1187,12 +1154,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
-"mK" = (
-/obj/floor_decal/corner/blue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/map_template/merc_spawn)
 "nd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1203,7 +1164,7 @@
 /obj/floor_decal/techfloor/corner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "ne" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1243,13 +1204,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "nI" = (
 /obj/floor_decal/techfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "nL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -1280,13 +1241,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle)
 "nY" = (
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
 /obj/floor_decal/corner/black{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "ob" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -1352,11 +1310,10 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "oK" = (
-/obj/floor_decal/corner/blue/mono,
 /obj/structure/table/standard,
 /obj/item/paper/merc/tutorial_1,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "oT" = (
 /obj/machinery/alarm{
@@ -1364,28 +1321,25 @@
 	pixel_y = -24;
 	req_access = list("ACCESS_SYNDICATE")
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "oW" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "oX" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/floor_decal/corner/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "oY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "pb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1397,7 +1351,7 @@
 /obj/floor_decal/techfloor/corner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "pc" = (
 /obj/structure/table/steel,
@@ -1420,7 +1374,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "ph" = (
 /obj/wallframe_spawn/reinforced/titanium,
@@ -1453,7 +1407,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "pt" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -1500,11 +1454,10 @@
 	locked = 0;
 	req_access = list("ACCESS_SYNDICATE")
 	},
-/obj/item/gun/energy/lasgun/laspistol/militarum,
-/obj/item/gun/energy/lasgun/laspistol/militarum,
-/obj/item/gun/energy/lasgun/laspistol/grim,
-/obj/item/gun/energy/lasgun/laspistol/grim,
-/obj/item/gun/energy/plasma/pistol,
+/obj/random/loot/lasbundle,
+/obj/random/loot/lasbundle,
+/obj/random/loot/armorinsertsrare,
+/obj/random/loot/armorinsertsrare,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "qj" = (
@@ -1562,7 +1515,7 @@
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "qY" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -1579,7 +1532,6 @@
 /obj/item/clothing/glasses/night,
 /obj/item/clothing/glasses/night,
 /obj/item/clothing/glasses/night,
-/obj/floor_decal/corner/red/mono,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1593,8 +1545,7 @@
 /obj/item/rig/merc/heavy/empty,
 /obj/item/cell/super,
 /obj/item/cell/super,
-/obj/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "rt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -1629,7 +1580,7 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_SYNDICATE")
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_shuttle)
 "rG" = (
 /obj/machinery/body_scanconsole{
@@ -1642,13 +1593,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_shuttle)
-"rK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/merc_spawn)
 "rL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/window/reinforced/crescent{
@@ -1683,20 +1629,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_shuttle)
 "sO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_shuttle)
 "sS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_shuttle)
 "sX" = (
 /obj/floor_decal/industrial/warning{
@@ -1708,7 +1654,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "ta" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
@@ -1718,7 +1664,7 @@
 /obj/machinery/telecomms/allinone{
 	intercept = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "tt" = (
 /obj/machinery/light/small{
@@ -1726,14 +1672,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
-/area/map_template/merc_spawn)
-"tO" = (
-/obj/floor_decal/corner/purple/half{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
 /area/map_template/merc_spawn)
 "tS" = (
 /obj/structure/table/rack{
@@ -1745,13 +1683,12 @@
 /obj/item/tank/jetpack/oxygen,
 /obj/item/tank/jetpack/oxygen,
 /obj/item/tank/jetpack/oxygen,
-/obj/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "tY" = (
 /obj/floor_decal/corner_techfloor_grid,
 /obj/floor_decal/techfloor/corner,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "uq" = (
 /turf/simulated/floor/tiled/dark/monotile,
@@ -1802,21 +1739,33 @@
 /obj/item/reagent_containers/glass/bottle/kelotane,
 /obj/item/reagent_containers/glass/bottle/kelotane,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_shuttle)
 "uM" = (
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
 	dir = 4;
 	name = "Cryostorage"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "uS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_shuttle)
+"uU" = (
+/obj/structure/closet,
+/obj/item/storage/belt/security,
+/obj/item/storage/belt/holster/security/tactical,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/random/loot/raresidearmbundle,
+/obj/random/loot/raregunslug,
+/obj/item/grenade/frag/high_yield,
+/obj/item/grenade/spawnergrenade/viscerator,
+/obj/item/grenade/chem_grenade/teargas,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/merc_spawn)
 "uV" = (
 /obj/paint/silver,
 /obj/structure/cable{
@@ -1854,7 +1803,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "vm" = (
 /obj/machinery/door/airlock,
@@ -1862,7 +1811,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/merc_shuttle)
 "vn" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "vs" = (
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
@@ -1877,7 +1826,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "vA" = (
 /obj/machinery/vitals_monitor,
@@ -1906,12 +1855,9 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "vN" = (
-/obj/floor_decal/corner/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "vO" = (
 /obj/structure/catwalk,
@@ -1928,7 +1874,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_shuttle)
 "wx" = (
 /obj/machinery/atmospherics/unary/tank/air{
@@ -1950,7 +1896,7 @@
 "wL" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/floor_decal/borderfloorwhite/full,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "wM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -1986,7 +1932,7 @@
 /area/map_template/merc_spawn)
 "xo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "xp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2020,10 +1966,10 @@
 /obj/item/reagent_containers/ivbag/nanoblood,
 /obj/item/storage/firstaid/adv,
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_shuttle)
 "xD" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_shuttle)
 "xT" = (
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
@@ -2036,13 +1982,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "yk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "ym" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
@@ -2138,7 +2084,7 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/map_template/merc_shuttle)
 "zj" = (
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "zu" = (
 /obj/machinery/bodyscanner{
@@ -2165,8 +2111,7 @@
 /area/map_template/merc_shuttle)
 "zJ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "zK" = (
 /obj/structure/cable/green{
@@ -2175,20 +2120,20 @@
 	icon_state = "1-2"
 	},
 /obj/floor_decal/techfloor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "zM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "zT" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "zW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2210,7 +2155,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "Ak" = (
 /obj/floor_decal/industrial/warning{
@@ -2231,7 +2176,7 @@
 /area/map_template/merc_spawn)
 "AB" = (
 /obj/floor_decal/borderfloorwhite/full,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "AF" = (
 /obj/paint/merc,
@@ -2282,7 +2227,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "Bh" = (
 /obj/machinery/radio_beacon,
@@ -2330,7 +2275,7 @@
 /obj/floor_decal/techfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "BK" = (
 /obj/floor_decal/industrial/warning/corner,
@@ -2354,7 +2299,7 @@
 /obj/floor_decal/corner/b_green{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Ct" = (
 /obj/spawner/newbomb/timer/syndicate,
@@ -2374,7 +2319,6 @@
 /obj/landmark/delete_on_shuttle{
 	shuttle_name = "Desperado"
 	},
-/obj/floor_decal/corner/red/mono,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -2388,13 +2332,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
+/area/map_template/merc_spawn)
+"CC" = (
+/obj/structure/closet,
+/obj/item/storage/belt/security,
+/obj/item/storage/belt/holster/security/tactical,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/random/loot/raresidearmbundle,
+/obj/random/loot/lasbundle,
+/obj/item/grenade/frag/high_yield,
+/obj/item/grenade/supermatter,
+/obj/item/grenade/chem_grenade/teargas,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_spawn)
 "CE" = (
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "CQ" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -2422,11 +2378,20 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "Dk" = (
-/obj/floor_decal/corner/orange/border{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/plating,
+/area/map_template/merc_spawn)
+"Dm" = (
+/obj/structure/closet,
+/obj/item/storage/belt/security,
+/obj/item/storage/belt/holster/security/tactical,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/random/loot/raresidearmbundle,
+/obj/random/loot/raregunsenergy,
+/obj/item/grenade/frag/high_yield,
+/obj/item/grenade/empgrenade/low_yield,
+/obj/item/grenade/empgrenade/low_yield,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_spawn)
 "Do" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2435,11 +2400,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "Ds" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "DE" = (
 /obj/machinery/power/debug_items/infinite_generator,
@@ -2456,8 +2421,7 @@
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
-/obj/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "DI" = (
 /obj/spawner/newbomb/timer/syndicate,
@@ -2477,7 +2441,6 @@
 /obj/landmark/delete_on_shuttle{
 	shuttle_name = "Desperado"
 	},
-/obj/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_spawn)
 "Eh" = (
@@ -2489,20 +2452,14 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_spawn)
-"ER" = (
-/turf/simulated/floor/tiled/white,
-/area/map_template/merc_spawn)
 "EU" = (
-/obj/floor_decal/corner/purple/half{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "EV" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -2520,29 +2477,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "Fx" = (
 /obj/shuttle_landmark/merc/nav4,
 /turf/space,
 /area/space)
 "Fy" = (
-/obj/floor_decal/corner/purple/half,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/merc_spawn)
-"FC" = (
-/obj/floor_decal/corner/purple/half,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "FR" = (
 /obj/floor_decal/techfloor{
@@ -2551,19 +2497,16 @@
 /obj/machinery/computer/ship/sensors/spacer{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "Gl" = (
-/obj/floor_decal/corner/blue{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Gn" = (
 /obj/structure/closet/fridge/meat,
@@ -2573,7 +2516,7 @@
 /obj/item/reagent_containers/food/snacks/meat,
 /obj/item/reagent_containers/food/snacks/meat,
 /obj/floor_decal/borderfloorwhite/full,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "Gx" = (
 /obj/floor_decal/techfloor{
@@ -2584,23 +2527,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "GB" = (
-/obj/floor_decal/corner/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/merc_spawn)
-"GG" = (
-/obj/floor_decal/corner/red,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "GN" = (
 /obj/machinery/door/airlock/glass/civilian{
@@ -2612,27 +2548,17 @@
 /obj/machinery/door/airlock{
 	name = "cold storage"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/map_template/merc_spawn)
-"GQ" = (
-/obj/floor_decal/corner/blue/three_quarters,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "Hr" = (
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Hw" = (
-/obj/floor_decal/corner/purple{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Ih" = (
 /obj/paint/silver,
@@ -2641,7 +2567,7 @@
 "ID" = (
 /obj/floor_decal/borderfloorwhite/full,
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "IO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2649,7 +2575,7 @@
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "Jc" = (
 /obj/wallframe_spawn/reinforced/titanium,
@@ -2663,16 +2589,24 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "Jr" = (
-/obj/floor_decal/corner/purple{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
+/area/map_template/merc_spawn)
+"JL" = (
+/obj/structure/closet,
+/obj/item/storage/belt/security,
+/obj/item/storage/belt/holster/security/tactical,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/random/loot/raresidearmbundle,
+/obj/random/loot/raregunslug,
+/obj/item/grenade/frag/high_yield/krak,
+/obj/item/grenade/chem_grenade/teargas,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_spawn)
 "JP" = (
 /obj/structure/hygiene/shower{
@@ -2681,7 +2615,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "JQ" = (
 /obj/structure/hygiene/sink{
@@ -2691,26 +2625,25 @@
 /obj/item/vox_changer/merc{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "KT" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Lb" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "Mp" = (
-/obj/floor_decal/corner/blue/mono,
 /obj/structure/table/standard,
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/paper/merc/tutorial_3,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Mq" = (
 /obj/machinery/light{
@@ -2719,54 +2652,41 @@
 /obj/floor_decal/corner/b_green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Mt" = (
-/obj/floor_decal/corner/blue/mono,
 /obj/machinery/suit_cycler/syndicate{
 	locked = 0
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "MK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
-"MS" = (
-/obj/floor_decal/corner/purple{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/map_template/merc_spawn)
 "MV" = (
-/obj/floor_decal/corner/red{
-	dir = 8
-	},
 /obj/floor_decal/corner/black,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "MW" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "MZ" = (
-/obj/floor_decal/corner/red{
-	dir = 6
-	},
 /obj/floor_decal/corner/black{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Ni" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Nn" = (
 /obj/structure/closet/fridge/meat,
@@ -2777,7 +2697,7 @@
 /obj/item/reagent_containers/food/snacks/meat,
 /obj/floor_decal/borderfloorwhite/full,
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "NK" = (
 /obj/item/storage/box/smokes,
@@ -2790,7 +2710,6 @@
 /obj/item/grenade/anti_photon,
 /obj/item/grenade/anti_photon,
 /obj/item/storage/box/frags,
-/obj/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_spawn)
 "NW" = (
@@ -2803,7 +2722,6 @@
 /obj/item/clothing/head/helmet/merc,
 /obj/item/clothing/head/helmet/merc,
 /obj/item/clothing/head/helmet/merc,
-/obj/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_spawn)
 "Oj" = (
@@ -2813,7 +2731,7 @@
 /obj/floor_decal/techfloor/corner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "Oo" = (
 /obj/paint/merc,
@@ -2824,14 +2742,11 @@
 /turf/simulated/wall/titanium,
 /area/map_template/merc_shuttle)
 "Oq" = (
-/obj/floor_decal/corner/red{
-	dir = 9
-	},
 /obj/floor_decal/corner/black{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "OD" = (
 /obj/machinery/door/airlock/glass/civilian{
@@ -2848,19 +2763,16 @@
 "PC" = (
 /obj/random/junk,
 /obj/floor_decal/borderfloorwhite/full,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "Qg" = (
-/obj/floor_decal/corner/purple/half{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Qi" = (
 /obj/structure/table/rack{
@@ -2880,14 +2792,14 @@
 /obj/floor_decal/techfloor{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "Qr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad/longrange,
 /obj/floor_decal/techfloor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "Qs" = (
 /obj/floor_decal/techfloor{
@@ -2898,7 +2810,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "Rb" = (
 /obj/structure/table/rack{
@@ -2909,7 +2821,7 @@
 /obj/item/clothing/gloves/vox,
 /obj/item/clothing/gloves/vox,
 /obj/floor_decal/borderfloorwhite/full,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "RH" = (
 /obj/structure/cable{
@@ -2931,6 +2843,12 @@
 /obj/item/storage/belt/security,
 /obj/item/storage/belt/holster/security/tactical,
 /obj/item/clothing/accessory/storage/holster/thigh,
+/obj/random/loot/raresidearmbundle,
+/obj/random/loot/raregunsenergy,
+/obj/item/grenade/frag/high_yield/krak,
+/obj/item/grenade/spawnergrenade/viscerator,
+/obj/item/grenade/chem_grenade/teargas,
+/obj/item/grenade/chem_grenade/incendiary,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_spawn)
 "RX" = (
@@ -2939,7 +2857,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Sf" = (
 /obj/structure/cable{
@@ -2964,13 +2882,9 @@
 /obj/paint/merc,
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
-"SW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/map_template/merc_spawn)
 "TF" = (
 /obj/floor_decal/techfloor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "TK" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -3001,7 +2915,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "TR" = (
 /obj/machinery/vending/fitness{
@@ -3015,28 +2929,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/map_template/merc_spawn)
-"UK" = (
-/obj/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "UR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/map_template/merc_spawn)
-"Vt" = (
-/obj/floor_decal/corner/blue/three_quarters{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "VJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3047,7 +2946,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_shuttle)
 "Wr" = (
 /obj/structure/table/rack{
@@ -3058,7 +2957,7 @@
 /obj/item/clothing/suit/space/vox/carapace,
 /obj/item/clothing/suit/space/vox/carapace,
 /obj/floor_decal/borderfloorwhite/full,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "WX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
@@ -3075,14 +2974,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "WZ" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Xa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3091,7 +2990,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Xt" = (
 /obj/structure/cable{
@@ -3104,11 +3003,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_spawn)
-"XJ" = (
-/obj/floor_decal/corner/purple{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+"Xy" = (
+/obj/structure/closet,
+/obj/item/storage/belt/security,
+/obj/item/storage/belt/holster/security/tactical,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/random/loot/raresidearmbundle,
+/obj/random/loot/raregunslug,
+/obj/item/grenade/frag/high_yield/plasma,
+/obj/item/grenade/chem_grenade/teargas,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_spawn)
 "XL" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -3119,13 +3023,7 @@
 	dir = 1;
 	pixel_y = 16
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/map_template/merc_spawn)
-"Ya" = (
-/obj/floor_decal/corner/orange/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "Yq" = (
 /obj/structure/table/rack{
@@ -3135,8 +3033,7 @@
 /obj/item/rig/merc/empty,
 /obj/item/cell/super,
 /obj/item/cell/super,
-/obj/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "Yv" = (
 /obj/machinery/door/airlock{
@@ -3148,22 +3045,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/map_template/merc_spawn)
-"YF" = (
-/obj/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "YI" = (
-/obj/floor_decal/corner/red{
-	dir = 9
-	},
 /obj/floor_decal/corner/black{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "YX" = (
 /obj/machinery/power/apc/hyper{
@@ -3175,14 +3063,14 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "YZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/surgerynew,
 /area/map_template/merc_spawn)
 "Zl" = (
 /turf/simulated/mineral,
@@ -3211,13 +3099,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/merc_spawn)
-"ZO" = (
-/obj/floor_decal/corner/red{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 "ZX" = (
 /obj/structure/cable{
@@ -3233,7 +3115,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/merc_spawn)
 
 (1,1,1) = {"
@@ -7065,7 +6947,7 @@ mo
 az
 az
 mo
-Ya
+vn
 jJ
 Dk
 Di
@@ -7167,7 +7049,7 @@ ev
 dc
 UR
 mo
-SW
+gF
 bx
 TX
 mo
@@ -7262,16 +7144,16 @@ aa
 Zl
 Zl
 aj
-ER
+zj
 CB
 eR
 ev
 fW
-ER
+zj
 GN
 vn
 yD
-ga
+vn
 mo
 rb
 zJ
@@ -7373,10 +7255,10 @@ dq
 mo
 vn
 yD
-YF
+vn
 ib
-bj
-GQ
+vn
+yk
 Mp
 mo
 Zl
@@ -7466,7 +7348,7 @@ mo
 ap
 KT
 mo
-ex
+zj
 xT
 mo
 mo
@@ -7477,7 +7359,7 @@ Mq
 oI
 lX
 CZ
-rK
+lX
 Gl
 Mt
 mo
@@ -7566,21 +7448,21 @@ aa
 Zl
 mo
 kx
-kb
+vn
 Hr
 gF
 Fy
 RT
-RT
+CC
 Qg
 fi
 mo
 TR
 yD
-YF
+vn
 ib
-UK
-Vt
+vn
+zM
 oK
 mo
 Zl
@@ -7668,18 +7550,18 @@ aa
 Zl
 mo
 ap
-kb
+vn
 mo
-kb
-FC
-RT
-RT
+vn
 EU
-kb
+uU
+Xy
+EU
+vn
 mo
 iP
 yD
-mK
+vn
 mo
 tS
 lg
@@ -7770,14 +7652,14 @@ aa
 Zl
 mo
 ap
-kb
+vn
 mo
 kQ
-FC
-RT
-RT
 EU
-bZ
+JL
+Dm
+EU
+Ds
 mo
 EV
 yD
@@ -7872,18 +7754,18 @@ Zl
 Zl
 mo
 kx
-kb
+vn
 Hr
-kb
-FC
+vn
+EU
 Qi
 hz
 EU
-kb
+vn
 mo
 Ci
 yD
-GG
+vn
 mo
 NW
 qZ
@@ -7978,8 +7860,8 @@ vf
 mo
 oW
 GB
-tO
-tO
+lX
+lX
 vN
 fe
 mo
@@ -8182,14 +8064,14 @@ mo
 ak
 oX
 Hw
-XJ
-MS
+vn
+vn
 Jr
-XJ
+vn
 Ni
 vn
 yD
-ZO
+vn
 mo
 NK
 Ct

--- a/maps/antag_spawn/ninja/ninja_base.dmm
+++ b/maps/antag_spawn/ninja/ninja_base.dmm
@@ -49,15 +49,11 @@
 "ak" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/surgery,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "al" = (
 /obj/machinery/optable,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "am" = (
 /obj/structure/closet/medical_wall{
@@ -74,9 +70,7 @@
 /obj/item/reagent_containers/glass/bottle/stoxin,
 /obj/item/reagent_containers/glass/bottle/stoxin,
 /obj/item/reagent_containers/syringe,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "an" = (
 /obj/structure/table/glass,
@@ -90,42 +84,30 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ao" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ap" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aq" = (
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/structure/table/glass,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ar" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/sterilizine,
 /obj/item/reagent_containers/spray/cleaner,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "as" = (
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "at" = (
 /obj/structure/table/glass,
@@ -139,18 +121,14 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
 /obj/floor_decal/corner/blue,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "av" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -159,16 +137,12 @@
 /obj/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aw" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ax" = (
 /obj/machinery/computer/teleporter,
@@ -196,9 +170,7 @@
 /obj/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aB" = (
 /obj/structure/table/glass,
@@ -208,9 +180,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aC" = (
 /obj/structure/table/glass,
@@ -225,9 +195,7 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aD" = (
 /obj/item/reagent_containers/glass/beaker/large,
@@ -235,17 +203,13 @@
 	dir = 4
 	},
 /obj/machinery/chemical_dispenser/full,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aE" = (
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aF" = (
 /obj/floor_decal/industrial/warning{
@@ -255,9 +219,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aG" = (
 /obj/machinery/cryopod{
@@ -284,9 +246,7 @@
 "aI" = (
 /obj/structure/iv_stand,
 /obj/structure/window/reinforced/crescent,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aJ" = (
 /obj/structure/table/glass,
@@ -296,17 +256,13 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/crescent,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aK" = (
 /obj/floor_decal/corner/blue{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aL" = (
 /obj/machinery/door/blast/regular/open{
@@ -321,25 +277,19 @@
 "aM" = (
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/chem_master,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aN" = (
 /obj/floor_decal/corner/black/border{
 	dir = 7
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aO" = (
 /obj/floor_decal/corner/blue{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aQ" = (
 /obj/structure/table/glass,
@@ -348,15 +298,13 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aR" = (
 /obj/machinery/bodyscanner{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aS" = (
 /obj/machinery/body_scanconsole{
@@ -365,9 +313,7 @@
 /obj/floor_decal/corner/blue{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aT" = (
 /obj/floor_decal/corner/blue{
@@ -379,33 +325,25 @@
 /obj/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aU" = (
 /obj/floor_decal/industrial/outline/blue,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aV" = (
 /obj/floor_decal/corner/black/border{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aW" = (
 /obj/structure/table/rack,
 /obj/item/tank/oxygen,
 /obj/item/tank/oxygen,
 /obj/item/tank/oxygen,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "aX" = (
 /obj/machinery/door/blast/regular/open{
@@ -414,42 +352,28 @@
 	},
 /turf/unsimulated/wall,
 /area/map_template/ninja_dojo/dojo)
-"aY" = (
-/turf/unsimulated/floor{
-	dir = 9;
-	icon_state = "vault"
-	},
-/area/map_template/ninja_dojo/dojo)
 "aZ" = (
 /obj/structure/table/rack,
 /obj/item/storage/belt/medical/emt,
 /obj/item/storage/firstaid/adv,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ba" = (
 /obj/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bb" = (
 /obj/floor_decal/industrial/outline/blue,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bc" = (
 /obj/floor_decal/corner/black/border{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bd" = (
 /turf/simulated/wall/prepainted,
@@ -480,18 +404,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bi" = (
 /obj/machinery/light,
 /obj/floor_decal/corner/black/bordercorner{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bj" = (
 /obj/structure/bed/chair/office/dark,
@@ -499,7 +419,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bl" = (
 /obj/floor_decal/industrial/warning{
@@ -516,9 +436,7 @@
 /obj/item/tank/nitrogen,
 /obj/item/tank/nitrogen,
 /obj/item/tank/nitrogen,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bn" = (
 /turf/unsimulated/floor{
@@ -548,7 +466,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "br" = (
 /obj/floor_decal/corner/black/border{
@@ -557,9 +475,7 @@
 /obj/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bs" = (
 /obj/machinery/light{
@@ -571,9 +487,7 @@
 /obj/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bt" = (
 /obj/structure/pit/closed/grave,
@@ -588,23 +502,11 @@
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bv" = (
 /obj/floor_decal/corner/blue,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/ninja_dojo/dojo)
-"bw" = (
-/obj/floor_decal/corner/black/border{
-	dir = 7
-	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bx" = (
 /obj/machinery/recharger/wallcharger{
@@ -612,9 +514,7 @@
 	pixel_x = -23;
 	pixel_y = -3
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "by" = (
 /obj/landmark{
@@ -637,17 +537,13 @@
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bA" = (
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bB" = (
 /obj/floor_decal/corner/black/bordercorner{
@@ -656,9 +552,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bC" = (
 /obj/machinery/door/airlock/centcom{
@@ -675,9 +569,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bE" = (
 /obj/floor_decal/corner/black/border{
@@ -688,17 +580,13 @@
 	name = "emergency alarm";
 	on = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bF" = (
 /obj/floor_decal/corner/black/border{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bG" = (
 /obj/floor_decal/corner/black/bordercorner{
@@ -707,9 +595,7 @@
 /obj/floor_decal/corner/black/bordercorner{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bH" = (
 /obj/floor_decal/industrial/warning{
@@ -732,17 +618,13 @@
 	id_tag = "prototype_chamber_blast"
 	},
 /obj/floor_decal/floordetail/tiled,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bJ" = (
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bK" = (
 /obj/floor_decal/corner/black/bordercorner{
@@ -751,9 +633,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bL" = (
 /obj/floor_decal/industrial/warning{
@@ -774,9 +654,7 @@
 	name = "emergency alarm";
 	on = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bN" = (
 /obj/machinery/cryopod{
@@ -793,32 +671,22 @@
 	name = "plating"
 	},
 /area/map_template/ninja_dojo/dojo)
-"bO" = (
-/obj/paint_stripe/yellow,
-/turf/simulated/wall/prepainted,
-/area/map_template/ninja_dojo/dojo)
 "bP" = (
 /obj/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bQ" = (
 /obj/floor_decal/corner/black/border{
 	dir = 5
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bR" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/contraband/chameleon,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bS" = (
 /obj/floor_decal/asteroid,
@@ -833,9 +701,7 @@
 	dir = 4;
 	icon_state = "warningcorner"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bU" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -854,9 +720,7 @@
 	dir = 4;
 	icon_state = "warningcorner"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bW" = (
 /obj/machinery/light{
@@ -866,28 +730,24 @@
 	dir = 2;
 	icon_state = "warningcorner"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bX" = (
 /obj/floor_decal/industrial/warning{
 	icon_state = "warning"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "bZ" = (
 /obj/wallframe_spawn/reinforced,
-/turf/space,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ca" = (
 /obj/structure/table/glass,
 /obj/floor_decal/corner/black/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cb" = (
 /obj/machinery/computer/modular/preset/medical,
@@ -895,25 +755,20 @@
 /obj/floor_decal/corner/black/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ce" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Equipment"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cf" = (
 /obj/floor_decal/corner/black/bordercorner{
 	dir = 7
 	},
 /obj/machinery/light,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/ninja_dojo/dojo)
-"cg" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ch" = (
 /obj/structure/bed/chair/office/dark{
@@ -923,7 +778,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ci" = (
 /obj/floor_decal/corner/black/border{
@@ -938,9 +793,7 @@
 /obj/item/stack/material/steel/fifty,
 /obj/item/stack/material/titanium/fifty,
 /obj/item/stack/material/glass/fifty,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cj" = (
 /obj/machinery/rotating_alarm/supermatter{
@@ -948,9 +801,7 @@
 	name = "emergency alarm";
 	on = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ck" = (
 /obj/paint/black,
@@ -961,18 +812,14 @@
 	dir = 9
 	},
 /obj/machinery/fabricator/hacked,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cm" = (
 /obj/floor_decal/corner/black/border{
 	dir = 10
 	},
 /obj/machinery/fabricator/hacked,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cn" = (
 /obj/floor_decal/industrial/warning{
@@ -993,20 +840,13 @@
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/map_template/ninja_dojo/dojo)
-"cp" = (
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cq" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cr" = (
 /obj/machinery/rotating_alarm/supermatter{
@@ -1014,9 +854,7 @@
 	name = "emergency alarm";
 	on = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cs" = (
 /obj/structure/table/rack,
@@ -1024,9 +862,7 @@
 	pixel_x = 9;
 	pixel_y = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cu" = (
 /obj/floor_decal/industrial/warning{
@@ -1045,27 +881,21 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cw" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cy" = (
 /obj/structure/table/rack,
 /obj/item/storage/belt/utility/full,
 /obj/item/device/multitool,
 /obj/item/tape_roll,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cz" = (
 /obj/floor_decal/snow,
@@ -1081,9 +911,7 @@
 /obj/structure/table/rack,
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/smokes,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cB" = (
 /obj/machinery/light,
@@ -1110,9 +938,7 @@
 /obj/floor_decal/corner/black/bordercorner{
 	dir = 3
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "cE" = (
 /obj/machinery/door/blast/regular/open{
@@ -1120,12 +946,6 @@
 	name = "Operative Cryo Chamber"
 	},
 /turf/unsimulated/wall,
-/area/map_template/ninja_dojo/dojo)
-"cF" = (
-/obj/wallframe_spawn/reinforced,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
 /area/map_template/ninja_dojo/dojo)
 "cG" = (
 /obj/floor_decal/industrial/warning{
@@ -1136,9 +956,7 @@
 	dir = 1
 	},
 /obj/structure/table/rack,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cH" = (
 /obj/machinery/computer/teleporter,
@@ -1164,9 +982,7 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cL" = (
 /obj/structure/bed/chair{
@@ -1177,40 +993,30 @@
 	icon_state = "tube1"
 	},
 /obj/floor_decal/industrial/outline/grey,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cM" = (
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cN" = (
 /obj/floor_decal/industrial/warning/corner{
 	dir = 4;
 	icon_state = "warningcorner"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cO" = (
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cP" = (
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cQ" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -1224,9 +1030,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cR" = (
 /obj/machinery/door/airlock/external{
@@ -1241,24 +1045,18 @@
 	name = "Blast Door";
 	opacity = 0
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cS" = (
 /obj/machinery/sleeper{
 	dir = 4
 	},
 /obj/floor_decal/industrial/outline/grey,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cT" = (
 /obj/shuttle_landmark/ninja/start,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1273,9 +1071,7 @@
 	pixel_y = 25;
 	req_access = list("ACCESS_SYNDICATE")
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1286,9 +1082,7 @@
 	id_tag = "ninja_shuttle_inner";
 	name = "Ship External Access"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cW" = (
 /obj/machinery/airlock_sensor{
@@ -1306,9 +1100,7 @@
 	name = "remote shutter control";
 	pixel_x = 25
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cX" = (
 /obj/structure/closet,
@@ -1317,16 +1109,12 @@
 	icon_state = "tube1"
 	},
 /obj/floor_decal/industrial/outline/grey,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cY" = (
 /obj/structure/table/rack,
 /obj/floor_decal/industrial/outline/grey,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "cZ" = (
 /obj/structure/table/steel_reinforced,
@@ -1342,15 +1130,11 @@
 /obj/item/screwdriver,
 /obj/floor_decal/industrial/outline/grey,
 /obj/item/toy/figure/ninja,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "da" = (
 /obj/structure/bed/chair/shuttle,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "db" = (
 /obj/machinery/button/blast_door{
@@ -1364,9 +1148,7 @@
 	pixel_x = -24;
 	pixel_y = -25
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "dc" = (
 /obj/structure/table/steel_reinforced,
@@ -1377,27 +1159,21 @@
 	icon_state = "tube1"
 	},
 /obj/floor_decal/industrial/outline/grey,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "dd" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/computer/station_alert/all{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "de" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/computer/shuttle_control/multi/ninja{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "df" = (
 /obj/floor_decal/industrial/outline/grey,
@@ -1405,9 +1181,7 @@
 	dir = 1;
 	icon_state = "console"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/start)
 "dg" = (
 /obj/machinery/door/blast/regular{
@@ -1424,9 +1198,7 @@
 /obj/structure/table/rack,
 /obj/item/clothing/mask/gas/swat/vox,
 /obj/item/clothing/mask/gas/swat/vox,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "qc" = (
 /obj/floor_decal/corner/blue{
@@ -1436,9 +1208,7 @@
 	dir = 5
 	},
 /obj/floor_decal/corner/blue,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "ss" = (
 /turf/unsimulated/wall,
@@ -1448,18 +1218,14 @@
 	dir = 8
 	},
 /obj/floor_decal/corner/blue,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "vP" = (
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "vQ" = (
 /obj/machinery/light{
@@ -1469,9 +1235,7 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "wG" = (
 /obj/floor_decal/corner/black/border{
@@ -1486,9 +1250,7 @@
 /obj/item/stack/material/steel/fifty,
 /obj/item/stack/material/titanium/fifty,
 /obj/item/stack/material/plastic/fifty,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "wX" = (
 /obj/structure/table/glass,
@@ -1496,7 +1258,7 @@
 	dir = 1
 	},
 /obj/item/newspaper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "zr" = (
 /obj/floor_decal/snow,
@@ -1507,31 +1269,38 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "Cj" = (
 /obj/structure/table/rack,
-/obj/random/biggun,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/obj/random/loot/swordmelee,
+/obj/random/loot/raresidearmbundle,
+/obj/random/loot/raresidearmbundle,
+/turf/simulated/floor/warhammer/metal/alt,
+/area/map_template/ninja_dojo/dojo)
+"Fw" = (
+/obj/structure/table/rack,
+/obj/random/loot/swordmelee,
+/obj/random/loot/randomsupply/engineering,
+/obj/random/loot/randomsupply/tech,
+/obj/random/loot/raregunslug,
+/obj/random/loot/raregunslug,
+/obj/random/loot/lootcontraband,
+/obj/random/loot/lootartifacts,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "Hl" = (
 /obj/structure/table/glass,
 /obj/floor_decal/corner/black/border{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "JH" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/gas/swat,
 /obj/item/clothing/mask/gas/swat,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "JM" = (
 /obj/machinery/door/blast/regular/open{
@@ -1539,48 +1308,36 @@
 	id_tag = "prototype_chamber_blast"
 	},
 /obj/floor_decal/floordetail/tiled,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "KK" = (
 /obj/floor_decal/corner/black/bordercorner{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "LW" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/handcuffs,
 /obj/item/storage/box/handcuffs,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "MC" = (
 /obj/floor_decal/corner/blue{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "Oo" = (
 /obj/machinery/light,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "OL" = (
 /obj/floor_decal/corner/black/border{
 	dir = 7
 	},
 /obj/machinery/light,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "PF" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -1590,7 +1347,7 @@
 /obj/floor_decal/corner/black/border{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "RX" = (
 /obj/floor_decal/corner/black/border{
@@ -1599,17 +1356,13 @@
 /obj/floor_decal/corner/blue{
 	dir = 5
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "TP" = (
 /obj/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 "UV" = (
 /obj/structure/table/rack,
@@ -1627,9 +1380,7 @@
 	},
 /obj/item/clothing/accessory/storage/holster/thigh,
 /obj/item/clothing/accessory/storage/holster/thigh,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/map_template/ninja_dojo/dojo)
 
 (1,1,1) = {"
@@ -2032,17 +1783,17 @@ TP
 aO
 aO
 qc
-bw
+aN
 aL
 bF
-cp
-cp
+as
+as
 aV
 ba
 bG
 ba
 bF
-cp
+as
 cu
 be
 bn
@@ -2078,12 +1829,12 @@ uZ
 RX
 aL
 bQ
-cp
-cp
+as
+as
 bc
-cp
-cp
-cp
+as
+as
+as
 bQ
 bn
 bf
@@ -2297,7 +2048,7 @@ ad
 ad
 ad
 bd
-cp
+as
 bd
 ad
 ad
@@ -2340,7 +2091,7 @@ ad
 ad
 ad
 bd
-cp
+as
 bd
 ad
 ad
@@ -2507,7 +2258,7 @@ ad
 ad
 ad
 bd
-Cj
+Fw
 bP
 aW
 bd
@@ -2555,7 +2306,7 @@ bP
 bb
 bd
 bD
-cp
+as
 OL
 bd
 aU
@@ -2598,7 +2349,7 @@ br
 bX
 JM
 cv
-cp
+as
 bX
 JM
 cv
@@ -2639,11 +2390,11 @@ aj
 cA
 bP
 bA
-cF
+bZ
 bP
-cp
+as
 aN
-cF
+bZ
 vP
 aN
 cA
@@ -2681,13 +2432,13 @@ ad
 bd
 UV
 bP
-cp
-cF
+as
+bZ
 bP
-cp
+as
 aN
-cF
-cp
+bZ
+as
 aN
 UV
 bd
@@ -2725,11 +2476,11 @@ bd
 ci
 aZ
 cy
-cF
+bZ
 bP
-cp
+as
 aN
-cF
+bZ
 cy
 aZ
 wG
@@ -2770,7 +2521,7 @@ bd
 bd
 bd
 bD
-cp
+as
 OL
 bd
 bd
@@ -2855,9 +2606,9 @@ ad
 ad
 ad
 bd
-aY
-aY
-aY
+as
+as
+as
 bd
 ad
 ad
@@ -2941,9 +2692,9 @@ ad
 bd
 bd
 cr
-cp
-cp
-cp
+as
+as
+as
 cr
 bd
 bd
@@ -2983,15 +2734,15 @@ bd
 bd
 bd
 bV
-cp
+as
 bF
 ba
 aV
-cp
+as
 bW
 bd
 cq
-cg
+as
 bd
 ad
 ad
@@ -3026,15 +2777,15 @@ bj
 PF
 bZ
 cv
-cp
-bO
+as
+bd
 bl
-bO
-cp
+bd
+as
 bX
 bZ
 ca
-cg
+as
 bd
 ad
 ad
@@ -3065,7 +2816,7 @@ ad
 ad
 ad
 bd
-cg
+as
 wX
 bZ
 cv
@@ -3077,7 +2828,7 @@ cC
 bX
 bZ
 aQ
-cg
+as
 bd
 ad
 ad
@@ -3108,15 +2859,15 @@ ad
 ad
 ad
 bd
-cg
+as
 Hl
 bZ
 cv
-cp
-bO
+as
+bd
 bL
-bO
-cp
+bd
+as
 bX
 bZ
 cb
@@ -3151,15 +2902,15 @@ ad
 ad
 ad
 bd
-cg
+as
 bq
 bd
 vQ
-cp
+as
 bQ
 aA
 bc
-cp
+as
 bu
 bd
 bd
@@ -3199,9 +2950,9 @@ bd
 bd
 bd
 cj
-aY
-aY
-aY
+as
+as
+as
 cj
 bd
 bd
@@ -3286,7 +3037,7 @@ ac
 ac
 bd
 bh
-cp
+as
 Oo
 bd
 ad
@@ -3329,7 +3080,7 @@ ad
 ad
 bd
 bz
-cp
+as
 co
 bd
 ac

--- a/maps/antag_spawn/vox/vox_raider.dmm
+++ b/maps/antag_spawn/vox/vox_raider.dmm
@@ -30,6 +30,14 @@
 /obj/item/material/knife/combat,
 /obj/item/material/knife/combat,
 /obj/item/material/sword/makeshift,
+/obj/random/loot/rarearmorbundle,
+/obj/random/loot/rarearmorbundle,
+/obj/random/loot/rarearmorbundle,
+/obj/random/loot/swordmelee,
+/obj/random/loot/swordmelee,
+/obj/random/loot/swordmelee,
+/obj/random/loot/basicarmorbundle,
+/obj/random/loot/basicarmorbundle,
 /turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
 "ae" = (
@@ -47,9 +55,9 @@
 "ag" = (
 /obj/structure/table/rack,
 /obj/floor_decal/corner/b_green/mono,
-/obj/item/gun/projectile/heavysniper/boltaction,
-/obj/item/gun/projectile/pistol/bolt_pistol/drusian,
-/obj/item/gun/projectile/pistol/slug/old,
+/obj/random/loot/lootartifacts,
+/obj/random/loot/lootcontraband,
+/obj/random/loot/lootcontraband,
 /turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
 "ah" = (
@@ -57,7 +65,8 @@
 /obj/item/clothing/mask/gas/swat/vox,
 /obj/item/clothing/under/vox/vox_casual,
 /obj/item/clothing/suit/armor/vox_scrap,
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/obj/random/loot/raregunslug,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "ai" = (
 /obj/structure/table/rack,
@@ -65,7 +74,8 @@
 /obj/item/clothing/under/vox/vox_casual,
 /obj/machinery/light/vox,
 /obj/item/clothing/suit/armor/vox_scrap,
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/obj/random/loot/raregunslug,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "aj" = (
 /obj/wallframe_spawn/reinforced/titanium,
@@ -78,16 +88,12 @@
 /obj/item/reagent_containers/ivbag/blood/vox/oneg,
 /obj/structure/iv_stand,
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "al" = (
 /obj/machinery/optable,
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "am" = (
 /obj/structure/table/rack,
@@ -95,13 +101,20 @@
 /obj/item/clothing/under/vox/vox_casual,
 /obj/decal/cleanable/filth,
 /obj/item/clothing/suit/armor/vox_scrap,
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/obj/random/loot/raregunslug,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "an" = (
 /obj/structure/table/rack,
 /obj/floor_decal/corner/b_green/mono,
 /obj/item/material/harpoon,
 /obj/item/material/harpoon,
+/obj/random/loot/randomcolonyitems,
+/obj/random/loot/randomcolonyitems,
+/obj/random/loot/randomsupply,
+/obj/random/loot/randomcolonyitems,
+/obj/random/loot/randomcolonyitems,
+/obj/random/loot/randomsupply/tech,
 /turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
 "ao" = (
@@ -109,7 +122,9 @@
 /obj/item/clothing/mask/gas/swat/vox,
 /obj/item/clothing/under/vox/vox_casual,
 /obj/item/clothing/suit/armor/makeshift,
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/obj/random/loot/raresidearmbundle,
+/obj/random/loot/raresidearmbundle,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "ap" = (
 /obj/structure/closet/crate{
@@ -139,9 +154,7 @@
 /obj/item/storage/firstaid/surgery,
 /obj/item/stack/nanopaste,
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "ax" = (
 /turf/space,
@@ -151,27 +164,21 @@
 	dir = 8
 	},
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "bb" = (
 /obj/machinery/body_scanconsole{
 	dir = 8
 	},
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "be" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -181,9 +188,7 @@
 	dir = 10
 	},
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "bk" = (
 /obj/structure/closet/medical_wall/filled{
@@ -208,9 +213,7 @@
 	dir = 4
 	},
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "bP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -227,9 +230,7 @@
 	},
 /obj/machinery/light/vox,
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "ck" = (
 /obj/structure/closet/crate/warhammer/freezer,
@@ -248,18 +249,14 @@
 /obj/floor_decal/corner/yellow/full,
 /obj/item/storage/box/detergent,
 /obj/item/storage/box/detergent,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "cm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "cB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -269,9 +266,7 @@
 	name = "Vox-Spawn"
 	},
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "cJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -279,9 +274,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "cU" = (
 /obj/machinery/vending/medical{
@@ -292,9 +285,7 @@
 	dir = 4
 	},
 /obj/floor_decal/corner/yellow/full,
-/turf/simulated/floor/tiled/freezer{
-	initial_gas = list("nitrogen" = 101.383)
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "dj" = (
 /obj/machinery/atmospherics/unary/tank/oxygen{
@@ -307,10 +298,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/floor_decal/corner/b_green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "dr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -328,16 +316,14 @@
 /turf/simulated/floor/shuttle_ceiling/vox,
 /area/map_template/vox_raider)
 "ee" = (
-/obj/floor_decal/corner/b_green/half,
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "ej" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/b_green/half,
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "ek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -360,14 +346,11 @@
 /obj/machinery/light/vox{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "eB" = (
 /obj/machinery/computer/shuttle_control/explore/vox_raider,
-/turf/simulated/floor/tiled/dark/monotile/vox,
-/area/map_template/vox_raider)
-"eE" = (
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "eF" = (
 /obj/machinery/fabricator/hacked,
@@ -381,10 +364,7 @@
 "eG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/b_green{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "eH" = (
 /obj/machinery/alarm/vox{
@@ -396,7 +376,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "eM" = (
 /obj/machinery/power/smes/buildable/preset/admin,
@@ -416,43 +396,24 @@
 /obj/floor_decal/industrial/hatch/orange,
 /turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
-"eQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/floor_decal/corner/b_green{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark/monotile/vox,
-/area/map_template/vox_raider)
-"eW" = (
-/obj/floor_decal/corner/b_green/three_quarters{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/vox,
-/area/map_template/vox_raider)
 "ff" = (
 /obj/machinery/computer/ship/helm{
 	dir = 4;
 	req_access = list("ACCESS_SYNDICATE")
 	},
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "fi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/floor_decal/corner/b_green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "fl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/floor_decal/corner/b_green/three_quarters{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "fo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -462,8 +423,7 @@
 /obj/landmark{
 	name = "Vox-Spawn"
 	},
-/obj/floor_decal/corner/b_green/three_quarters,
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "fV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -472,10 +432,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/floor_decal/corner/b_green/three_quarters{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "kF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -486,10 +443,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/corner/b_green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "kI" = (
 /obj/machinery/power/terminal{
@@ -499,10 +453,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/floor_decal/corner/b_green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "nN" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
@@ -515,8 +466,7 @@
 /obj/structure/bed/chair/comfy/green{
 	dir = 8
 	},
-/obj/floor_decal/corner/b_green,
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "pU" = (
 /obj/structure/cable/yellow{
@@ -524,15 +474,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/floor_decal/corner/b_green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "qj" = (
-/obj/floor_decal/corner/b_green/three_quarters,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "rM" = (
 /obj/paint/vox,
@@ -548,8 +494,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/floor_decal/corner/b_green/full,
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "tN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -558,15 +503,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/floor_decal/corner/b_green/full,
-/turf/simulated/floor/tiled/dark/vox,
-/area/map_template/vox_raider)
-"tW" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/floor_decal/corner/b_green/full,
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "vU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -578,7 +515,7 @@
 /obj/structure/table/steel,
 /obj/item/clothing/glasses/hud/health/goggle,
 /obj/item/clothing/glasses/meson,
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "vX" = (
 /obj/overmap/visitable/sector/vox_start,
@@ -588,7 +525,7 @@
 /obj/machinery/computer/ship/sensors/vox{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "ww" = (
 /obj/machinery/light/vox,
@@ -598,20 +535,14 @@
 /obj/structure/bed/chair/comfy/green{
 	dir = 8
 	},
-/obj/floor_decal/corner/b_green{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "wz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
 	level = 2
 	},
-/obj/floor_decal/corner/b_green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "wG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
@@ -635,10 +566,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/floor_decal/corner/b_green/three_quarters{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "xE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -648,7 +576,7 @@
 /obj/structure/closet/crate/radiation,
 /obj/item/stack/material/phoron/ten,
 /obj/item/stack/material/phoron/ten,
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "xK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -657,13 +585,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/floor_decal/corner/b_green/half{
-	dir = 1
-	},
 /obj/machinery/door/airlock/multi_tile{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "yA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -672,22 +597,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/floor_decal/corner/b_green/three_quarters{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "yQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/floor_decal/corner/b_green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/vox,
-/area/map_template/vox_raider)
-"zx" = (
-/obj/floor_decal/corner/b_green/full,
-/turf/simulated/floor/tiled/dark/vox,
+/obj/random/loot/lootstructureartifact,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "Ah" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -701,28 +617,10 @@
 	},
 /obj/shuttle_landmark/vox_raider/start,
 /obj/overmap/visitable/ship/landable/vox_raider,
-/obj/floor_decal/corner/b_green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "Am" = (
-/obj/floor_decal/corner/b_green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/vox,
-/area/map_template/vox_raider)
-"Av" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/floor_decal/corner/b_green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "BI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -731,15 +629,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/floor_decal/corner/b_green/full,
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "Db" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "Dm" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -751,21 +648,18 @@
 /area/map_template/vox_raider)
 "DZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/b_green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "EG" = (
 /obj/machinery/light/vox,
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "GJ" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc/hyper{
 	req_access = list("ACCESS_SYNDICATE")
 	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "HJ" = (
 /obj/machinery/access_button{
@@ -780,10 +674,7 @@
 /obj/landmark{
 	name = "Vox-Spawn"
 	},
-/obj/floor_decal/corner/b_green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -792,10 +683,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/floor_decal/corner/b_green/three_quarters{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "Jj" = (
 /obj/machinery/door/airlock/external/bolted{
@@ -807,28 +695,13 @@
 "JN" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/b_green/half{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "KM" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/floor_decal/corner/b_green/half{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile/vox,
-/area/map_template/vox_raider)
-"KQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "Lc" = (
 /obj/machinery/door/airlock/external/bolted_open{
@@ -876,35 +749,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "Pk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/floor_decal/corner/b_green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "Rn" = (
 /obj/machinery/light/vox{
 	dir = 1
 	},
-/obj/floor_decal/corner/b_green/full,
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "Ry" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/floor_decal/corner/b_green/half,
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/tiled/dark/monotile/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "RP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "Tw" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
@@ -923,7 +791,7 @@
 /obj/landmark{
 	name = "Vox-Spawn"
 	},
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "UC" = (
 /obj/wallframe_spawn/reinforced/titanium,
@@ -939,10 +807,6 @@
 	},
 /obj/structure/handrail,
 /turf/simulated/floor/plating/vox,
-/area/map_template/vox_raider)
-"Vf" = (
-/obj/floor_decal/corner/b_green/half,
-/turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
 "Ww" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
@@ -981,11 +845,11 @@
 /obj/item/reagent_containers/food/snacks/meat/beef,
 /obj/item/reagent_containers/food/snacks/meat/beef,
 /obj/item/reagent_containers/food/snacks/meat/beef,
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 "ZC" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled/dark/vox,
+/turf/simulated/floor/warhammer/plating,
 /area/map_template/vox_raider)
 
 (1,1,1) = {"
@@ -1271,7 +1135,7 @@ bb
 bU
 ae
 ae
-Vf
+Am
 xK
 ae
 ae
@@ -1380,8 +1244,8 @@ ae
 ae
 eM
 kI
-Av
-eE
+fV
+Am
 ae
 UY
 Tw
@@ -1433,7 +1297,7 @@ ab
 ek
 ae
 ae
-Vf
+Am
 xK
 ae
 ae
@@ -1459,7 +1323,7 @@ bP
 dH
 dr
 Ry
-eQ
+qj
 qj
 dq
 ao
@@ -1486,7 +1350,7 @@ ae
 ae
 ae
 ae
-eW
+Am
 sE
 BI
 IF
@@ -1514,7 +1378,7 @@ dZ
 dZ
 ae
 ad
-KQ
+tN
 Dm
 tN
 ai
@@ -1543,7 +1407,7 @@ ae
 ag
 RP
 af
-tW
+RP
 ah
 ae
 ax
@@ -1568,9 +1432,9 @@ ax
 ax
 ae
 an
-eE
+Am
 ap
-zx
+Am
 am
 ae
 ax

--- a/maps/antag_spawn/wizard/wizard_base.dmm
+++ b/maps/antag_spawn/wizard/wizard_base.dmm
@@ -29,18 +29,18 @@
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/food/drinks/flask/barflask,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "ag" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/rd,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "ah" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/backpack/satchel/grey/withwallet,
 /obj/item/clothing/glasses/monocle,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "ai" = (
 /obj/structure/table/woodentable,
@@ -48,124 +48,91 @@
 	name = "Teleport-Scroll"
 	},
 /obj/item/toy/figure/ninja,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aj" = (
 /obj/landmark/start{
 	name = "wizard"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "ak" = (
 /obj/structure/aliumizer,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "al" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/backpack/cultpack,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "am" = (
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "an" = (
 /obj/item/device/radio/intercom/syndicate{
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "ao" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/backpack/satchel/grey/withwallet,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "ap" = (
 /obj/structure/undies_wardrobe,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aq" = (
 /obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "ar" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
 	},
 /obj/decal/cleanable/cobweb,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "as" = (
 /obj/structure/table/woodentable,
 /obj/item/dice,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
-/area/map_template/wizard_station)
-"at" = (
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/obj/item/material/twohanded/ravenor/sword/demon,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "au" = (
 /obj/structure/table/woodentable,
 /obj/item/dice/d20,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/obj/item/material/twohanded/ravenor/axe/thunderhammer,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "av" = (
 /obj/structure/bookcase{
 	name = "bookcase (Tactics)"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aw" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "ax" = (
 /mob/living/carbon/human/monkey{
 	name = "Murphey"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "ay" = (
 /turf/unsimulated/wall/fakeglass{
 	dir = 1
 	},
 /area/map_template/wizard_station)
-"az" = (
-/turf/unsimulated/floor{
-	icon = 'icons/misc/beach.dmi';
-	icon_state = "seashallow";
-	name = "water"
-	},
-/area/map_template/wizard_station)
 "aA" = (
 /obj/item/bikehorn/rubberducky,
-/turf/unsimulated/floor{
-	icon = 'icons/misc/beach.dmi';
-	icon_state = "seashallow";
-	name = "water"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aB" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -174,17 +141,13 @@
 /obj/machinery/acting/changer/mirror{
 	pixel_y = 32
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aC" = (
 /obj/structure/hygiene/toilet{
 	pixel_y = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aD" = (
 /obj/structure/table/woodentable,
@@ -193,46 +156,32 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aE" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4;
 	icon_state = "wooden_chair_wings"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aF" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/chawanmushi,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/obj/random/loot/lootartifacts,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aG" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 8;
 	icon_state = "wooden_chair_wings"
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aH" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/cups,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aI" = (
 /obj/structure/closet,
@@ -240,9 +189,7 @@
 /obj/item/clothing/shoes/sandal,
 /obj/item/clothing/head/wizard/red,
 /obj/item/staff,
-/turf/unsimulated/floor{
-	icon_state = "lino"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aJ" = (
 /obj/structure/closet,
@@ -250,18 +197,14 @@
 /obj/item/clothing/shoes/sandal/marisa,
 /obj/item/clothing/head/wizard/marisa,
 /obj/item/staff/broom,
-/turf/unsimulated/floor{
-	icon_state = "lino"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aK" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/wizrobe/magusblue,
 /obj/item/clothing/head/wizard/magus,
 /obj/item/staff,
-/turf/unsimulated/floor{
-	icon_state = "lino"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aL" = (
 /obj/structure/closet,
@@ -269,9 +212,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/pwine,
 /obj/item/reagent_containers/food/drinks/bottle/specialwhiskey,
 /obj/item/reagent_containers/food/drinks/bottle/cognac,
-/turf/unsimulated/floor{
-	icon_state = "lino"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aM" = (
 /turf/unsimulated/wall/fakeglass{
@@ -283,66 +224,35 @@
 /obj/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
-/area/map_template/wizard_station)
-"aO" = (
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aP" = (
 /obj/machinery/door/unpowered/simple/iron,
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aQ" = (
 /obj/structure/table/woodentable,
 /obj/item/device/megaphone,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/obj/random/loot/lootcontraband,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aR" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/donut,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aS" = (
 /obj/structure/table/woodentable,
 /obj/item/spacecash/bundle/c1,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
-/area/map_template/wizard_station)
-"aT" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/unsimulated/floor{
-	icon_state = "lino"
-	},
-/area/map_template/wizard_station)
-"aU" = (
-/turf/unsimulated/floor{
-	icon_state = "lino"
-	},
+/obj/random/loot/lootcontraband,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aV" = (
 /turf/unsimulated/wall/fakeglass,
 /area/map_template/wizard_station)
 "aW" = (
 /obj/item/soap,
-/turf/unsimulated/floor{
-	icon = 'icons/misc/beach.dmi';
-	icon_state = "seashallow";
-	name = "water"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aX" = (
 /obj/floor_decal/spline/fancy/wood{
@@ -352,9 +262,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aY" = (
 /obj/structure/hygiene/sink{
@@ -364,24 +272,17 @@
 /obj/item/storage/mirror{
 	pixel_x = 32
 	},
-/turf/unsimulated/floor{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "aZ" = (
 /obj/machinery/vending/magivend,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "ba" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/milosoup,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/obj/random/loot/lootartifacts,
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bb" = (
 /obj/structure/table/woodentable,
@@ -390,18 +291,13 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bc" = (
 /obj/structure/closet,
 /obj/item/clothing/under/psysuit,
 /obj/item/clothing/suit/wizrobe/psypurple,
-/turf/unsimulated/floor{
-	icon_state = "lino"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bd" = (
 /obj/structure/closet,
@@ -417,231 +313,133 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/unsimulated/floor{
-	icon_state = "lino"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "be" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/wizrobe/magusred,
 /obj/item/clothing/head/wizard/magus,
 /obj/item/staff,
-/turf/unsimulated/floor{
-	icon_state = "lino"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bf" = (
 /obj/structure/closet,
 /obj/item/storage/briefcase,
-/turf/unsimulated/floor{
-	icon_state = "lino"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bg" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/nuclear,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bh" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/robotics_cyborgs,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bi" = (
 /obj/structure/bookcase,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bj" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/bag/cash,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bk" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/candle_box,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bl" = (
 /obj/machinery/door/unpowered/simple/silver,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bm" = (
 /obj/item/device/radio/intercom/syndicate{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "wood"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bn" = (
 /obj/structure/closet/coffin,
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
-/area/map_template/wizard_station)
-"bo" = (
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bp" = (
 /obj/item/device/radio/intercom/syndicate{
 	pixel_y = 22
 	},
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bq" = (
 /obj/structure/cult/pylon,
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "br" = (
 /obj/structure/kitchenspike,
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bs" = (
 /obj/item/remains/human,
-/turf/unsimulated/floor{
-	icon_state = "lava";
-	name = "plating"
-	},
-/area/map_template/wizard_station)
-"bt" = (
-/turf/unsimulated/floor{
-	icon_state = "lava";
-	name = "plating"
-	},
-/area/map_template/wizard_station)
-"bu" = (
-/turf/unsimulated/floor{
-	icon_state = "grass0";
-	name = "grass"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bv" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/unsimulated/floor{
-	icon_state = "grass0";
-	name = "grass"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bw" = (
 /mob/living/simple_animal/hostile/creature{
 	name = "Experiment 35b"
 	},
-/turf/unsimulated/floor{
-	icon_state = "lava";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bx" = (
 /obj/structure/cult/talisman,
 /obj/item/material/knife/ritual,
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "by" = (
 /obj/gateway/active/cult,
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/coralg,
 /area/map_template/wizard_station)
 "bz" = (
 /obj/structure/table/marble,
 /obj/item/device/flashlight/slime,
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bA" = (
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Experiment 97d"
 	},
-/turf/unsimulated/floor{
-	icon_state = "grass0";
-	name = "grass"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bB" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/unsimulated/floor{
-	icon_state = "grass0";
-	name = "grass"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bC" = (
 /obj/structure/flora/pottedplant/unusual,
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bD" = (
 /obj/structure/table/woodentable,
 /obj/item/xenos_claw,
-/turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
-	},
-/area/map_template/wizard_station)
-"bE" = (
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bF" = (
 /obj/overlay/palmtree_r,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bG" = (
 /mob/living/simple_animal/passive/crab{
 	name = "Experiment 68a"
 	},
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 "bH" = (
 /obj/overlay/coconut,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/map_template/wizard_station)
 
 (1,1,1) = {"
@@ -971,8 +769,8 @@ aa
 aa
 aa
 ab
-az
-az
+am
+am
 aW
 ab
 aa
@@ -984,8 +782,8 @@ aa
 aa
 ab
 bs
-bt
-bt
+am
+am
 ab
 aa
 aa
@@ -1011,8 +809,8 @@ aa
 aa
 ab
 aA
-az
-az
+am
+am
 ab
 aa
 aa
@@ -1022,9 +820,9 @@ aa
 aa
 aa
 ab
-bt
-bt
-bt
+am
+am
+am
 ab
 aa
 aa
@@ -1061,9 +859,9 @@ aa
 aa
 aa
 ab
-bt
+am
 bw
-bt
+am
 ab
 aa
 aa
@@ -1089,7 +887,7 @@ aa
 aa
 ab
 aC
-aO
+am
 aY
 ab
 aa
@@ -1100,8 +898,8 @@ aa
 aa
 aa
 ab
-bt
-bt
+am
+am
 bs
 ab
 aa
@@ -1167,7 +965,7 @@ ab
 ab
 aw
 aD
-at
+am
 aZ
 bg
 ab
@@ -1178,9 +976,9 @@ aa
 ab
 ab
 bq
-bo
+am
 bx
-bo
+am
 bq
 ab
 ab
@@ -1204,11 +1002,11 @@ ab
 ab
 ab
 ar
-at
-at
-at
-at
-at
+am
+am
+am
+am
+am
 bi
 ab
 ay
@@ -1216,11 +1014,11 @@ aM
 aV
 ab
 bn
-bo
-bo
-bo
-bo
-bo
+am
+am
+am
+am
+am
 bC
 ab
 ab
@@ -1243,28 +1041,28 @@ al
 ao
 ab
 as
-at
+am
 aE
 aQ
 aE
-at
+am
 bj
 ab
-at
-at
+am
+am
 bm
 ab
-bo
-bo
+am
+am
 ac
 ab
 ac
-bo
-bo
+am
+am
 ac
-bE
-bE
-bE
+am
+am
+am
 bH
 ab
 "}
@@ -1281,30 +1079,30 @@ aj
 am
 am
 aq
-at
-at
+am
+am
 aF
 aR
 ba
-at
-at
+am
+am
 bl
-at
-at
-at
+am
+am
+am
 bl
-bo
-bo
+am
+am
 ad
 by
 ad
-bo
+am
 bD
 ad
-bE
-bE
+am
+am
 bG
-bE
+am
 ab
 "}
 (18,1,1) = {"
@@ -1325,25 +1123,25 @@ ax
 aG
 aS
 aG
-at
+am
 bk
 ab
-at
-at
-at
+am
+am
+am
 ab
 bp
-bo
+am
 ae
 ab
 ae
-bo
-bo
+am
+am
 ae
-bE
+am
 bF
-bE
-bE
+am
+am
 ab
 "}
 (19,1,1) = {"
@@ -1360,11 +1158,11 @@ ab
 ab
 ab
 av
-at
-at
-at
-at
-at
+am
+am
+am
+am
+am
 bi
 ab
 ay
@@ -1372,11 +1170,11 @@ aM
 aV
 ab
 bn
-bo
-bo
-bo
-bo
-bo
+am
+am
+am
+am
+am
 bC
 ab
 ab
@@ -1401,7 +1199,7 @@ ab
 ab
 av
 aH
-at
+am
 bb
 bh
 ab
@@ -1412,9 +1210,9 @@ aa
 ab
 ab
 br
-bo
+am
 bz
-bo
+am
 br
 ab
 ab
@@ -1440,7 +1238,7 @@ aa
 ab
 ab
 ab
-aT
+aq
 ab
 ab
 ab
@@ -1479,7 +1277,7 @@ aa
 aa
 ab
 aI
-aU
+am
 bc
 ab
 aa
@@ -1490,8 +1288,8 @@ aa
 aa
 aa
 ab
-bu
-bu
+am
+am
 bB
 ab
 aa
@@ -1518,7 +1316,7 @@ aa
 aa
 ab
 aJ
-aU
+am
 bd
 ab
 aa
@@ -1529,9 +1327,9 @@ aa
 aa
 aa
 ab
-bu
-bu
-bu
+am
+am
+am
 ab
 aa
 aa
@@ -1557,7 +1355,7 @@ aa
 aa
 ab
 aK
-aU
+am
 be
 ab
 aa
@@ -1568,9 +1366,9 @@ aa
 aa
 aa
 ab
-bu
+am
 bA
-bu
+am
 ab
 aa
 aa
@@ -1596,7 +1394,7 @@ aa
 aa
 ab
 aL
-aU
+am
 bf
 ab
 aa
@@ -1608,8 +1406,8 @@ aa
 aa
 ab
 bv
-bu
-bu
+am
+am
 ab
 aa
 aa

--- a/maps/away/abandoned_hotel/abandoned_hotel-1.dmm
+++ b/maps/away/abandoned_hotel/abandoned_hotel-1.dmm
@@ -12,13 +12,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
-"ae" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/old_tile,
-/area/abandoned_hotel/buffet)
 "ak" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/grass/cut,
@@ -40,12 +35,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
-"ap" = (
-/obj/structure/closet/athletic_mixed,
-/turf/simulated/floor/tiled,
-/area/abandoned_hotel/pool)
 "as" = (
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled/old_cargo,
@@ -57,7 +48,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "aB" = (
@@ -68,25 +58,19 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "aE" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "aH" = (
 /obj/structure/hygiene/faucet{
 	dir = 8
 	},
-/turf/simulated/floor/pool,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "aO" = (
 /obj/structure/bedsheetbin,
@@ -105,12 +89,6 @@
 "aV" = (
 /turf/simulated/floor/plating,
 /area/space)
-"aW" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/old_cargo,
-/area/abandoned_hotel/pool)
 "aX" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/grass/cut,
@@ -127,20 +105,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "bf" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/bed,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "bo" = (
 /obj/structure/closet/athletic_mixed,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "bq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -149,8 +125,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -172,35 +147,22 @@
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
 "bx" = (
-/obj/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "by" = (
-/obj/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/old_cargo,
-/area/abandoned_hotel/pool)
-"bA" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "bF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "bG" = (
 /obj/structure/firedoor_assembly,
@@ -210,7 +172,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "bI" = (
 /obj/structure/window/reinforced,
@@ -222,46 +184,42 @@
 	dir = 1
 	},
 /obj/structure/kitchenspike,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "bN" = (
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "bO" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = 25
 	},
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "bW" = (
-/obj/floor_decal/corner/pink/diagonal,
 /obj/structure/hygiene/toilet,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "cg" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/machinery/cooker/fryer,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "cm" = (
 /obj/structure/closet/fridge,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "cp" = (
 /obj/structure/stairs/north,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "cq" = (
 /obj/structure/bed/chair/comfy/red,
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/abandoned_hotel/lobby)
 "cv" = (
@@ -270,26 +228,19 @@
 "cz" = (
 /turf/simulated/floor,
 /area/abandoned_hotel/pool)
-"cB" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/door/unpowered/simple/plastic/open,
-/turf/simulated/floor/tiled/white,
-/area/abandoned_hotel/buffet)
 "cG" = (
-/obj/floor_decal/corner/pink/diagonal,
 /obj/machinery/door/unpowered/simple/plastic,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "cK" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/machinery/cooker/oven,
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "cT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "cU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -313,16 +264,11 @@
 	dir = 4
 	},
 /obj/structure/table,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "dl" = (
 /turf/simulated/floor/tiled/steel_ridged,
 /area/abandoned_hotel/lobby)
-"dv" = (
-/obj/floor_decal/corner/black/diagonal,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/kafel_full,
-/area/abandoned_hotel/kitchen)
 "dQ" = (
 /obj/structure/ironing_board/fancy,
 /turf/simulated/floor/tiled/freezer,
@@ -339,18 +285,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
-"ea" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/abandoned_hotel/buffet)
-"ec" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/buffet)
 "ed" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -364,13 +300,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "ei" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "el" = (
 /obj/structure/table/steel_reinforced,
@@ -378,26 +314,16 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/abandoned_hotel/lobby)
-"em" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/structure/hygiene/urinal{
-	pixel_x = -29
-	},
-/turf/simulated/floor/tiled/white,
-/area/abandoned_hotel/buffet)
 "eo" = (
-/obj/floor_decal/corner/blue/diagonal,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "ep" = (
 /obj/machinery/door/unpowered/simple/ebony,
@@ -422,17 +348,16 @@
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "eF" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 1
-	},
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "eH" = (
 /obj/structure/closet/wardrobe,
+/obj/random/loot/sidearmbundle,
+/obj/random/loot/randomsupply,
 /turf/simulated/floor/carpet/blue3,
 /area/abandoned_hotel/lobby)
 "eP" = (
@@ -451,11 +376,10 @@
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
 "eS" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/machinery/alarm{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "eT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -487,7 +411,7 @@
 /area/abandoned_hotel/lobby)
 "fr" = (
 /obj/machinery/light,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "fs" = (
 /obj/floor_decal/spline/fancy/black{
@@ -521,13 +445,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "fK" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/old_tile,
 /area/abandoned_hotel/lobby)
 "fL" = (
-/obj/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -541,7 +461,6 @@
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "gb" = (
-/obj/floor_decal/corner/pink/diagonal,
 /obj/structure/hygiene/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -554,7 +473,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "gc" = (
 /obj/structure/window/reinforced,
@@ -564,14 +483,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
-"gf" = (
-/turf/simulated/floor/tiled/old_tile,
-/area/abandoned_hotel/buffet)
-"gi" = (
-/obj/floor_decal/corner/pink/diagonal,
-/obj/machinery/door/unpowered/simple/plastic/open,
-/turf/simulated/floor/tiled/white,
-/area/abandoned_hotel/buffet)
 "gk" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/carpet/blue2,
@@ -580,7 +491,6 @@
 /obj/machinery/alarm{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/lobby)
 "gu" = (
@@ -606,7 +516,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "gJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -615,7 +525,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/abandoned_hotel/pool)
 "gK" = (
@@ -623,14 +532,14 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "gL" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "gM" = (
 /obj/structure/bed/chair/comfy/green{
@@ -653,21 +562,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "gT" = (
 /obj/structure/bed/chair/comfy/green{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blue2,
 /area/abandoned_hotel/lobby)
 "gX" = (
 /obj/floor_decal/spline/fancy/black{
 	dir = 9
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "gZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -675,15 +582,14 @@
 /area/abandoned_hotel/buffet)
 "ha" = (
 /obj/machinery/smartfridge/foods,
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "hb" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/floor_decal/spline/fancy/black{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "hd" = (
 /obj/structure/filingcabinet/wallcabinet{
@@ -694,8 +600,7 @@
 	pixel_x = 5;
 	pixel_y = 27
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "hg" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -707,7 +612,7 @@
 	dir = 1
 	},
 /obj/structure/flora/pottedplant/dead,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "hj" = (
 /obj/structure/cable,
@@ -730,33 +635,32 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "hl" = (
-/obj/decal/cleanable/dirt,
 /obj/structure/kitchenspike,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "hm" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/chemical_dispenser/bar_alc/full{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "hn" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/floor_decal/spline/fancy/black{
 	dir = 10
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "ho" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/floor_decal/spline/fancy/black,
 /obj/item/form_printer,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "hs" = (
 /obj/machinery/computer/modular{
@@ -769,13 +673,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "hx" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/floor_decal/spline/fancy/black,
 /obj/item/modular_computer/laptop,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "hy" = (
 /obj/structure/table/woodentable_reinforced/walnut,
@@ -784,7 +688,7 @@
 	},
 /obj/item/paper/abandoned_hotel/note_5,
 /obj/item/paper/abandoned_hotel/note_5,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "hA" = (
 /obj/structure/window/reinforced/full,
@@ -796,7 +700,6 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blue2,
 /area/abandoned_hotel/lobby)
 "hC" = (
@@ -811,7 +714,7 @@
 /obj/machinery/chemical_dispenser/bar_soft{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "hN" = (
 /obj/structure/reagent_dispensers/water_cooler{
@@ -820,7 +723,7 @@
 /obj/decal/cleanable/cobweb{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "hO" = (
 /obj/structure/window/reinforced{
@@ -848,13 +751,13 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "hS" = (
 /obj/floor_decal/spline/fancy/black{
 	dir = 5
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "hV" = (
 /obj/structure/table/woodentable/walnut,
@@ -871,7 +774,7 @@
 /obj/floor_decal/spline/fancy/black{
 	dir = 6
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "io" = (
 /obj/structure/flora/ausbushes/genericbush,
@@ -918,7 +821,7 @@
 /obj/floor_decal/spline/fancy/black{
 	dir = 10
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "iK" = (
 /obj/structure/window/reinforced{
@@ -944,15 +847,13 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "iR" = (
 /obj/structure/table/standard,
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "iS" = (
-/obj/floor_decal/corner/pink/diagonal,
 /obj/structure/hygiene/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -965,29 +866,20 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
-"jc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/lobby)
 "jf" = (
 /obj/floor_decal/spline/fancy/black{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "jg" = (
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "jl" = (
 /obj/structure/flora/pottedplant/fern,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "jr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1003,7 +895,6 @@
 /area/abandoned_hotel/lobby)
 "jV" = (
 /obj/structure/safe,
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/reception)
 "kf" = (
@@ -1023,37 +914,26 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/buffet)
-"kk" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/structure/hygiene/toilet,
-/obj/decal/cleanable/cobweb,
-/turf/simulated/floor/tiled/white,
-/area/abandoned_hotel/buffet)
 "kG" = (
 /turf/simulated/floor/carpet,
 /area/abandoned_hotel/lobby)
 "kK" = (
 /obj/structure/ironing_board/fancy,
 /obj/item/ironing_iron,
-/obj/decal/cleanable/dirt,
 /obj/item/soap/random,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "kM" = (
-/obj/decal/cleanable/dirt,
 /obj/item/trash/plate,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
 "kT" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 1
-	},
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "li" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1073,7 +953,7 @@
 /area/abandoned_hotel/lobby)
 "ln" = (
 /obj/item/trash/cigbutt/menthol,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "lx" = (
 /obj/machinery/light/small{
@@ -1102,6 +982,7 @@
 /obj/item/trash/pluto,
 /obj/item/trash/oort,
 /obj/item/trash/fishegg,
+/obj/random/loot/randomsupply,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "lZ" = (
@@ -1112,7 +993,6 @@
 /obj/machinery/alarm{
 	dir = 1
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/reception)
 "md" = (
@@ -1129,7 +1009,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "mj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1138,10 +1018,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "mx" = (
-/obj/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -1158,13 +1037,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/reception)
 "mF" = (
 /obj/structure/table/woodentable/walnut,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "nd" = (
 /obj/structure/cable{
@@ -1173,15 +1050,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
-"nr" = (
-/obj/structure/bed/chair/comfy/green{
-	dir = 1
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/buffet)
 "nv" = (
 /obj/structure/bed/chair/comfy/green{
 	dir = 4
@@ -1189,11 +1059,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "nx" = (
 /obj/structure/table/woodentable/walnut,
-/obj/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -1210,13 +1079,12 @@
 "nA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "nD" = (
 /obj/structure/table/marble,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "nI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1225,7 +1093,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "nK" = (
 /obj/structure/bed/chair/comfy/green{
@@ -1237,22 +1105,20 @@
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
 "nO" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "nT" = (
-/obj/floor_decal/corner/pink/diagonal,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "nV" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "nW" = (
 /obj/random/junk,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "oa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1262,19 +1128,14 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "oe" = (
 /obj/machinery/constructable_frame/computerframe{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/carpet/blue2,
-/area/abandoned_hotel/lobby)
-"oo" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "oq" = (
 /obj/structure/bed/chair/comfy/green{
@@ -1288,7 +1149,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/lobby)
 "oM" = (
@@ -1296,7 +1156,6 @@
 	dir = 4;
 	pixel_x = 25
 	},
-/obj/decal/cleanable/dirt,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -1315,35 +1174,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "oW" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
-"pa" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/old_tile,
-/area/abandoned_hotel/buffet)
-"pd" = (
-/obj/floor_decal/corner/pink/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/abandoned_hotel/buffet)
 "pf" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "pi" = (
 /obj/structure/cable{
@@ -1357,7 +1200,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "pk" = (
 /obj/floor_decal/spline/fancy/black{
@@ -1369,26 +1212,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
-"pB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
-/area/abandoned_hotel/reception)
 "pH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "pK" = (
 /obj/floor_decal/spline/fancy/black{
@@ -1397,13 +1225,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
-"pO" = (
-/obj/structure/bed/chair/comfy/green,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/buffet)
 "pT" = (
 /obj/floor_decal/spline/fancy/black{
 	dir = 8
@@ -1419,16 +1242,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "pZ" = (
-/obj/floor_decal/corner/blue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "qa" = (
 /obj/structure/ore_box,
@@ -1439,14 +1260,13 @@
 /obj/floor_decal/spline/fancy/black{
 	dir = 1
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "qc" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/carpet,
 /area/abandoned_hotel/lobby)
 "qf" = (
-/obj/decal/cleanable/dirt,
 /obj/item/stack/cable_coil,
 /obj/item/stock_parts/circuitboard/modular_computer,
 /turf/simulated/floor/carpet/blue2,
@@ -1461,10 +1281,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/reception)
-"qi" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/lobby)
 "qk" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1474,11 +1290,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "ql" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "qn" = (
 /obj/structure/table/woodentable/walnut,
@@ -1492,15 +1307,8 @@
 /obj/machinery/alarm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
-"qq" = (
-/obj/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/buffet)
 "qt" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -1518,24 +1326,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "qH" = (
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
-"qM" = (
-/obj/item/stack/tile/carpetgreen,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/lobby)
 "qO" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "qU" = (
 /obj/structure/cable{
@@ -1545,26 +1345,21 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "rd" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
-"rr" = (
-/obj/floor_decal/spline/fancy/black{
-	dir = 8
-	},
-/turf/simulated/floor/wood/walnut,
-/area/abandoned_hotel/lobby)
 "rx" = (
 /obj/structure/closet/wardrobe,
+/obj/random/loot/lightmelee,
+/obj/random/loot/randomcolonyitems,
 /turf/simulated/floor/carpet,
 /area/abandoned_hotel/lobby)
 "rC" = (
@@ -1574,23 +1369,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
-"rE" = (
-/obj/structure/table/steel_reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/trash/plate,
-/turf/simulated/floor/tiled/old_tile,
-/area/abandoned_hotel/buffet)
-"rG" = (
-/obj/structure/table/woodentable/walnut,
-/obj/decal/cleanable/dirt,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/buffet)
 "rH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1611,18 +1391,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/reception)
-"sO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/blue,
-/area/abandoned_hotel/buffet)
 "sS" = (
 /obj/floor_decal/spline/fancy/black{
 	dir = 4
@@ -1638,8 +1408,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "sU" = (
 /obj/machinery/light,
@@ -1652,14 +1421,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "ti" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "tm" = (
 /obj/machinery/constructable_frame/computerframe{
@@ -1674,44 +1442,39 @@
 "ts" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/floor_decal/spline/fancy/black,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "tt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "ty" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "tP" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "tW" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "tX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "tY" = (
 /mob/living/simple_animal/passive/mouse/rat,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "ul" = (
 /obj/structure/cable{
@@ -1721,19 +1484,18 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "um" = (
 /obj/structure/table/marble,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "uq" = (
 /obj/structure/cable{
@@ -1743,7 +1505,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "ur" = (
 /obj/machinery/washing_machine,
@@ -1755,10 +1517,9 @@
 /area/abandoned_hotel/pool)
 "uA" = (
 /obj/structure/bed/chair,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "uF" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/machinery/power/apc{
 	dir = 4;
 	pixel_x = 25
@@ -1767,21 +1528,19 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "uY" = (
 /obj/floor_decal/spline/fancy/black,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "vi" = (
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
 /obj/item/storage/box/freezer/blood/human,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "vn" = (
 /obj/structure/cable{
@@ -1795,20 +1554,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
-"vo" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_cargo,
-/area/abandoned_hotel/pool)
 "vr" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -1833,28 +1580,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
-"vM" = (
-/obj/floor_decal/corner/pink/diagonal,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/abandoned_hotel/buffet)
 "vO" = (
-/obj/decal/cleanable/dirt,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/freezer,
-/area/abandoned_hotel/kitchen)
-"vW" = (
-/obj/decal/cleanable/dirt,
-/mob/living/simple_animal/passive/mouse/rat,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "vX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1863,24 +1593,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/abandoned_hotel/kitchen)
-"vY" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "we" = (
 /obj/floor_decal/spline/fancy/black{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "wf" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "wp" = (
 /obj/structure/table/steel_reinforced,
@@ -1891,25 +1613,13 @@
 	dir = 8
 	},
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "ws" = (
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/airless,
 /area/abandoned_hotel/lobby)
-"wA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/lobby)
 "wG" = (
-/obj/floor_decal/corner/blue/diagonal,
 /obj/item/storage/mirror{
 	pixel_x = 25
 	},
@@ -1922,7 +1632,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "wL" = (
 /obj/structure/bed/chair/comfy/green,
@@ -1935,10 +1645,6 @@
 /obj/structure/window/basic/full,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/abandoned_hotel/pool)
-"wZ" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/maple,
-/area/abandoned_hotel/pool)
 "xi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -1946,25 +1652,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
-"xA" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/structure/hygiene/toilet,
-/turf/simulated/floor/tiled/white,
-/area/abandoned_hotel/buffet)
 "xE" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
-"xL" = (
-/obj/floor_decal/spline/fancy/black,
-/turf/simulated/floor/wood/walnut,
-/area/abandoned_hotel/lobby)
 "xT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -1977,12 +1674,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "yl" = (
 /obj/item/trash/cigbutt/spitwad,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "yn" = (
 /obj/structure/cable{
@@ -1993,32 +1689,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "yq" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "yu" = (
 /obj/floor_decal/spline/fancy/black{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "yy" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "yH" = (
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/reception)
 "yJ" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -2028,24 +1719,20 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "yX" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "yY" = (
 /turf/simulated/wall/prepainted,
 /area/abandoned_hotel/kitchen)
 "zc" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "zd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2054,7 +1741,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "zp" = (
 /obj/structure/coatrack,
@@ -2082,29 +1769,26 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "zB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "zG" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "zJ" = (
 /obj/structure/bed/chair/comfy/green{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "An" = (
 /obj/structure/closet/crate/trashcart,
@@ -2115,21 +1799,20 @@
 /obj/item/trash/sosjerky,
 /obj/item/trash/proteinbar,
 /obj/item/trash/pluto,
+/obj/random/loot/randomcolonyitems,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "Ar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "AC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "AG" = (
 /obj/item/storage/mirror,
@@ -2149,22 +1832,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "AM" = (
 /obj/item/device/oxycandle{
 	icon_state = "oxycandle_burnt"
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "AX" = (
 /obj/item/towel/random,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Bg" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -2172,13 +1852,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "Bo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "Bq" = (
@@ -2191,35 +1870,31 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "BE" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "BI" = (
 /obj/structure/curtain/open/shower,
 /obj/item/towel/random,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "BW" = (
 /obj/structure/curtain/open/shower,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "BX" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "Cb" = (
 /obj/structure/bedsheetbin,
@@ -2229,18 +1904,10 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
-"Cf" = (
-/obj/structure/table/steel_reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/old_tile,
-/area/abandoned_hotel/buffet)
 "Ch" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Cl" = (
 /obj/machinery/light/small{
@@ -2258,7 +1925,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "CB" = (
 /turf/simulated/floor/wood,
@@ -2281,23 +1948,11 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
-"Dc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/abandoned_hotel/lobby)
 "Dh" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/floor_decal/spline/fancy/black,
-/obj/decal/cleanable/dirt,
 /obj/item/device/tape/random,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "Dk" = (
 /obj/machinery/computer/modular{
@@ -2310,7 +1965,7 @@
 /area/abandoned_hotel/lobby)
 "Dt" = (
 /obj/item/trash/chips,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "Dv" = (
 /obj/structure/window/reinforced,
@@ -2318,7 +1973,6 @@
 /turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "Dw" = (
-/obj/decal/cleanable/dirt,
 /obj/item/material/kitchen/utensil/fork/silver,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
@@ -2334,13 +1988,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "DO" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
 "DS" = (
@@ -2350,23 +2003,21 @@
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "DY" = (
-/obj/floor_decal/corner/blue/diagonal,
 /obj/structure/hygiene/urinal{
 	pixel_x = -29
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "DZ" = (
 /obj/structure/stairs/north,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "Eg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "Eh" = (
 /obj/structure/table/woodentable/walnut,
@@ -2393,16 +2044,14 @@
 	dir = 4
 	},
 /obj/structure/firedoor_assembly,
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/lobby)
 "Ew" = (
 /mob/living/simple_animal/passive/mouse/rat,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "EL" = (
 /obj/structure/table/woodentable/walnut,
-/obj/decal/cleanable/dirt,
 /obj/item/trash/plate,
 /obj/item/flame/lighter/random,
 /turf/simulated/floor/wood,
@@ -2415,25 +2064,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
-"Ff" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/buffet)
-"Fp" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/abandoned_hotel/pool)
 "Fv" = (
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/lobby)
@@ -2456,8 +2088,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "FI" = (
 /obj/machinery/light,
@@ -2493,7 +2124,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Gi" = (
 /obj/machinery/door/airlock,
@@ -2503,36 +2134,31 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/abandoned_hotel/buffet)
 "Gj" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 1
-	},
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/item/material/kitchen/utensil/fork/silver,
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "Gu" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/decal/cleanable/cobweb2{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "Gv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "GA" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	pixel_y = -25
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "GD" = (
 /obj/structure/cable{
@@ -2553,19 +2179,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "Hd" = (
-/obj/floor_decal/corner/blue/diagonal,
 /obj/machinery/door/unpowered/simple/plastic/open,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blue2,
 /area/abandoned_hotel/lobby)
 "Hm" = (
@@ -2575,7 +2198,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/crowbar,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "Hn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2594,7 +2217,6 @@
 /turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "Hr" = (
-/obj/decal/cleanable/dirt,
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/carpet/blue3,
 /area/abandoned_hotel/lobby)
@@ -2608,13 +2230,13 @@
 "HK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "HQ" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/pool,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Io" = (
 /obj/structure/window/reinforced{
@@ -2625,19 +2247,18 @@
 /area/abandoned_hotel/lobby)
 "It" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "Iu" = (
 /obj/machinery/alarm{
 	dir = 8
 	},
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "Iz" = (
 /obj/structure/table/steel_reinforced,
 /obj/floor_decal/corner/red/border,
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/abandoned_hotel/lobby)
 "IF" = (
@@ -2647,13 +2268,10 @@
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "IX" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "Jg" = (
 /obj/structure/cable{
@@ -2667,14 +2285,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Jt" = (
 /obj/item/trash/chips{
 	pixel_x = 5;
 	pixel_y = 7
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "Jv" = (
 /obj/structure/cable{
@@ -2688,7 +2306,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "JD" = (
 /obj/floor_decal/spline/fancy/black{
@@ -2697,18 +2315,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "JE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/lobby)
-"JF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "JG" = (
 /obj/floor_decal/spline/fancy/black{
@@ -2724,10 +2335,6 @@
 /obj/item/soap/random,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
-"JN" = (
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/wood/walnut,
-/area/abandoned_hotel/lobby)
 "JT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2741,15 +2348,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "JW" = (
 /obj/item/stack/material/wood/walnut,
 /turf/simulated/floor,
 /area/abandoned_hotel/pool)
-"Kh" = (
-/turf/simulated/floor/wood/walnut,
-/area/abandoned_hotel/reception)
 "Kr" = (
 /obj/structure/lattice,
 /turf/space,
@@ -2768,7 +2372,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Kv" = (
 /obj/structure/table/woodentable/walnut,
@@ -2788,7 +2392,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "KI" = (
@@ -2803,7 +2406,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "KQ" = (
 /obj/structure/table/woodentable/walnut,
@@ -2814,27 +2417,26 @@
 /area/abandoned_hotel/lobby)
 "KS" = (
 /obj/structure/stairs/north,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "KT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/structure/table,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "KW" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
 /mob/living/simple_animal/passive/mouse/rat,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "KY" = (
 /obj/item/material/shard,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Ld" = (
 /obj/structure/flora/pottedplant/sticky,
@@ -2842,20 +2444,18 @@
 /area/abandoned_hotel/lobby)
 "Lf" = (
 /obj/floor_decal/spline/fancy/black,
-/obj/decal/cleanable/dirt,
 /obj/structure/roller_bed,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "Lk" = (
 /turf/simulated/wall/prepainted,
 /area/abandoned_hotel/buffet)
 "Ln" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "Lo" = (
 /obj/structure/window/reinforced{
@@ -2867,7 +2467,6 @@
 "Lv" = (
 /obj/structure/table/standard,
 /obj/item/ironing_board/fancy,
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "Lw" = (
@@ -2900,24 +2499,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "LL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/prepainted,
 /area/abandoned_hotel/reception)
-"LQ" = (
-/obj/structure/curtain/open/shower,
-/turf/simulated/floor/tiled,
-/area/abandoned_hotel/pool)
 "LR" = (
 /obj/structure/bed/chair/comfy/green{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
 "Md" = (
@@ -2928,7 +2521,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "Mj" = (
 /obj/structure/bed/chair/comfy/green{
@@ -2937,28 +2530,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "Mo" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/abandoned_hotel/buffet)
-"Ms" = (
-/obj/structure/table/woodentable/walnut,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "Mt" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
 /obj/item/material/knife/kitchen/cleaver,
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "Mv" = (
 /obj/structure/window/reinforced{
@@ -2969,13 +2552,12 @@
 /area/abandoned_hotel/lobby)
 "MA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "MG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "MX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -2987,15 +2569,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/decal/cleanable/dirt,
 /obj/machinery/light,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
-"Nd" = (
-/obj/floor_decal/corner/black/diagonal,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/kafel_full,
-/area/abandoned_hotel/kitchen)
 "No" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3005,11 +2581,11 @@
 	dir = 4
 	},
 /obj/structure/door_assembly,
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Nx" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "NM" = (
 /obj/machinery/door/airlock/external/glass/bolted,
@@ -3020,31 +2596,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/lobby)
-"NX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/abandoned_hotel/lobby)
 "Oa" = (
 /turf/simulated/floor/wood/maple,
 /area/abandoned_hotel/pool)
 "Oc" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
-/obj/decal/cleanable/dirt,
 /obj/item/material/kitchen/rollingpin,
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "Og" = (
 /obj/structure/window/reinforced{
@@ -3072,10 +2630,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
-"Oz" = (
-/obj/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/kafel_full,
-/area/abandoned_hotel/kitchen)
 "OK" = (
 /obj/structure/hygiene/sink{
 	dir = 8;
@@ -3092,20 +2646,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/lobby)
 "OQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
 /mob/living/simple_animal/passive/mouse/rat,
 /turf/simulated/floor/wood/maple,
 /area/abandoned_hotel/pool)
 "OS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "OU" = (
 /obj/structure/table/woodentable/walnut,
@@ -3119,19 +2671,6 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
-"Pn" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/blue2,
-/area/abandoned_hotel/lobby)
-"Pp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/abandoned_hotel/kitchen)
 "Pu" = (
 /obj/structure/window/basic{
 	dir = 8
@@ -3154,7 +2693,7 @@
 /area/abandoned_hotel/lobby)
 "Px" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "PD" = (
 /obj/machinery/door/firedoor,
@@ -3165,13 +2704,13 @@
 	dir = 4
 	},
 /obj/structure/door_assembly,
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Qg" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "Qi" = (
 /obj/structure/window/reinforced{
@@ -3192,38 +2731,23 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
-"Qo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue,
-/area/abandoned_hotel/buffet)
 "QD" = (
 /obj/structure/bed,
 /obj/item/towel/random,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "QE" = (
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blue3,
 /area/abandoned_hotel/lobby)
-"QX" = (
-/turf/simulated/floor/carpet/blue,
-/area/abandoned_hotel/buffet)
 "Rg" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/item/material/knife/kitchen,
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "Rm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3232,7 +2756,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Ro" = (
 /obj/structure/window/reinforced{
@@ -3248,10 +2772,9 @@
 /turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "Ru" = (
-/obj/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
 /obj/machinery/microwave,
-/turf/simulated/floor/tiled/kafel_full,
+/turf/simulated/floor/warhammer/ceramic/surgery,
 /area/abandoned_hotel/kitchen)
 "RA" = (
 /obj/item/reagent_containers/pill/three_eye,
@@ -3273,14 +2796,13 @@
 /area/abandoned_hotel/buffet)
 "RT" = (
 /obj/structure/flora/pottedplant/thinbush,
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "RU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "RX" = (
 /obj/machinery/constructable_frame/computerframe{
@@ -3290,17 +2812,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/decal/cleanable/dirt,
 /obj/item/stock_parts/circuitboard/broken,
 /turf/simulated/floor/carpet/blue2,
 /area/abandoned_hotel/lobby)
 "Se" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue2,
-/area/abandoned_hotel/lobby)
-"Sm" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
 /area/abandoned_hotel/lobby)
 "Sn" = (
 /obj/machinery/door/airlock,
@@ -3326,7 +2843,7 @@
 /area/abandoned_hotel/lobby)
 "Sw" = (
 /obj/structure/hygiene/drain/bath,
-/turf/simulated/floor/pool,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Sx" = (
 /obj/structure/table/steel_reinforced,
@@ -3334,7 +2851,7 @@
 	dir = 4
 	},
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "Sy" = (
 /obj/floor_decal/spline/fancy/black{
@@ -3352,7 +2869,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/abandoned_hotel/pool)
 "SI" = (
@@ -3365,13 +2881,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/stack/tile/carpetgreen,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "SZ" = (
 /obj/structure/window/reinforced{
@@ -3386,10 +2900,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/stack/tile/carpetgreen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "Tn" = (
 /obj/structure/table/steel_reinforced,
@@ -3399,7 +2912,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "TF" = (
 /obj/structure/window/reinforced{
@@ -3416,7 +2929,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Uc" = (
 /obj/structure/table/woodentable_reinforced/walnut,
@@ -3434,26 +2947,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
-"UB" = (
-/obj/item/stack/tile/carpetgreen,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/lobby)
 "UG" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "UI" = (
 /turf/simulated/floor/tiled/freezer,
@@ -3466,8 +2966,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "UL" = (
 /obj/structure/ore_box,
@@ -3480,18 +2979,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "Va" = (
 /turf/simulated/floor/airless,
 /area/space)
-"Vc" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/abandoned_hotel/lobby)
 "Vf" = (
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor,
@@ -3508,10 +3000,9 @@
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/lobby)
 "Vs" = (
-/obj/floor_decal/corner/pink/diagonal,
 /obj/structure/hygiene/toilet,
 /obj/decal/cleanable/cobweb,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "Vu" = (
 /obj/structure/table/woodentable/walnut,
@@ -3554,11 +3045,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "VV" = (
-/obj/floor_decal/corner/blue/diagonal,
 /obj/item/storage/mirror{
 	pixel_x = 25
 	},
@@ -3571,7 +3060,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/abandoned_hotel/buffet)
 "Wk" = (
 /obj/machinery/door/airlock,
@@ -3588,19 +3077,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "Wy" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "WQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3609,36 +3095,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
 /obj/item/soap/random,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "WR" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "WU" = (
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/airless,
 /area/abandoned_hotel/buffet)
-"Xb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/abandoned_hotel/pool)
 "Xc" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3653,21 +3126,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
-"Xn" = (
-/obj/item/stack/tile/carpetgreen,
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/lobby)
 "Xo" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "Xq" = (
 /obj/structure/window/reinforced{
@@ -3683,7 +3148,6 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
 	dir = 1
 	},
-/obj/decal/cleanable/dirt,
 /obj/decal/cleanable/cobweb{
 	dir = 8
 	},
@@ -3713,9 +3177,8 @@
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/lobby)
 "XL" = (
-/obj/decal/cleanable/dirt,
 /obj/random/maintenance,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/lobby)
 "XM" = (
 /obj/floor_decal/spline/fancy/black{
@@ -3724,21 +3187,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/lobby)
 "XQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
 "XZ" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/decal/cleanable/dirt,
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled/old_tile,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "Ya" = (
 /obj/structure/window/reinforced{
@@ -3756,13 +3218,12 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "YE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "YH" = (
@@ -3776,9 +3237,6 @@
 /obj/item/material/shard,
 /turf/space,
 /area/space)
-"YM" = (
-/turf/simulated/floor/wood/walnut,
-/area/abandoned_hotel/lobby)
 "YY" = (
 /obj/floor_decal/spline/fancy/black{
 	dir = 4
@@ -3794,24 +3252,15 @@
 "Zw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/coralg,
 /area/abandoned_hotel/buffet)
 "ZB" = (
-/obj/floor_decal/borderfloorwhite{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/abandoned_hotel/pool)
-"ZK" = (
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/lobby)
 "ZN" = (
 /obj/item/stack/material/wood/walnut/ten,
 /turf/simulated/floor/wood/maple,
-/area/abandoned_hotel/pool)
-"ZQ" = (
-/turf/simulated/floor/pool,
 /area/abandoned_hotel/pool)
 "ZS" = (
 /obj/structure/bookcase,
@@ -3824,7 +3273,7 @@
 /obj/floor_decal/spline/fancy/black{
 	dir = 8
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/reception)
 "ZZ" = (
 /obj/random/drinkbottle,
@@ -21289,18 +20738,18 @@ aa
 aa
 cv
 cv
-oo
+UI
 UI
 lD
 cv
 OK
-oo
+UI
 JK
 Db
 cv
 OK
 UI
-oo
+UI
 Db
 cv
 gk
@@ -21492,12 +20941,12 @@ aa
 cv
 cv
 Cb
-oo
+UI
 An
 cv
 ll
 UI
-oo
+UI
 Pu
 cv
 ll
@@ -21506,7 +20955,7 @@ UI
 Pu
 cv
 lB
-Pn
+XE
 gT
 XE
 Pw
@@ -21708,7 +21157,7 @@ cv
 cv
 cv
 Ld
-Pn
+XE
 oq
 qf
 oq
@@ -22103,16 +21552,16 @@ Lv
 cv
 zp
 CB
-Sm
+kG
 kG
 cv
 QE
 QE
 RA
-qi
+CB
 cv
 lx
-Pn
+XE
 oq
 XE
 hB
@@ -22304,13 +21753,13 @@ fF
 iR
 cv
 DS
-qi
+CB
 kG
 kG
 cv
 Cl
 Hr
-qi
+CB
 CB
 cv
 Eo
@@ -22718,15 +22167,15 @@ HB
 FQ
 cv
 bG
-ZK
+yX
 qb
 hg
-YM
+nO
 ln
 Jt
 uY
 jl
-ZK
+yX
 cv
 cv
 Kr
@@ -22919,8 +22368,8 @@ ep
 cv
 cv
 cv
-jc
-ZK
+bq
+yX
 qb
 io
 uA
@@ -22928,7 +22377,7 @@ yl
 nO
 uY
 yX
-ZK
+yX
 iK
 ws
 Kr
@@ -23098,18 +22547,18 @@ Vf
 aB
 SZ
 bf
-VL
+ql
 oW
-VL
+ql
 QD
 Rr
 ZU
 yX
 yX
-ZK
-ZK
+yX
+yX
 zd
-ZK
+yX
 cT
 Qg
 yX
@@ -23117,10 +22566,10 @@ bq
 yX
 yX
 FH
-jc
+bq
 nW
-ZK
-ZK
+yX
+yX
 bq
 yX
 qb
@@ -23128,9 +22577,9 @@ ip
 Dt
 AM
 nO
-xL
+uY
 yX
-ZK
+yX
 iL
 ws
 Kr
@@ -23298,12 +22747,12 @@ aa
 Vf
 Vf
 Dv
-VL
+ql
 KM
-VL
-VL
-VL
-VL
+ql
+ql
+ql
+ql
 Pf
 ZU
 xi
@@ -23313,26 +22762,26 @@ mg
 pi
 mg
 ab
-wA
+mg
 Qk
 sX
 HK
-JF
+HK
 AC
 rC
 MG
 MG
 MG
 nA
-ZK
+yX
 qb
 ix
-YM
+nO
 KT
 dh
-xL
+uY
 yX
-ZK
+yX
 Xq
 ws
 Kr
@@ -23500,12 +22949,12 @@ aa
 Vf
 aS
 aD
-bA
+ql
 yy
 tW
 tW
 bx
-VL
+ql
 ZU
 ZU
 No
@@ -23515,7 +22964,7 @@ ZU
 ZU
 cp
 nV
-rr
+we
 pT
 CO
 CO
@@ -23525,7 +22974,7 @@ CO
 ZV
 hb
 hn
-jc
+bq
 yX
 hR
 cv
@@ -23701,23 +23150,23 @@ aa
 aa
 Vf
 aS
-ZQ
-ZQ
-ZQ
-ZQ
-ZQ
+ql
+ql
+ql
+ql
+ql
 Xo
-VL
+ql
 ZU
-LQ
-Xb
+BW
+mj
 ZU
 Jg
 BW
 ZU
 KS
-YM
-YM
+nO
+nO
 LH
 CO
 jV
@@ -23727,8 +23176,8 @@ CO
 hd
 yq
 ho
-jc
-ZK
+bq
+yX
 hS
 yu
 yu
@@ -23903,11 +23352,11 @@ aa
 aa
 Vf
 bI
-ZQ
+ql
 Sw
-ZQ
+ql
 Sw
-ZQ
+ql
 WR
 tt
 ZU
@@ -23932,12 +23381,12 @@ hx
 nI
 HK
 HK
-JF
-JF
+HK
+HK
 Ar
 JE
-ZK
-ZK
+yX
+yX
 NM
 fK
 fK
@@ -24105,15 +23554,15 @@ aa
 aa
 Vf
 Dv
-ZQ
-ZQ
-ZQ
-ZQ
-ZQ
-vo
-VL
+ql
+ql
+ql
+ql
+ql
+Rm
+ql
 ZU
-LQ
+BW
 UJ
 ZU
 oT
@@ -24128,12 +23577,12 @@ de
 rV
 mc
 CO
-Kh
+yq
 vn
 Dh
-ZK
+yX
 tY
-ZK
+yX
 yX
 yX
 RU
@@ -24141,8 +23590,8 @@ EX
 yX
 yX
 NM
-Vc
-Vc
+fK
+fK
 NM
 Va
 aa
@@ -24308,21 +23757,21 @@ aa
 ZU
 ZU
 HQ
-ZQ
-ZQ
-ZQ
-ZQ
-vo
+ql
+ql
+ql
+ql
+Rm
 Px
 ZU
 OS
 tX
 ZU
 yn
-Fp
+tt
 ZU
 KS
-YM
+nO
 nO
 xT
 LL
@@ -24330,13 +23779,13 @@ Xs
 fL
 hj
 CO
-Kh
-pB
+yq
+vn
 ts
-ZK
+yX
 XL
 gX
-rr
+we
 we
 pK
 JD
@@ -24509,19 +23958,19 @@ aa
 aa
 Vf
 Dv
-ZQ
-ZQ
-ZQ
-ZQ
-ZQ
-vo
-VL
+ql
+ql
+ql
+ql
+ql
+Rm
+ql
 ZU
 bo
 Rm
 ZU
 xE
-ap
+bo
 ZU
 DZ
 ei
@@ -24535,8 +23984,8 @@ CO
 jf
 Uc
 hy
-ZK
-ZK
+yX
+yX
 hR
 cv
 BX
@@ -24711,13 +24160,13 @@ aa
 aa
 Vf
 aS
-ZQ
-ZQ
-ZQ
-ZQ
-ZQ
-vo
-VL
+ql
+ql
+ql
+ql
+ql
+Rm
+ql
 ZU
 ZU
 PD
@@ -24733,20 +24182,20 @@ Jv
 JT
 Tk
 SJ
-NX
-Dc
+JT
+Tk
 qU
-ZK
+yX
 yX
 yX
 qb
 iG
-YM
+nO
 CA
 vi
 uY
-ZK
-ZK
+yX
+yX
 iK
 ws
 Kr
@@ -24913,11 +24362,11 @@ aa
 aa
 Vf
 bI
-ZQ
+ql
 Sw
-ZQ
+ql
 Sw
-ZQ
+ql
 Wy
 XQ
 XQ
@@ -24930,21 +24379,21 @@ ZU
 cq
 el
 tP
-ZK
+yX
 zd
 vI
-qM
+yX
 Me
 Hm
-Xn
-UB
-ZK
-ZK
-ZK
+yX
+zd
+yX
+yX
+yX
 qb
 iH
-YM
-JN
+nO
+mF
 mF
 Lf
 yX
@@ -25115,13 +24564,13 @@ aa
 aa
 Vf
 bI
-ZQ
-ZQ
-ZQ
-ZQ
-ZQ
-vo
-VL
+ql
+ql
+ql
+ql
+ql
+Rm
+ql
 ZU
 as
 VL
@@ -25145,10 +24594,10 @@ XK
 cv
 cv
 iI
-YM
+nO
 zJ
 zJ
-xL
+uY
 yX
 yX
 Mv
@@ -25317,13 +24766,13 @@ aa
 aa
 Vf
 qt
-ZQ
-ZQ
-ZQ
-ZQ
-ZQ
-vo
-VL
+ql
+ql
+ql
+ql
+ql
+Rm
+ql
 ZU
 ZU
 ZU
@@ -25347,8 +24796,8 @@ iu
 cv
 cv
 hg
-YM
-YM
+nO
+nO
 nO
 uY
 yX
@@ -25520,11 +24969,11 @@ aa
 ZU
 ZU
 HQ
-ZQ
-ZQ
-ZQ
-ZQ
-vo
+ql
+ql
+ql
+ql
+Rm
 KY
 ZU
 Oa
@@ -25532,9 +24981,9 @@ Oa
 VI
 eA
 Lk
-xA
-cB
-em
+bW
+Hd
+DY
 DY
 Lk
 Xg
@@ -25721,18 +25170,18 @@ aa
 aa
 Vf
 qt
-ZQ
-ZQ
-ZQ
-ZQ
-ZQ
-vo
-VL
+ql
+ql
+ql
+ql
+ql
+Rm
+ql
 uz
 ZN
-wZ
+Oa
 li
-wZ
+Oa
 Lk
 Lk
 Lk
@@ -25923,11 +25372,11 @@ aa
 aa
 Vf
 bI
-ZQ
+ql
 Sw
-ZQ
+ql
 Sw
-ZQ
+ql
 BE
 Gv
 wR
@@ -25936,13 +25385,13 @@ cU
 gJ
 cz
 Lk
-kk
+Vs
 Hd
 VV
 wG
 Lk
-Qo
-sO
+UW
+DD
 eP
 eV
 qH
@@ -26125,16 +25574,16 @@ aa
 aa
 Vf
 Dv
-ZQ
+ql
 aH
-ZQ
-ZQ
-ZQ
+ql
+ql
+ql
 UG
-VL
+ql
 uz
 Oa
-wZ
+Oa
 OQ
 sU
 Lk
@@ -26143,12 +25592,12 @@ Lk
 Lk
 Lk
 Lk
-Qo
+UW
 DD
 eP
 eX
 gu
-Ms
+Vu
 RP
 LR
 Dx
@@ -26328,20 +25777,20 @@ aa
 Vf
 ak
 aE
-aW
+ql
 qO
 ZB
 ZB
 by
-VL
+ql
 Lw
-wZ
+Oa
 CV
 Sz
 ZZ
 Lk
 Vs
-gi
+Hd
 nT
 nT
 Lk
@@ -26349,7 +25798,7 @@ UW
 DD
 eP
 fB
-pO
+gu
 EL
 Kv
 nK
@@ -26530,12 +25979,12 @@ aa
 Vf
 Vf
 qt
-VL
+ql
 hv
 AX
-VL
-VL
-VL
+ql
+ql
+ql
 wR
 cz
 Oa
@@ -26544,17 +25993,17 @@ Oa
 Lk
 Lk
 Lk
-vM
-pd
+eo
+pZ
 hC
 Zw
 DD
 eP
 fD
 Ox
-qq
 Ox
-ec
+Ox
+qH
 gB
 hP
 kh
@@ -26734,14 +26183,14 @@ Vf
 aX
 FK
 bf
-VL
+ql
 oW
-VL
+ql
 oW
 wR
 RH
 JW
-wZ
+Oa
 Cu
 Lk
 bW
@@ -26749,7 +26198,7 @@ cG
 gb
 iS
 Lk
-Qo
+UW
 DD
 eP
 fE
@@ -26757,7 +26206,7 @@ gZ
 gZ
 fE
 Ro
-Ff
+Hn
 Lk
 Lk
 aa
@@ -26958,7 +26407,7 @@ fB
 wL
 ny
 nx
-nr
+FC
 FI
 Lk
 Lk
@@ -27147,14 +26596,14 @@ ZU
 yY
 yY
 Mt
-Oz
+jg
 cg
 cK
 cK
 Gu
 yY
 UW
-sO
+DD
 eP
 eV
 gu
@@ -27349,18 +26798,18 @@ aa
 yY
 yY
 Ru
-dv
-Oz
-Oz
-dv
-dv
+jg
+jg
+jg
+jg
+jg
 yY
 UW
-sO
+DD
 eP
 fD
-ec
-ec
+qH
+qH
 Dw
 kM
 Hn
@@ -27551,19 +27000,19 @@ aa
 yY
 yY
 Ru
-dv
+jg
 Oc
-Nd
-Nd
-Oz
+bN
+bN
+jg
 yY
-Qo
-sO
+UW
+DD
 eP
 eV
 gu
 Vu
-rG
+Vu
 FC
 Hn
 Xc
@@ -27752,15 +27201,15 @@ vr
 Kr
 yY
 yY
-Nd
-dv
+bN
+jg
 Ln
-Nd
+bN
 Rg
-dv
+jg
 yY
-Qo
-sO
+UW
+DD
 eP
 gc
 gu
@@ -28161,17 +27610,17 @@ zG
 ti
 eS
 uF
-Oz
+jg
 Ej
-QX
-sO
-ea
 wf
-pa
+DD
+wf
+wf
+wf
 Mo
 IX
 wf
-pa
+wf
 Lk
 Lk
 aa
@@ -28365,15 +27814,15 @@ yY
 yY
 yY
 yY
-QX
-sO
+wf
+DD
 eF
-gf
+wf
 Sx
 Tn
 wp
 gK
-gf
+wf
 Lk
 Lk
 aa
@@ -28561,7 +28010,7 @@ aa
 yY
 yY
 bN
-Pp
+zG
 jg
 KW
 hl
@@ -28570,11 +28019,11 @@ yY
 ef
 DD
 kT
-ae
+wf
 gL
-rE
 XZ
-Cf
+XZ
+gL
 It
 Lk
 Lk
@@ -28764,20 +28213,20 @@ yY
 yY
 nD
 vX
-vW
-vY
+Ew
+jg
 Ew
 vO
 yY
 Nx
 DD
 Gj
-gf
-gf
-ae
-ae
-ae
-gf
+wf
+wf
+wf
+wf
+wf
+wf
 Lk
 Lk
 aa
@@ -28974,7 +28423,7 @@ yY
 Iu
 Yc
 eF
-gf
+wf
 RT
 ha
 hm

--- a/maps/away/abandoned_hotel/abandoned_hotel-2.dmm
+++ b/maps/away/abandoned_hotel/abandoned_hotel-2.dmm
@@ -61,7 +61,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "ap" = (
 /obj/structure/grille,
@@ -85,7 +85,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "av" = (
 /obj/machinery/power/tracker,
@@ -105,7 +105,7 @@
 	dir = 9
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "aA" = (
 /obj/machinery/light/small{
@@ -141,10 +141,6 @@
 /obj/structure/railing/mapped,
 /turf/simulated/open,
 /area/abandoned_hotel/overlook)
-"aR" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/carpet/blue,
-/area/abandoned_hotel/rooms)
 "aY" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -155,7 +151,7 @@
 /obj/floor_decal/corner/white{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "be" = (
 /obj/item/stack/material/tritium,
@@ -173,7 +169,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "bl" = (
 /obj/floor_decal/solarpanel,
@@ -197,7 +193,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "bp" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -219,12 +215,12 @@
 "bv" = (
 /obj/spider/stickyweb,
 /mob/living/simple_animal/hostile/giant_spider,
-/turf/simulated/floor/carpet/blue3,
+/turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
 "bx" = (
 /obj/decal/cleanable/dirt,
 /mob/living/simple_animal/passive/mouse/rat,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "bA" = (
 /obj/machinery/light{
@@ -237,7 +233,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "bI" = (
 /obj/structure/table/steel_reinforced,
@@ -258,7 +254,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "bT" = (
 /obj/floor_decal/spline/fancy/black{
@@ -274,7 +270,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "cb" = (
 /obj/floor_decal/corner/red,
@@ -282,7 +278,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "cd" = (
 /obj/floor_decal/corner/red{
@@ -294,7 +290,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "cf" = (
 /obj/floor_decal/solarpanel,
@@ -343,7 +339,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "cW" = (
 /obj/structure/bed/chair{
@@ -394,7 +390,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "dx" = (
 /obj/structure/cable/yellow{
@@ -414,7 +410,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "dC" = (
 /turf/simulated/wall/prepainted,
@@ -436,7 +432,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "dO" = (
 /obj/structure/window/reinforced{
@@ -464,7 +460,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "dZ" = (
 /obj/structure/cable/yellow{
@@ -530,7 +526,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "eM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -596,13 +592,13 @@
 "fj" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "fk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "fy" = (
 /turf/simulated/floor/plating,
@@ -637,7 +633,7 @@
 /area/abandoned_hotel/solar)
 "fS" = (
 /obj/structure/flora/pottedplant/drooping,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "fT" = (
 /obj/floor_decal/spline/fancy/black{
@@ -702,7 +698,8 @@
 /area/abandoned_hotel/solar)
 "ge" = (
 /obj/structure/closet/wardrobe,
-/turf/simulated/floor/carpet/magenta,
+/obj/random/loot/randomsupply/tech,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "gh" = (
 /obj/machinery/door/unpowered/simple/ebony,
@@ -713,7 +710,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "gi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -732,7 +729,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /obj/item/tank/oxygen_emergency,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "gs" = (
 /obj/structure/cable{
@@ -740,7 +737,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "gt" = (
 /turf/simulated/wall/prepainted,
@@ -769,7 +766,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "gx" = (
 /obj/structure/cable/yellow{
@@ -822,7 +819,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "gV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -875,7 +872,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
 /mob/living/simple_animal/hostile/giant_spider,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ha" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -897,7 +894,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "hy" = (
 /obj/floor_decal/spline/fancy/black{
@@ -922,7 +919,7 @@
 "hD" = (
 /obj/decal/cleanable/cobweb,
 /obj/structure/largecrate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "hK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -948,7 +945,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "hO" = (
 /obj/item/solar_assembly,
@@ -958,7 +955,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "hY" = (
 /obj/floor_decal/spline/fancy/black{
@@ -970,7 +967,8 @@
 /area/abandoned_hotel/rooms)
 "if" = (
 /obj/structure/closet/wardrobe,
-/turf/simulated/floor/carpet/blue,
+/obj/random/loot/rarearmorbundle,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -1002,13 +1000,13 @@
 /area/abandoned_hotel/atmos)
 "io" = (
 /mob/living/simple_animal/passive/mouse/rat,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ip" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/rooms)
+/obj/machinery/door/firedoor,
+/obj/item/material/shard,
+/turf/simulated/floor/warhammer/darkwood,
+/area/abandoned_hotel/overlook)
 "it" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1023,14 +1021,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "iy" = (
 /obj/structure/cable/yellow{
@@ -1075,7 +1073,7 @@
 /area/abandoned_hotel/overlook)
 "jg" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "jh" = (
 /obj/floor_decal/solarpanel,
@@ -1086,13 +1084,13 @@
 "jv" = (
 /obj/structure/table/standard,
 /obj/structure/window/basic,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "jx" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "jA" = (
 /obj/decal/cleanable/dirt,
@@ -1114,7 +1112,7 @@
 "jG" = (
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "jZ" = (
 /obj/decal/cleanable/dirt,
@@ -1124,7 +1122,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "kw" = (
 /obj/structure/cable{
@@ -1134,10 +1132,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/solar)
-"kA" = (
-/mob/living/simple_animal/passive/mouse/rat,
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/rooms)
 "kM" = (
 /obj/floor_decal/spline/fancy/black{
 	dir = 1
@@ -1151,7 +1145,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "kY" = (
 /obj/decal/cleanable/dirt,
@@ -1167,7 +1161,7 @@
 	dir = 6
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ln" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1193,14 +1187,14 @@
 	dir = 8
 	},
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "lL" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "lW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1216,7 +1210,7 @@
 	dir = 1
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "mb" = (
 /obj/structure/cable{
@@ -1231,16 +1225,12 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "mh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/red,
-/area/abandoned_hotel/rooms)
-"mp" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "mr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1254,19 +1244,15 @@
 	dir = 8
 	},
 /obj/structure/largecrate,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "mz" = (
 /obj/random/bomb_supply,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "mC" = (
 /obj/random/accessory,
-/turf/simulated/floor/carpet/blue,
-/area/abandoned_hotel/rooms)
-"mO" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "mT" = (
 /obj/structure/bed/chair/comfy/green{
@@ -1281,7 +1267,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "no" = (
 /obj/structure/table/woodentable/walnut,
@@ -1289,12 +1275,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "nH" = (
 /obj/spider/stickyweb,
 /mob/living/simple_animal/hostile/giant_spider,
-/turf/simulated/floor/carpet/magenta,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "nM" = (
 /obj/item/material/shard,
@@ -1312,9 +1298,6 @@
 	dir = 1
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/old_cargo,
-/area/abandoned_hotel/overlook)
-"ob" = (
 /turf/simulated/floor/tiled/old_cargo,
 /area/abandoned_hotel/overlook)
 "oe" = (
@@ -1338,14 +1321,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "oo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ot" = (
 /obj/floor_decal/solarpanel,
@@ -1354,10 +1337,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space)
-"oy" = (
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/rooms)
 "oB" = (
 /obj/overmap/visitable/sector/abandoned_hotel,
 /turf/space,
@@ -1374,7 +1353,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "oM" = (
 /obj/structure/railing/mapped{
@@ -1387,7 +1366,7 @@
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "pr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -1412,12 +1391,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "pM" = (
 /obj/structure/closet/wardrobe,
 /obj/random/accessory,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "pY" = (
 /obj/structure/cable{
@@ -1435,7 +1414,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "qb" = (
 /obj/item/storage/mirror{
@@ -1447,14 +1426,14 @@
 	pixel_x = 11;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "qd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "qe" = (
 /obj/wallframe_spawn/reinforced,
@@ -1472,7 +1451,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "qp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1487,7 +1466,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "qt" = (
 /obj/item/frame/apc,
@@ -1495,7 +1474,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "qu" = (
 /obj/structure/hygiene/toilet,
@@ -1503,7 +1482,7 @@
 	dir = 1
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "qv" = (
 /obj/structure/window/reinforced{
@@ -1520,7 +1499,7 @@
 	dir = 8
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "qC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1535,10 +1514,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/solar)
-"qJ" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/carpet/magenta,
-/area/abandoned_hotel/rooms)
 "qR" = (
 /obj/floor_decal/borderfloorwhite{
 	dir = 1
@@ -1575,28 +1550,24 @@
 	dir = 8
 	},
 /obj/random/backpack,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ry" = (
 /obj/decal/cleanable/dirt,
 /obj/structure/ore_box,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "rH" = (
 /obj/structure/hygiene/shower{
 	dir = 8
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "rT" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/item/material/shard,
 /turf/simulated/floor/grass/cut,
-/area/abandoned_hotel/rooms)
-"rW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
 /area/abandoned_hotel/rooms)
 "si" = (
 /obj/decal/cleanable/dirt,
@@ -1618,21 +1589,23 @@
 /obj/item/storage/mirror{
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "sA" = (
 /obj/structure/closet/wardrobe,
-/turf/simulated/floor/carpet/blue3,
+/obj/random/loot/randomsupply/engineering,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
 "sB" = (
 /obj/spider/stickyweb,
-/turf/simulated/floor/carpet/magenta,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "sC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "sH" = (
 /obj/floor_decal/spline/fancy/black{
@@ -1649,7 +1622,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blue3,
+/turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
 "sR" = (
 /obj/structure/bed/chair,
@@ -1660,10 +1633,7 @@
 	dir = 6
 	},
 /obj/item/paper/abandoned_hotel/note_4,
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/rooms)
-"sW" = (
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "tc" = (
 /obj/structure/cable{
@@ -1671,12 +1641,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ti" = (
 /obj/structure/closet/wardrobe,
 /obj/random/backpack,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "tm" = (
 /obj/structure/table/standard,
@@ -1690,7 +1660,7 @@
 /obj/floor_decal/corner/white{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "tu" = (
 /obj/decal/cleanable/dirt,
@@ -1700,7 +1670,7 @@
 "tC" = (
 /obj/structure/bed/chair/comfy/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "tI" = (
 /obj/decal/cleanable/dirt,
@@ -1710,7 +1680,7 @@
 "tL" = (
 /obj/decal/cleanable/dirt,
 /obj/spider/stickyweb/dark,
-/turf/simulated/floor/carpet/blue3,
+/turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
 "tW" = (
 /obj/structure/cable{
@@ -1733,7 +1703,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "tZ" = (
 /obj/structure/table/woodentable/walnut,
@@ -1768,7 +1738,7 @@
 /area/abandoned_hotel/rooms)
 "uv" = (
 /obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "uD" = (
 /obj/decal/cleanable/dirt,
@@ -1778,7 +1748,7 @@
 /obj/machinery/alarm{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "uF" = (
 /obj/floor_decal/corner/red,
@@ -1786,7 +1756,7 @@
 	dir = 4
 	},
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "uJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1804,7 +1774,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "uY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1813,7 +1783,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "uZ" = (
 /obj/structure/cable{
@@ -1837,7 +1807,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/spider/stickyweb,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "vj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1848,11 +1818,14 @@
 /area/abandoned_hotel/overlook)
 "vp" = (
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "vW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/green,
+/obj/structure/hygiene/toilet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "vZ" = (
 /obj/structure/lattice,
@@ -1861,17 +1834,17 @@
 /area/space)
 "wt" = (
 /obj/structure/bookcase,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ww" = (
 /obj/item/paper/abandoned_hotel/note_3,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "wI" = (
 /obj/decal/cleanable/dirt,
 /obj/structure/bed,
 /obj/spider/stickyweb/dark,
-/turf/simulated/floor/carpet/blue3,
+/turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
 "wO" = (
 /obj/floor_decal/corner/white{
@@ -1895,7 +1868,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "wQ" = (
 /obj/structure/cable{
@@ -1907,12 +1880,12 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "wS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "wW" = (
 /obj/decal/cleanable/dirt,
@@ -1927,7 +1900,7 @@
 	dir = 4
 	},
 /obj/item/material/shard,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "xy" = (
 /obj/item/stack/material/tritium,
@@ -1955,7 +1928,7 @@
 "ym" = (
 /obj/decal/cleanable/dirt,
 /obj/item/seeds/potatoseed,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "yu" = (
 /obj/machinery/door/firedoor,
@@ -1976,7 +1949,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "yV" = (
 /obj/floor_decal/spline/fancy/black{
@@ -2007,16 +1980,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "zn" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/item/material/shard,
 /turf/simulated/floor/grass/cut,
-/area/abandoned_hotel/rooms)
-"zF" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/blue,
 /area/abandoned_hotel/rooms)
 "zG" = (
 /obj/floor_decal/corner/red{
@@ -2026,7 +1995,7 @@
 	dir = 1
 	},
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "zL" = (
 /obj/structure/window/reinforced/full,
@@ -2040,7 +2009,7 @@
 "zY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Ac" = (
 /obj/structure/grille,
@@ -2051,7 +2020,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Al" = (
 /obj/machinery/light{
@@ -2062,7 +2031,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Av" = (
 /obj/item/stack/cable_coil,
@@ -2075,13 +2044,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "AR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "AX" = (
 /obj/landmark/map_data{
@@ -2094,13 +2063,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/blue3,
+/turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
 "Bb" = (
 /obj/item/device/oxycandle{
 	icon_state = "oxycandle_burnt"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "Bd" = (
 /obj/structure/cable{
@@ -2117,18 +2086,18 @@
 /turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/rooms)
 "Bg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/rooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/warhammer/darkwood,
+/area/abandoned_hotel/overlook)
 "Bo" = (
 /obj/decal/cleanable/dirt,
 /obj/spider/stickyweb,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Bu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2138,11 +2107,11 @@
 	dir = 6
 	},
 /obj/spider/stickyweb,
-/turf/simulated/floor/carpet/magenta,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Bw" = (
 /obj/structure/bed,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "BL" = (
 /obj/structure/bed/chair/comfy/green{
@@ -2151,7 +2120,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "BU" = (
 /obj/shuttle_landmark/abandoned_hotel/one,
@@ -2209,7 +2178,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "CZ" = (
 /obj/structure/hygiene/toilet,
@@ -2226,13 +2195,13 @@
 "Dk" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Dp" = (
 /obj/structure/table/standard,
 /obj/machinery/alarm,
 /obj/item/storage/mrebag/menu9,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Ds" = (
 /obj/decal/cleanable/dirt,
@@ -2245,11 +2214,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "DJ" = (
 /obj/item/storage/wallet/random,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "DL" = (
 /obj/structure/lattice,
@@ -2271,7 +2240,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/barricade,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Ex" = (
 /obj/item/stool/bar/padded,
@@ -2323,7 +2292,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Fm" = (
 /obj/floor_decal/borderfloorwhite{
@@ -2337,7 +2306,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Fq" = (
 /obj/structure/cable{
@@ -2352,7 +2321,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/abandoned_hotel/overlook)
 "Ft" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "Fw" = (
 /obj/floor_decal/corner/red,
@@ -2363,7 +2332,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "FE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2378,7 +2347,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Gb" = (
 /turf/simulated/open,
@@ -2395,7 +2364,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "Go" = (
 /obj/structure/bed,
@@ -2406,7 +2375,7 @@
 "Gv" = (
 /obj/decal/cleanable/dirt,
 /obj/item/trash/beans,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Gx" = (
 /obj/structure/cable{
@@ -2446,14 +2415,14 @@
 	},
 /obj/decal/cleanable/dirt,
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "Hy" = (
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/bar_coffee/full{
 	pixel_y = 7
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "HB" = (
 /obj/floor_decal/spline/fancy/black{
@@ -2477,7 +2446,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "HE" = (
 /obj/floor_decal/spline/fancy/black{
@@ -2499,7 +2468,7 @@
 	dir = 4
 	},
 /obj/item/frame/fire_alarm,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "HV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2516,7 +2485,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Ie" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2525,7 +2495,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Ii" = (
 /obj/machinery/door/firedoor,
@@ -2542,7 +2512,7 @@
 	dir = 8
 	},
 /obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "JE" = (
 /obj/structure/table/woodentable/walnut,
@@ -2550,7 +2520,8 @@
 	dir = 1
 	},
 /obj/item/storage/box/donut/empty,
-/turf/simulated/floor/wood,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Kk" = (
 /obj/machinery/light{
@@ -2564,7 +2535,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "Kn" = (
 /obj/structure/window/reinforced/full,
@@ -2587,7 +2558,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/blue3,
+/turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
 "KX" = (
 /obj/structure/railing/mapped{
@@ -2602,35 +2573,35 @@
 /area/abandoned_hotel/rooms)
 "Ld" = (
 /obj/spider/stickyweb/dark,
-/turf/simulated/floor/carpet/blue3,
+/turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
 "Lj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "LE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "LI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "LT" = (
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "Md" = (
 /obj/structure/bookcase,
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "MA" = (
 /obj/structure/cable{
@@ -2639,7 +2610,7 @@
 	icon_state = "1-2"
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "MD" = (
 /obj/floor_decal/corner/red,
@@ -2648,7 +2619,7 @@
 	},
 /obj/structure/flora/pottedplant/minitree,
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "MJ" = (
 /obj/structure/cable{
@@ -2659,26 +2630,17 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ML" = (
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/paper/abandoned_hotel/note_5,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "MM" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/carpet/red,
-/area/abandoned_hotel/rooms)
-"MS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/magenta,
+/obj/machinery/door/unpowered/simple/ebony,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "MT" = (
 /obj/structure/bed/chair/comfy/green{
@@ -2689,7 +2651,7 @@
 "Nm" = (
 /obj/structure/bed,
 /obj/item/bedsheet/ce,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Np" = (
 /obj/structure/bed/chair{
@@ -2705,7 +2667,7 @@
 	dir = 4
 	},
 /obj/item/frame/air_alarm,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "NA" = (
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -2715,7 +2677,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "NH" = (
 /obj/structure/railing/mapped{
@@ -2749,11 +2711,11 @@
 	},
 /obj/decal/cleanable/dirt,
 /obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Od" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Oi" = (
 /obj/structure/cable{
@@ -2768,7 +2730,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Op" = (
 /obj/floor_decal/corner/white{
@@ -2783,7 +2745,7 @@
 /obj/machinery/alarm{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "Ov" = (
 /obj/structure/window/basic/full,
@@ -2807,13 +2769,13 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "OJ" = (
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/random/accessory,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "OM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2822,7 +2784,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Pf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2858,7 +2820,7 @@
 /area/abandoned_hotel/atmos)
 "Qf" = (
 /obj/structure/ore_box,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "Qm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2873,11 +2835,12 @@
 /turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/rooms)
 "Qv" = (
-/turf/simulated/floor/carpet/blue3,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "QA" = (
 /obj/structure/flora/pottedplant/largebush,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "QJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2886,7 +2849,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "QM" = (
 /obj/structure/window/reinforced{
@@ -2896,7 +2859,7 @@
 /turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "QQ" = (
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "QZ" = (
 /obj/structure/cable{
@@ -2910,7 +2873,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Ri" = (
 /obj/decal/cleanable/dirt,
@@ -2918,7 +2881,8 @@
 /area/abandoned_hotel/rooms)
 "Rj" = (
 /obj/structure/closet/wardrobe,
-/turf/simulated/floor/carpet/red,
+/obj/random/loot/raregunslug,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "RJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2935,7 +2899,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/rooms)
 "Sl" = (
 /obj/structure/cable{
@@ -2953,7 +2917,7 @@
 	dir = 4
 	},
 /obj/random/bomb_supply,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Sr" = (
 /obj/structure/window/reinforced{
@@ -2962,10 +2926,10 @@
 /turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "Su" = (
-/obj/structure/bookcase,
-/obj/spider/stickyweb/dark,
-/turf/simulated/floor/carpet/blue3,
-/area/abandoned_hotel/rooms)
+/obj/structure/window/basic/full,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/warhammer/darkwood,
+/area/abandoned_hotel/overlook)
 "SL" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -2986,7 +2950,7 @@
 "SZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Tl" = (
 /obj/decal/cleanable/dirt,
@@ -2997,7 +2961,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Ts" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3020,7 +2984,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "TT" = (
 /obj/structure/cable{
@@ -3035,7 +2999,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "TY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3043,7 +3007,7 @@
 	dir = 6
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Uf" = (
 /obj/structure/flora/pottedplant/unusual,
@@ -3053,7 +3017,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Uo" = (
 /obj/structure/window/reinforced/full,
@@ -3081,23 +3045,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/rooms)
-"UZ" = (
-/obj/spider/stickyweb,
-/turf/simulated/floor/carpet/blue3,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Vh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Vi" = (
 /obj/decal/cleanable/dirt,
 /mob/living/simple_animal/passive/mouse/rat,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "Vp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3140,7 +3100,7 @@
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/overlook)
 "VT" = (
-/turf/simulated/floor/carpet/magenta,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "VZ" = (
 /obj/floor_decal/spline/fancy/black{
@@ -3166,7 +3126,7 @@
 	dir = 8
 	},
 /obj/item/paper/abandoned_hotel/note_5,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Wy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
@@ -3180,11 +3140,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "WI" = (
 /obj/random/toolbox,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "WT" = (
 /obj/structure/cable{
@@ -3198,19 +3158,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/rooms)
-"WU" = (
-/obj/spider/stickyweb,
-/turf/simulated/floor/wood,
-/area/abandoned_hotel/rooms)
-"Xa" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Xq" = (
 /obj/structure/closet/crate/large/hydroponics,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Xr" = (
 /obj/structure/window/reinforced{
@@ -3223,20 +3175,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "XS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "XV" = (
 /obj/structure/bed/chair/comfy/green{
 	dir = 8
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Yf" = (
 /obj/machinery/light/small{
@@ -3245,7 +3197,7 @@
 /obj/item/device/oxycandle{
 	icon_state = "oxycandle_burnt"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Yo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3258,11 +3210,12 @@
 /turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/rooms)
 "Yp" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/abandoned_hotel/evac)
 "Yu" = (
-/turf/simulated/floor/carpet/green,
-/area/abandoned_hotel/rooms)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/warhammer/darkwood,
+/area/abandoned_hotel/overlook)
 "YC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3276,7 +3229,7 @@
 	dir = 8
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "YE" = (
 /obj/structure/flora/pottedplant/orientaltree,
@@ -3287,14 +3240,14 @@
 /obj/structure/table/woodentable/walnut,
 /obj/spider/stickyweb,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/carpet/blue3,
+/turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
 "Ze" = (
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/atmos)
 "Zg" = (
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "Zk" = (
 /turf/simulated/wall/prepainted,
@@ -3305,7 +3258,7 @@
 	dir = 4
 	},
 /obj/item/cell/high/empty,
-/turf/simulated/floor/tiled/old_cargo,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/overlook)
 "ZH" = (
 /obj/item/soap/random,
@@ -3329,7 +3282,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 "ZZ" = (
 /obj/structure/cable{
@@ -3339,7 +3292,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/warhammer/darkwood,
 /area/abandoned_hotel/rooms)
 
 (1,1,1) = {"
@@ -20816,8 +20769,8 @@ wW
 fW
 Uq
 Bw
-QQ
-mO
+VT
+Zg
 ym
 bp
 jG
@@ -21019,7 +20972,7 @@ fX
 Uq
 Xq
 jg
-QQ
+VT
 ww
 DR
 jG
@@ -21220,9 +21173,9 @@ cN
 Uq
 Uq
 Xq
-QQ
+VT
 ym
-QQ
+VT
 Tv
 jG
 aa
@@ -21407,7 +21360,7 @@ aa
 Uq
 Uq
 fj
-QQ
+VT
 mC
 if
 Uq
@@ -21417,14 +21370,14 @@ Hp
 gY
 Uq
 fj
-QQ
-Yu
+VT
+VT
 pM
 Uq
 wt
-Yu
+VT
 Zg
-Yu
+VT
 Tv
 jG
 aa
@@ -21608,18 +21561,18 @@ aa
 aa
 Uq
 Uq
-kA
-QQ
-zF
-zF
+io
+VT
+Zg
+Zg
 Uq
 VT
 sB
-WU
-WU
+sB
+sB
 Uq
-QQ
-mO
+VT
+Zg
 io
 Zg
 Uq
@@ -21811,8 +21764,8 @@ aa
 Uq
 Uq
 hU
-mO
-zF
+Zg
+Zg
 Dk
 Uq
 aA
@@ -21821,12 +21774,12 @@ Bo
 Hp
 Uq
 no
-rW
+Od
 ix
-Yu
+VT
 Uq
 gO
-Yu
+VT
 NW
 JB
 Uq
@@ -22015,9 +21968,9 @@ Uq
 gw
 TY
 AD
-aR
+wt
 Uq
-qJ
+wt
 Bu
 vd
 BL
@@ -22217,16 +22170,16 @@ Uq
 rr
 Wp
 bZ
-aR
+wt
 Uq
-qJ
-MS
+wt
+bZ
 yR
 Fp
 Uq
-oy
-oy
-Bg
+uv
+uv
+bZ
 wt
 Uq
 QJ
@@ -22626,13 +22579,13 @@ wQ
 DA
 WT
 eJ
-Yu
+VT
 sC
-Yu
-Yu
-Bg
-Yu
-Yu
+VT
+VT
+bZ
+VT
+VT
 OM
 VZ
 uj
@@ -23016,10 +22969,10 @@ ZN
 ZN
 ZN
 ZN
-ax
+Yu
 xi
-ob
-gl
+Ft
+LT
 Ft
 Zk
 dp
@@ -23036,8 +22989,8 @@ qC
 qC
 ik
 Wj
-Yu
-Yu
+VT
+VT
 bT
 uj
 Gb
@@ -23218,12 +23171,12 @@ ZN
 ZN
 ZN
 ZN
-Ii
+ip
 jZ
 Vi
 Bb
-gl
-Ov
+LT
+Su
 qi
 Yo
 Gb
@@ -23238,7 +23191,7 @@ hL
 Ze
 il
 Wj
-Yu
+VT
 DJ
 bT
 KX
@@ -23421,11 +23374,11 @@ ZN
 ZN
 ZN
 Ov
-ok
-gl
-gl
+Bg
+LT
+LT
 Ft
-Ov
+Su
 Bd
 tW
 fU
@@ -23441,7 +23394,7 @@ ig
 UF
 Wj
 Zg
-Yu
+VT
 yV
 HE
 HE
@@ -23623,11 +23576,11 @@ ZN
 ZN
 ZN
 Ov
-ok
-gl
+Bg
+LT
 ry
-gl
-Ov
+LT
+Su
 ga
 yx
 fV
@@ -23642,8 +23595,8 @@ fd
 ii
 fC
 Wj
-Yu
-Yu
+VT
+VT
 kM
 sq
 sq
@@ -23825,11 +23778,11 @@ ZN
 ZN
 ZN
 Ov
-ok
+Bg
 LT
 WI
-ob
-Ov
+Ft
+Su
 qi
 Yo
 Gb
@@ -23845,7 +23798,7 @@ hK
 fC
 Wj
 bx
-Yu
+VT
 bT
 NH
 bJ
@@ -24027,11 +23980,11 @@ ZN
 ZN
 ZN
 Ov
-ok
+Bg
 Ft
-ob
+Ft
 Qf
-Ov
+Su
 Gx
 VC
 uk
@@ -24046,7 +23999,7 @@ Wj
 Wj
 Wj
 Wj
-Yu
+VT
 Zg
 bT
 uj
@@ -24229,27 +24182,27 @@ ZN
 ZN
 ZN
 Ov
-ok
+Bg
 WA
-ob
+Ft
 mw
-Ov
+Su
 tc
 qq
-ip
-ip
+mh
+mh
 Tr
-ip
-ip
-ip
+mh
+mh
+mh
 iu
 FW
-vW
-vW
-vW
-vW
-vW
-vW
+Od
+Od
+Od
+Od
+Od
+Od
 hy
 uj
 Gb
@@ -24449,9 +24402,9 @@ Vh
 Zg
 Zg
 Zg
-Yu
-Yu
-Yu
+VT
+VT
+VT
 VZ
 uj
 Gb
@@ -24647,7 +24600,7 @@ Uq
 Uq
 Uq
 HN
-Yu
+VT
 Uq
 fT
 fT
@@ -24843,7 +24796,7 @@ Zk
 Zk
 Zk
 QA
-QQ
+VT
 NE
 uv
 ol
@@ -25045,13 +24998,13 @@ hj
 ew
 Zk
 hU
-mO
+Zg
 XC
 XV
 bo
 Uq
 pK
-Yu
+VT
 uf
 Ri
 lr
@@ -25246,14 +25199,14 @@ Qm
 lW
 Ce
 Zk
-mp
-QQ
+wt
+VT
 qo
 Od
 cU
 Ai
 ZZ
-ip
+mh
 xZ
 FE
 gD
@@ -25448,9 +25401,9 @@ si
 mr
 si
 Zk
-mp
-mO
-sW
+wt
+Zg
+VT
 Nm
 Rj
 Uq
@@ -25651,13 +25604,13 @@ Ex
 tI
 Zk
 Uq
-cN
+MM
 Uq
 Uq
 Uq
 Uq
 ZO
-Yu
+VT
 Uq
 Uq
 Uq
@@ -25853,13 +25806,13 @@ bm
 Ce
 Zk
 sv
-wW
+Qv
 Uq
 jv
 pq
 Uq
 pK
-Yu
+VT
 Uq
 Dp
 cW
@@ -26055,10 +26008,10 @@ si
 Ce
 Zk
 qu
-wW
+Qv
 Uq
-fh
-wW
+vW
+Qv
 Uq
 UQ
 fk
@@ -26260,7 +26213,7 @@ jv
 rH
 Uq
 qb
-fH
+QQ
 Uq
 QZ
 zY
@@ -26462,13 +26415,13 @@ Uq
 Uq
 Uq
 Uq
-cN
+MM
 Uq
 pK
-Yu
+VT
 Uq
 Yf
-mO
+Zg
 tu
 CG
 QM
@@ -26660,14 +26613,14 @@ Zk
 Zk
 Zk
 Uq
-oy
-QQ
-MM
-MM
-sW
+uv
+VT
+wt
+wt
+VT
 Uq
 TT
-Yu
+VT
 Uq
 jx
 jx
@@ -27066,15 +27019,15 @@ Uq
 Uq
 no
 AR
-sW
-sW
-Xa
+VT
+VT
+Zg
 Uq
 pK
-Yu
+VT
 Uq
 sA
-UZ
+Hp
 tL
 wI
 Uq
@@ -27266,14 +27219,14 @@ dZ
 cf
 Uq
 Uq
-oy
-oy
+uv
+uv
 ti
 fS
 SZ
 Uq
 oE
-ip
+mh
 hN
 KP
 AY
@@ -27480,7 +27433,7 @@ Uq
 sN
 HV
 bv
-UZ
+Hp
 it
 bs
 aa
@@ -27677,7 +27630,7 @@ fy
 Ds
 dC
 pK
-Yu
+VT
 Uq
 YS
 jA
@@ -27879,12 +27832,12 @@ be
 fy
 dC
 pK
-Yu
+VT
 Uq
 tZ
-Qv
+Tv
 Ld
-Su
+pF
 qv
 bs
 aa
@@ -28081,7 +28034,7 @@ Tl
 gb
 pY
 OC
-Yu
+VT
 Uq
 Uq
 Uq

--- a/maps/away/blueriver/blueriver-1.dmm
+++ b/maps/away/blueriver/blueriver-1.dmm
@@ -17,31 +17,29 @@
 	color = "BLUE";
 	desc = "Slightly transparent. You are not sure what it is."
 	},
-/turf/simulated/floor/away/blueriver/alienfloor,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "f" = (
-/turf/simulated/floor/away/blueriver/alienfloor,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "g" = (
-/obj/machinery/replicator{
-	alpha = 150;
-	anchored = 1;
-	color = "BLUE"
+/mob/living/simple_animal/hostile/daemon/minion,
+/turf/unsimulated/mineral{
+	temperature = 233
 	},
-/turf/simulated/floor/away/blueriver/alienfloor,
 /area/bluespaceriver/underground)
 "h" = (
 /obj/item/pickaxe/xeno/brush,
-/turf/simulated/floor/away/blueriver/alienfloor,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "i" = (
 /obj/item/pickaxe/xeno/six_pick,
 /obj/item/device/measuring_tape,
-/turf/simulated/floor/away/blueriver/alienfloor,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "j" = (
 /obj/item/device/camera,
-/turf/simulated/floor/away/blueriver/alienfloor,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "k" = (
 /turf/simulated/floor/asteroid,
@@ -50,30 +48,42 @@
 /obj/item/gun/energy/plasmacutter,
 /obj/item/device/depth_scanner,
 /turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/one,
 /area/bluespaceriver/underground)
 "m" = (
 /mob/living/simple_animal/hostile/hive_alien/defender,
-/turf/simulated/floor/away/blueriver/alienfloor,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/one,
+/turf/simulated/floor/warhammer/basalt/two,
 /area/bluespaceriver/underground)
 "n" = (
 /obj/item/roller_bed,
 /turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "o" = (
 /obj/structure/ladder/up,
 /turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "p" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/two,
 /area/bluespaceriver/underground)
 "q" = (
 /obj/item/crowbar,
 /turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt/four,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "r" = (
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt/four,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "s" = (
 /obj/item/cell/infinite{
@@ -84,15 +94,20 @@
 	icon_state = "delivery";
 	name = "alien power cell"
 	},
-/turf/simulated/floor/away/blueriver/alienfloor,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "t" = (
 /obj/item/device/geiger,
 /turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt/four,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/one,
 /area/bluespaceriver/underground)
 "u" = (
 /obj/item/pickaxe/drill,
 /turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt/four,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "v" = (
 /obj/structure/deity{
@@ -105,11 +120,12 @@
 	desc = "A strange unerganomic pistol clearly not designed for a human hand. You are surprised that it actually has a trigger.";
 	name = "strange gun"
 	},
-/turf/simulated/floor/away/blueriver/alienfloor,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "w" = (
 /obj/structure/closet/excavation,
 /turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt,
 /area/bluespaceriver/underground)
 "x" = (
 /obj/machinery/crystal_static{
@@ -119,20 +135,93 @@
 	desc = "Slightly transparent. You are not sure what it is."
 	},
 /turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/one,
 /area/bluespaceriver/underground)
 "y" = (
 /obj/machinery/giga_drill{
 	alpha = 129;
 	color = "BLUE"
 	},
-/turf/simulated/floor/away/blueriver/alienfloor,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/one,
 /area/bluespaceriver/underground)
 "z" = (
 /obj/machinery/artifact{
 	alpha = 123;
 	color = "BLUE"
 	},
-/turf/simulated/floor/away/blueriver/alienfloor,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/one,
+/area/bluespaceriver/underground)
+"A" = (
+/turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/one,
+/area/bluespaceriver/underground)
+"C" = (
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/two,
+/area/bluespaceriver/underground)
+"E" = (
+/obj/random/loot/tech2,
+/turf/simulated/floor/warhammer/basalt,
+/area/bluespaceriver/underground)
+"F" = (
+/turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt,
+/area/bluespaceriver/underground)
+"K" = (
+/turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt/four,
+/turf/simulated/floor/warhammer/basalt,
+/area/bluespaceriver/underground)
+"M" = (
+/turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt,
+/area/bluespaceriver/underground)
+"S" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/basalt,
+/area/bluespaceriver/underground)
+"T" = (
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/one,
+/area/bluespaceriver/underground)
+"U" = (
+/turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/two,
+/area/bluespaceriver/underground)
+"V" = (
+/turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt/four,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt,
+/area/bluespaceriver/underground)
+"X" = (
+/obj/machinery/crystal_static{
+	alpha = 120;
+	anchored = 1;
+	color = "BLUE";
+	desc = "Slightly transparent. You are not sure what it is."
+	},
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/one,
+/area/bluespaceriver/underground)
+"Y" = (
+/turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt/four,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/one,
+/area/bluespaceriver/underground)
+"Z" = (
+/turf/simulated/floor/asteroid,
+/turf/simulated/floor/warhammer/basalt/four,
+/turf/simulated/floor/warhammer/basalt,
+/turf/simulated/floor/warhammer/basalt/two,
 /area/bluespaceriver/underground)
 
 (1,1,1) = {"
@@ -2333,9 +2422,9 @@ a
 a
 a
 a
-k
-k
-k
+A
+M
+M
 w
 a
 a
@@ -2435,10 +2524,10 @@ a
 a
 a
 a
-k
+M
 o
-k
-k
+M
+M
 a
 a
 a
@@ -2537,10 +2626,10 @@ a
 a
 a
 a
-k
-k
-k
-k
+M
+M
+M
+A
 a
 a
 a
@@ -2639,10 +2728,10 @@ a
 a
 a
 a
-k
-k
-k
-k
+U
+M
+M
+F
 a
 a
 a
@@ -2742,9 +2831,9 @@ b
 b
 b
 b
-k
-k
-k
+M
+M
+U
 a
 a
 a
@@ -2844,8 +2933,8 @@ b
 b
 b
 b
-k
-k
+A
+M
 b
 b
 b
@@ -2946,7 +3035,7 @@ b
 b
 b
 b
-p
+S
 b
 b
 b
@@ -3048,7 +3137,7 @@ b
 b
 b
 b
-p
+S
 b
 b
 b
@@ -3150,7 +3239,7 @@ c
 b
 b
 b
-p
+S
 b
 b
 b
@@ -3354,7 +3443,7 @@ b
 b
 b
 b
-p
+S
 b
 b
 b
@@ -3456,7 +3545,7 @@ b
 b
 b
 b
-p
+S
 b
 b
 b
@@ -3558,7 +3647,7 @@ b
 b
 b
 b
-p
+S
 b
 b
 b
@@ -3762,7 +3851,7 @@ b
 b
 b
 b
-p
+S
 b
 b
 b
@@ -3864,7 +3953,7 @@ b
 b
 b
 b
-p
+S
 b
 b
 b
@@ -3966,7 +4055,7 @@ b
 a
 b
 b
-p
+S
 b
 b
 b
@@ -4068,7 +4157,7 @@ a
 a
 b
 b
-p
+S
 b
 b
 b
@@ -4170,7 +4259,7 @@ a
 a
 a
 a
-k
+K
 t
 a
 a
@@ -4272,8 +4361,8 @@ a
 a
 a
 a
-k
-k
+K
+K
 a
 a
 a
@@ -4361,26 +4450,26 @@ b
 b
 b
 e
+E
 f
 f
 f
 f
 f
 f
-k
-k
-k
-k
-k
-k
-k
-k
-k
+M
+M
+U
+M
+M
+M
+V
+V
 x
-k
-k
-k
-k
+M
+M
+M
+M
 a
 a
 a
@@ -4466,23 +4555,23 @@ e
 h
 j
 f
+T
 f
 f
 f
-c
 l
-k
-k
-k
-k
+M
+M
+M
+M
 n
-k
-k
-k
-k
-k
-k
-k
+V
+V
+M
+M
+M
+U
+M
 a
 a
 a
@@ -4564,24 +4653,24 @@ a
 c
 c
 f
-g
+f
 i
 f
 f
 f
 e
+C
 f
-c
 a
 a
 a
 a
 a
 a
-k
-k
+K
+K
 a
-a
+g
 a
 a
 a
@@ -4673,17 +4762,17 @@ f
 f
 f
 f
-c
+f
 a
 a
 a
 a
 a
+a
+K
+Z
 a
 k
-k
-a
-a
 a
 a
 a
@@ -4770,8 +4859,8 @@ c
 c
 c
 f
-c
-c
+f
+T
 e
 f
 e
@@ -4782,8 +4871,8 @@ a
 a
 a
 a
-k
-k
+K
+K
 a
 a
 a
@@ -4872,8 +4961,8 @@ a
 c
 c
 c
-c
-c
+f
+f
 c
 f
 f
@@ -4884,8 +4973,8 @@ a
 a
 a
 a
-k
-k
+K
+K
 a
 a
 a
@@ -4972,22 +5061,22 @@ a
 a
 a
 a
-a
-c
-c
-c
-c
-c
+g
+f
+f
 f
 c
+c
+T
+c
 a
 a
 a
 a
 a
 a
-k
-k
+Y
+K
 a
 a
 a
@@ -5074,22 +5163,22 @@ a
 a
 a
 a
-a
-a
-c
-c
-c
-c
-c
-c
-a
-a
-a
-a
-a
-a
 k
-k
+a
+c
+c
+c
+c
+c
+c
+a
+a
+a
+a
+a
+a
+K
+K
 a
 a
 a
@@ -5190,8 +5279,8 @@ a
 a
 a
 a
-k
-k
+K
+K
 a
 a
 a
@@ -5494,13 +5583,13 @@ a
 a
 c
 c
-c
+f
 e
 f
 f
 e
-c
-c
+f
+f
 c
 a
 a
@@ -5596,13 +5685,13 @@ a
 a
 c
 c
-c
+f
 f
 f
 f
 y
 f
-c
+f
 c
 a
 a
@@ -5697,8 +5786,8 @@ a
 a
 a
 c
-e
-c
+X
+f
 f
 f
 f
@@ -5803,7 +5892,7 @@ e
 e
 f
 f
-f
+C
 f
 f
 z
@@ -5907,8 +5996,8 @@ f
 f
 f
 f
-c
-c
+f
+f
 c
 a
 a
@@ -6008,9 +6097,9 @@ m
 e
 s
 v
-c
-c
-c
+f
+f
+f
 c
 a
 a
@@ -6107,12 +6196,12 @@ a
 c
 f
 f
-c
-c
-c
-c
-c
-c
+f
+f
+f
+f
+f
+f
 c
 c
 a

--- a/maps/away/blueriver/blueriver-2.dmm
+++ b/maps/away/blueriver/blueriver-2.dmm
@@ -83,19 +83,19 @@
 /area/bluespaceriver/ship)
 "ao" = (
 /obj/machinery/computer/power_monitor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "ap" = (
 /obj/machinery/computer/ship/helm,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aq" = (
 /obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "ar" = (
 /obj/machinery/computer/ship/engines,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "as" = (
 /obj/machinery/light,
@@ -116,28 +116,28 @@
 /obj/item/paper{
 	info = "We've landed, and aside from the permafrost, there's not a lot to mention on this rock. The readings are strongest in the middle of an open field near the ship, but there's nothing there, meaning we really only have one choice. Digging down. One of the others thinks theres a good chance that it's underground, so we might as well see if they're onto something. We don't have any other decent plans, and we need this find. Fortunate we brought the larger scale excavation equipment."
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "au" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "av" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aw" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "ax" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "ay" = (
 /turf/simulated/wall/titanium,
@@ -152,7 +152,7 @@
 /area/bluespaceriver/ship)
 "aB" = (
 /obj/machinery/door/airlock/command,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aC" = (
 /obj/machinery/vending/boozeomat{
@@ -162,28 +162,28 @@
 /area/bluespaceriver/ship)
 "aD" = (
 /obj/machinery/computer/rdconsole,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aE" = (
 /obj/machinery/r_n_d/server,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aF" = (
 /obj/structure/handrail,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aG" = (
 /obj/machinery/door/airlock/science,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/handrail,
 /obj/item/stool/padded,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aI" = (
 /obj/machinery/vending/wallmed1{
@@ -199,32 +199,32 @@
 /obj/item/paper{
 	info = "Well, it didn't take the three days I was betting on, so i'm out twenty bucks, but we managed to punch through into a cave of some sort with the drilling equipment. We're lowering a ladder down now and sending one of the guards down to check that there's no spiders in there or anything. Once they report back, we'll Move the whole basecamp down there, and- SO, We've moved down into the cave now, and what we've found is astounding! It looks a LOT like a lake or river of blue goo, but... not? I took some scans, but couldn't pick anything up aside from radiation spikes from the pool. I also lowered a swab into the fluid to take a sample, but when I touched the swab to the surface of the... Fluid? the Swab just... Ceased And yes, that's the best way to describe it. it just stopped existing in my hand. We figure it's best we DON'T touch the blue stuff for now. one of our help has started moving supplies down into the cave to build a bridge of sorts though across the pool. We spotted some sort of structure on the far side, and the bridge is the only way to get to it, so now we wait."
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/stool/padded,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aK" = (
-/obj/random/maintenance/clean,
-/turf/simulated/floor/tiled,
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "aL" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_coffee,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aM" = (
 /obj/machinery/r_n_d/protolathe,
 /obj/item/paper{
 	info = "Well, it only took three weeks... this trip... but we finally found something worth investigating! An energy signature, just on or under the planet's surface. It's bizarre, similar to a bluespace signature, but... not. I'll need to get down there to really get a reading on it, but this could be the kind of discovery that makes a career. We've identified a landing site, so our pilot is setting the ship down there in the next couple of hours. it'll take some more time after that to set up a base camp and such."
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aN" = (
 /obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aO" = (
 /obj/machinery/smartfridge/chemistry,
@@ -233,34 +233,34 @@
 "aP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/stool/padded,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aQ" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/lunchbox/nt,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aR" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/glasses/mug,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aS" = (
 /obj/structure/table/steel,
 /obj/machinery/microwave,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aT" = (
 /obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aU" = (
 /obj/machinery/chemical_dispenser,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aV" = (
 /obj/machinery/chem_master,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -269,15 +269,15 @@
 	pixel_x = -25;
 	rcon_setting = 3
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "aY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "aZ" = (
 /obj/structure/table/steel,
@@ -287,7 +287,8 @@
 	icon_state = "tube1"
 	},
 /obj/random/maintenance/clean,
-/turf/simulated/floor/tiled,
+/obj/random/loot/valuableloot,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "ba" = (
 /obj/wallframe_spawn/reinforced,
@@ -299,14 +300,14 @@
 /obj/item/paper{
 	info = "I don't understand where they could have gone, but one of the researchers and a guard disappeared last night. We've started looking for them, figuring maybe they got trapped somewhere in the ruins, maybe a booby trap or something that was still functioning, but we haven't seen any sign of them. Their equipment, both of their equipment, is still in the ship, and there's no signs of anything grabbing them in the night, they're just... Gone.  Tomorrow morning we head back into space to go resupply and submit what we've found so far, but when we come back we'll have more than enough manpower to really dig into this place."
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/item/reagent_containers/spray,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -316,7 +317,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -330,7 +331,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -346,7 +347,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -356,14 +357,14 @@
 	dir = 1
 	},
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -372,7 +373,7 @@
 	},
 /obj/machinery/light,
 /obj/structure/filingcabinet,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -381,14 +382,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bl" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -403,7 +404,7 @@
 	dir = 8;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bo" = (
 /obj/machinery/light{
@@ -416,16 +417,16 @@
 /area/bluespaceriver/ship)
 "bp" = (
 /obj/machinery/fabricator,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bq" = (
 /obj/structure/bed/chair/office/light,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "br" = (
 /obj/machinery/artifact_analyser,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bs" = (
 /obj/structure/hygiene/toilet{
@@ -442,22 +443,22 @@
 /area/bluespaceriver/ship)
 "bt" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "bv" = (
 /obj/structure/curtain/open/bed,
 /obj/structure/bed/padded,
 /obj/item/bedsheet/brown,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bw" = (
 /obj/structure/curtain/open/bed,
 /obj/structure/bed/padded,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bx" = (
 /obj/structure/closet/hydrant,
@@ -468,13 +469,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bz" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bA" = (
 /obj/structure/table/glass,
@@ -483,13 +484,13 @@
 	code = "63214"
 	},
 /obj/item/form_printer,
-/obj/item/gun/energy/lasgun/laspistol/grim,
 /obj/item/rig/hazmat/equipped,
 /obj/random/cash,
 /obj/item/paper{
 	info = "We've finished the bridge and began our initial investigation into the site. Thus far, we're finding a lot of structures clearly made by a sapient species, one that from all indications was relatively advanced, but no signs of what actually happened to them. There's clear signs of habitation, but no signs of what caused abandonment. We're setting up camp in the ruins tonight so that we can continue studying as long as possible before our scheduled departure for refueling, but I feel confident we'll have enough to secure funds for the forseeable future at least!"
 	},
-/turf/simulated/floor/tiled,
+/obj/random/loot/raresidearmbundle,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bB" = (
 /obj/machinery/light{
@@ -513,7 +514,7 @@
 "bE" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -522,14 +523,14 @@
 	icon_state = "tube1"
 	},
 /obj/random/toolbox,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bG" = (
 /turf/simulated/floor/reinforced,
 /area/bluespaceriver/ship)
 "bH" = (
 /obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/bloodbar/off,
 /area/bluespaceriver/ship)
 "bI" = (
 /obj/structure/bed/padded,
@@ -537,25 +538,25 @@
 /obj/item/storage/secure/safe{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "bJ" = (
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "bK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "bL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/handrail,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "bM" = (
 /obj/structure/bed/padded,
@@ -563,7 +564,7 @@
 /obj/item/storage/secure/safe{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "bN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -575,13 +576,13 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bO" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bP" = (
 /obj/structure/fuel_port,
@@ -595,7 +596,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "bS" = (
 /obj/machinery/vending/wallmed1{
@@ -609,7 +610,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/mop,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "bT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -619,7 +620,7 @@
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Solar - Port"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -648,7 +649,7 @@
 /obj/item/storage/secure/safe{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "bY" = (
 /obj/structure/bed/padded,
@@ -656,67 +657,65 @@
 /obj/item/storage/secure/safe{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "bZ" = (
 /obj/structure/table/woodentable,
 /obj/random/energy,
 /obj/item/storage/pill_bottle/happy,
 /obj/random/contraband,
-/turf/simulated/floor/tiled,
+/obj/random/loot/valuableloot,
+/turf/simulated/floor/warhammer/darkwood,
 /area/bluespaceriver/ship)
 "ca" = (
 /obj/machinery/door/blast/shutters,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cb" = (
 /obj/machinery/door/blast/shutters,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cc" = (
 /obj/structure/closet/excavation,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cd" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/closet/wardrobe/science_white,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "ce" = (
 /obj/structure/closet/radiation,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/bluespaceriver/ship)
-"ch" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "ci" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/random/maintenance/clean,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/shieldwallgen,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "ck" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/shieldwallgen,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cl" = (
 /obj/structure/sign/warning/vacuum,
@@ -724,11 +723,11 @@
 /area/bluespaceriver/ship)
 "cm" = (
 /obj/machinery/door/airlock/external/bolted,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cn" = (
 /obj/structure/closet/secure_closet/scientist,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "co" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -736,14 +735,14 @@
 	level = 2
 	},
 /obj/machinery/floodlight,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/machinery/suspension_gen,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cq" = (
 /obj/structure/dispenser/oxygen,
@@ -751,25 +750,25 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cr" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cs" = (
 /obj/random/maintenance/clean,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "ct" = (
 /obj/structure/ore_box,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cu" = (
 /obj/machinery/door/blast/regular,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "cv" = (
 /obj/machinery/mining/brace,
@@ -834,7 +833,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 "Co" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -842,7 +841,7 @@
 /area/bluespaceriver/ship)
 "Lk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/bluespaceriver/ship)
 
 (1,1,1) = {"
@@ -2829,14 +2828,14 @@ aU
 bf
 ay
 ay
-bH
+aK
 ay
-bH
+aK
 ay
 cc
-ch
+au
 cm
-ch
+au
 cm
 ac
 ac
@@ -2936,7 +2935,7 @@ ay
 bX
 ay
 cd
-ch
+au
 ay
 cl
 ay
@@ -3038,7 +3037,7 @@ ay
 bJ
 ay
 ce
-ch
+au
 cn
 cr
 cu
@@ -3133,7 +3132,7 @@ aH
 aP
 aW
 bg
-bu
+cf
 bE
 bK
 bR
@@ -3142,7 +3141,7 @@ ca
 cf
 cj
 co
-ch
+au
 cu
 ac
 ac
@@ -3335,7 +3334,7 @@ ax
 aA
 aJ
 aJ
-aX
+cg
 bi
 bv
 ay
@@ -3343,7 +3342,7 @@ bJ
 ay
 bJ
 ay
-ch
+au
 cl
 ay
 ay
@@ -3447,8 +3446,8 @@ bY
 ay
 ci
 cm
-ch
-ch
+au
+au
 cm
 ac
 ac
@@ -3537,7 +3536,7 @@ ac
 an
 an
 aC
-aK
+cs
 au
 au
 bk
@@ -3547,7 +3546,7 @@ bH
 ay
 bZ
 ay
-ch
+au
 cm
 cq
 ct

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -110,22 +110,22 @@
 	name = "Casino Bridge Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bridge)
 "ap" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "aq" = (
 /obj/machinery/computer/ship/engines,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "ar" = (
 /obj/machinery/computer/ship/helm,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "as" = (
 /obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "at" = (
 /obj/wallframe_spawn/reinforced,
@@ -138,19 +138,19 @@
 	name = "Casino Bridge Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bridge)
 "au" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "av" = (
 /obj/structure/table/steel_reinforced,
-/obj/random/handgun,
-/turf/simulated/floor/tiled,
+/obj/random/loot/lootartifacts,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "aw" = (
 /obj/item/wirecutters,
@@ -161,18 +161,18 @@
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "ay" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "aA" = (
 /obj/machinery/computer/modular{
 	dir = 8;
 	name = "Gambling console"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "aB" = (
 /turf/simulated/wall/r_wall,
@@ -180,7 +180,7 @@
 "aC" = (
 /obj/machinery/door/firedoor,
 /obj/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "aD" = (
 /obj/machinery/door/airlock/external{
@@ -189,20 +189,20 @@
 	id_tag = "casino_dock_outer";
 	name = "Docking Port Airlock"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "aE" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "aF" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "aH" = (
 /obj/floor_decal/industrial/warning{
@@ -217,7 +217,7 @@
 	},
 /obj/item/device/multitool,
 /obj/item/plastique,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "aI" = (
 /obj/floor_decal/industrial/warning{
@@ -230,24 +230,24 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "aJ" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/loot,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "aL" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/radio,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "aM" = (
 /obj/machinery/computer/modular{
 	dir = 8;
 	name = "Security console"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "aN" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -257,7 +257,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "aO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -269,11 +269,11 @@
 /obj/floor_decal/industrial/warning{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "aT" = (
 /obj/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "aU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -283,7 +283,7 @@
 	id_tag = "casino_dock_inner";
 	name = "Docking Port Airlock"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "aV" = (
 /obj/machinery/light{
@@ -305,7 +305,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "aW" = (
 /obj/machinery/button/blast_door{
@@ -321,7 +321,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "ba" = (
 /obj/structure/closet/warhammer/emcloset,
@@ -329,7 +329,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "bb" = (
 /obj/structure/lattice,
@@ -380,7 +380,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "bf" = (
 /obj/machinery/door/firedoor,
@@ -388,7 +388,7 @@
 	name = "Casino Bridge"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "bh" = (
 /turf/simulated/floor/tiled/dark,
@@ -410,13 +410,13 @@
 	pixel_y = 2
 	},
 /obj/item/gun/projectile/pistol/sec/MK,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bk" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "casino_weaponry"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -425,25 +425,25 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bn" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bo" = (
 /obj/machinery/floodlight,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -462,13 +462,13 @@
 "bu" = (
 /obj/structure/table/rack,
 /obj/item/material/knife/combat,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -477,7 +477,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bz" = (
 /obj/structure/cable{
@@ -491,7 +491,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bA" = (
 /obj/item/trash/cigbutt/professionals{
@@ -509,7 +509,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bB" = (
 /obj/item/trash/cigbutt/professionals,
@@ -524,7 +524,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bC" = (
 /obj/machinery/light/small{
@@ -541,7 +541,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bD" = (
 /obj/item/material/shard,
@@ -554,7 +554,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bE" = (
 /obj/decal/cleanable/blood/drip,
@@ -570,7 +570,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bF" = (
 /obj/decal/cleanable/blood/drip,
@@ -585,7 +585,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bG" = (
 /obj/machinery/door/airlock{
@@ -603,7 +603,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_security)
 "bI" = (
 /obj/structure/fireaxecabinet{
@@ -620,7 +620,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "bJ" = (
 /obj/machinery/light{
@@ -635,7 +635,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "bK" = (
 /obj/structure/reagent_dispensers/peppertank{
@@ -647,7 +647,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "bL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -659,7 +659,7 @@
 /obj/machinery/alarm{
 	pixel_y = 25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "bM" = (
 /obj/machinery/door/airlock{
@@ -673,7 +673,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "bN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -682,7 +682,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "bO" = (
 /obj/machinery/light{
@@ -694,7 +694,7 @@
 	dir = 8;
 	level = 2
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "bP" = (
 /obj/machinery/button/blast_door{
@@ -710,38 +710,38 @@
 	pixel_y = 25
 	},
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "bQ" = (
 /obj/structure/bed/chair,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "bR" = (
 /obj/machinery/alarm{
 	pixel_y = 25
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "bS" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "bT" = (
 /obj/machinery/atmospherics/unary/tank/nitrogen,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "bU" = (
 /obj/structure/table/rack,
 /obj/item/gun/projectile/shotgun/pump/voxlegis,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bV" = (
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bW" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "bZ" = (
 /turf/simulated/wall,
@@ -753,19 +753,19 @@
 /turf/simulated/wall/r_wall,
 /area/casino/casino_crew_bunk)
 "cc" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cd" = (
 /obj/decal/cleanable/blood/splatter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "ce" = (
 /obj/structure/cable{
 	icon_state = "4-9"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cf" = (
 /obj/structure/cable{
@@ -778,50 +778,50 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cg" = (
 /obj/structure/table/rack,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "ch" = (
 /obj/structure/table/rack,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "ci" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/wrench,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "cj" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/radio,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "ck" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "cl" = (
 /obj/machinery/atmospherics/binary/pump/high_power,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_security)
 "cm" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "cn" = (
 /obj/structure/table/rack,
 /obj/item/tank/nitrogen,
 /obj/item/tank/nitrogen,
 /obj/item/tank/nitrogen,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "co" = (
 /turf/simulated/wall/r_wall,
@@ -837,13 +837,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "cr" = (
 /obj/structure/bed,
 /obj/random/plushie,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cs" = (
 /obj/structure/closet,
@@ -855,7 +855,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "ct" = (
 /obj/machinery/light{
@@ -868,7 +868,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cu" = (
 /obj/machinery/vending/wallmed1{
@@ -881,7 +881,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cv" = (
 /obj/structure/bed,
@@ -891,7 +891,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cw" = (
 /obj/structure/closet,
@@ -902,7 +902,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cx" = (
 /obj/machinery/light{
@@ -915,7 +915,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cy" = (
 /obj/structure/bed,
@@ -928,7 +928,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cz" = (
 /obj/structure/table/steel_reinforced,
@@ -938,23 +938,24 @@
 	level = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cA" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cB" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/radio,
-/turf/simulated/floor/tiled,
+/obj/random/loot/gunbundle,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cC" = (
 /obj/machinery/computer/modular{
 	dir = 8;
 	name = "Gambling console"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cD" = (
 /obj/wallframe_spawn/reinforced,
@@ -963,17 +964,17 @@
 	id_tag = "casino_shuttle_control"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/wall/r_wall,
 /area/casino/casino_security)
 "cF" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "cH" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bathroom)
 "cI" = (
 /obj/structure/cable{
@@ -992,7 +993,7 @@
 	pixel_y = 24;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bathroom)
 "cJ" = (
 /obj/machinery/door/firedoor,
@@ -1010,30 +1011,31 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bathroom)
 "cL" = (
 /obj/decal/cleanable/blood/splatter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cM" = (
 /obj/decal/cleanable/blood/splatter,
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cN" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cO" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cP" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/obj/random/loot/rarearmorbundle,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "cQ" = (
 /obj/structure/table/steel_reinforced,
@@ -1041,14 +1043,14 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cS" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cT" = (
 /obj/machinery/light{
@@ -1060,18 +1062,18 @@
 	icon_state = "console";
 	name = "Cameras console"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "cU" = (
 /obj/floor_decal/industrial/warning,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "cV" = (
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "cW" = (
 /obj/floor_decal/industrial/warning,
@@ -1082,7 +1084,7 @@
 	icon_state = "map_vent_out";
 	use_power = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "cX" = (
 /obj/machinery/door/blast/regular{
@@ -1090,7 +1092,7 @@
 	id_tag = "casino_hangar";
 	name = "Hangar gate"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_hangar)
 "cY" = (
 /obj/structure/lattice,
@@ -1101,7 +1103,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bathroom)
 "db" = (
 /obj/machinery/door/firedoor,
@@ -1119,7 +1121,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_maintenance)
 "dc" = (
 /obj/structure/cable{
@@ -1127,7 +1129,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "dd" = (
 /obj/structure/closet,
@@ -1135,61 +1137,61 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "de" = (
 /obj/machinery/light,
 /obj/structure/bed,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "df" = (
 /obj/structure/closet,
 /obj/random/junk,
 /obj/random/smokes,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "dg" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "dh" = (
 /obj/structure/bed,
 /obj/random/plushie,
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "di" = (
 /obj/machinery/light,
 /obj/structure/closet,
 /obj/random/action_figure,
 /obj/random/shoes,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "dj" = (
 /obj/machinery/vending/security{
 	req_access = list()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "dm" = (
 /obj/machinery/computer/modular{
 	dir = 8;
 	name = "Security console"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "dn" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "dr" = (
 /obj/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "ds" = (
 /obj/machinery/power/tracker,
@@ -1209,13 +1211,13 @@
 	},
 /obj/item/material/knife/folding,
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bathroom)
 "du" = (
 /obj/machinery/door/airlock{
 	name = "Crew toilet"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bathroom)
 "dx" = (
 /turf/simulated/wall,
@@ -1223,36 +1225,30 @@
 "dy" = (
 /turf/simulated/wall/r_wall,
 /area/casino/casino_storage)
-"dz" = (
-/obj/random/ammo,
-/turf/simulated/floor/tiled,
-/area/casino/casino_security)
 "dA" = (
 /obj/structure/table/rack,
 /obj/item/gun/projectile/shotgun/pump/voxlegis,
-/obj/item/gun/projectile/shotgun/pump/voxlegis,
-/obj/item/gun/projectile/shotgun/pump/voxlegis,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "dB" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/ammo/shotgunammo,
 /obj/item/storage/box/ammo/shotgunammo,
 /obj/item/storage/box/ammo/shotgunammo,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "dC" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/armor/bulletproof/vest,
-/obj/item/clothing/suit/armor/bulletproof/vest,
-/turf/simulated/floor/tiled,
+/obj/random/loot/lootcontraband,
+/obj/random/loot/lootartifacts,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "dD" = (
 /obj/structure/table/rack,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
 /obj/item/tank/air,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "dE" = (
 /obj/floor_decal/industrial/warning{
@@ -1261,7 +1257,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "dL" = (
 /obj/structure/cable/yellow{
@@ -1275,21 +1271,21 @@
 /obj/structure/bed/chair/comfy/red{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "dN" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/casino/bj_table,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "dO" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/casino/bj_table/bj_right,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "dP" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "dQ" = (
 /obj/structure/table/woodentable,
@@ -1309,26 +1305,25 @@
 	pixel_y = 5
 	},
 /obj/random/tool,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "dR" = (
 /obj/structure/bed/chair,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "dS" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "dT" = (
 /obj/structure/bed/chair/office/light,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "dU" = (
 /obj/item/clothing/suit/armor/bulletproof/vest,
-/obj/random/ammo,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "eb" = (
 /obj/overmap/visitable/ship/casino,
@@ -1357,11 +1352,11 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bathroom)
 "ef" = (
 /obj/structure/curtain/open/shower,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bathroom)
 "eg" = (
 /obj/random/trash,
@@ -1372,7 +1367,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "eh" = (
 /obj/structure/table/gamblingtable,
@@ -1381,38 +1376,37 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "ei" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/casino/roulette,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "ej" = (
 /obj/item/stock_parts/circuitboard/broken,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "ek" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "el" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "em" = (
-/obj/random/ammo,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "en" = (
 /obj/structure/safe,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_security)
 "eq" = (
 /obj/structure/cable/yellow{
@@ -1504,63 +1498,62 @@
 /area/space)
 "ew" = (
 /obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "ex" = (
 /obj/structure/casino/oh_bandit,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "ey" = (
 /obj/structure/bed/chair,
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "ez" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "eA" = (
 /obj/item/device/multitool,
 /obj/item/wirecutters,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "eB" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Safe area"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_security)
 "eC" = (
 /obj/random/coin,
 /obj/random/cash,
-/obj/random/ammo,
-/turf/simulated/floor/plating,
+/obj/random/cash,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_security)
 "eD" = (
 /obj/random/coin,
-/obj/random/ammo,
-/obj/random/ammo,
-/turf/simulated/floor/plating,
+/obj/random/cash,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_security)
 "eE" = (
 /obj/random/coin,
 /obj/random/coin,
 /obj/item/storage/bag/cash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_security)
 "eF" = (
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "eG" = (
 /obj/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "eH" = (
 /obj/floor_decal/industrial/warning{
@@ -1572,7 +1565,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "eI" = (
 /obj/structure/cable/yellow,
@@ -1585,24 +1578,24 @@
 /area/space)
 "eJ" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "eK" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "eL" = (
 /obj/machinery/vending/generic,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "eM" = (
 /obj/machinery/vending/engineering{
 	req_access = list()
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "eN" = (
 /obj/machinery/light/small{
@@ -1615,27 +1608,27 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "eO" = (
 /obj/machinery/constructable_frame/machine_frame,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "eP" = (
 /obj/machinery/light,
 /obj/machinery/vending/tool,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "eQ" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "eR" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/toolbox/electrical,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "eS" = (
 /obj/structure/table/steel_reinforced,
@@ -1644,7 +1637,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "eT" = (
 /obj/structure/table/steel_reinforced,
@@ -1656,7 +1649,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "eU" = (
 /obj/decal/cleanable/blood/splatter,
@@ -1676,20 +1669,19 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_storage)
 "eV" = (
-/obj/random/cash,
-/obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
-/area/casino/casino_security)
+/mob/living/simple_animal/hostile/human/heretic/trooper,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
+/area/casino/casino_mainfloor)
 "eW" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "eX" = (
 /obj/structure/cable{
@@ -1697,7 +1689,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "eY" = (
 /obj/structure/cable{
@@ -1710,7 +1702,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "eZ" = (
 /obj/structure/cable{
@@ -1721,11 +1713,11 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "fa" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "fb" = (
 /obj/structure/closet/warhammer/emcloset,
@@ -1733,15 +1725,15 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_hangar)
 "fc" = (
 /obj/machinery/floodlight,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fd" = (
 /obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fe" = (
 /obj/structure/cable{
@@ -1757,7 +1749,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "ff" = (
 /obj/machinery/door/firedoor,
@@ -1772,7 +1764,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_maintenance)
 "fg" = (
 /obj/machinery/door/airlock{
@@ -1780,7 +1772,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_security)
 "fh" = (
 /obj/machinery/door/firedoor,
@@ -1800,11 +1792,11 @@
 	name = "Casino Checkpoint Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "fi" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1813,7 +1805,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fk" = (
 /obj/random/trash,
@@ -1826,7 +1818,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fo" = (
 /obj/machinery/door/airlock{
@@ -1841,7 +1833,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_maintenance)
 "fq" = (
 /obj/random/coin,
@@ -1860,7 +1852,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "fr" = (
 /obj/machinery/door/airlock{
@@ -1879,7 +1871,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "fu" = (
 /obj/structure/table/steel_reinforced,
@@ -1898,7 +1890,7 @@
 	name = "Casino Checkpoint Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "fv" = (
 /obj/decal/cleanable/blood/drip,
@@ -1907,7 +1899,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "fw" = (
 /obj/machinery/light{
@@ -1915,22 +1907,22 @@
 	icon_state = "tube1"
 	},
 /obj/structure/coatrack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "fx" = (
 /obj/random/loot,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "fy" = (
 /obj/structure/casino/oh_bandit,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "fz" = (
 /obj/structure/casino/oh_bandit,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "fA" = (
 /obj/wallframe_spawn/reinforced,
@@ -1941,13 +1933,13 @@
 	id_tag = "casino_main"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_mainfloor)
 "fB" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fC" = (
 /obj/structure/cable{
@@ -1955,11 +1947,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fD" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fE" = (
 /obj/machinery/door/firedoor,
@@ -1971,7 +1963,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_maintenance)
 "fF" = (
 /obj/machinery/door/airlock{
@@ -1985,7 +1977,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "fH" = (
 /obj/structure/table/steel_reinforced,
@@ -1997,30 +1989,30 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "fI" = (
 /obj/decal/cleanable/blood/drip,
 /obj/item/ammo_casing/shotgun,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "fJ" = (
 /obj/item/material/shard,
 /obj/structure/coatrack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "fK" = (
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "fL" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "fM" = (
 /obj/machinery/power/solar{
@@ -2034,15 +2026,15 @@
 "fN" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fO" = (
 /obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fP" = (
 /obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "fQ" = (
 /turf/simulated/wall,
@@ -2055,14 +2047,14 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "fS" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "fT" = (
 /obj/machinery/light{
@@ -2072,28 +2064,28 @@
 	name = "plastic table frame"
 	},
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "fU" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "fV" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/reagent_containers/food/drinks/small_milk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "fW" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/trash/cigbutt/professionals,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "fX" = (
 /obj/structure/table/standard{
@@ -2102,7 +2094,7 @@
 /obj/item/trash/plate,
 /obj/random/snack,
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "fY" = (
 /obj/machinery/light{
@@ -2112,11 +2104,11 @@
 	name = "plastic table frame"
 	},
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "fZ" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "ga" = (
 /turf/simulated/wall,
@@ -2126,7 +2118,7 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "gc" = (
 /obj/structure/closet/warhammer/emcloset,
@@ -2137,7 +2129,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "gd" = (
 /obj/machinery/door/firedoor,
@@ -2152,14 +2144,16 @@
 	name = "Casino Checkpoint Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_security)
 "ge" = (
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 4
+	},
 /area/casino/casino_mainfloor)
 "gf" = (
 /obj/structure/window/basic,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "gg" = (
 /turf/simulated/wall/r_wall,
@@ -2172,7 +2166,7 @@
 /obj/random/material,
 /obj/random/material,
 /obj/random/material,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "gi" = (
 /obj/structure/table/rack{
@@ -2181,41 +2175,43 @@
 /obj/random/tech_supply,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "gj" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "gk" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "gl" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "gm" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/item/reagent_containers/food/drinks/flask/shiny,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "gn" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "gp" = (
-/obj/random/ammo,
-/turf/simulated/floor/tiled,
+/obj/machinery/door/firedoor,
+/obj/structure/table/marble,
+/mob/living/simple_animal/hostile/human/heretic/trooper,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "gq" = (
 /obj/structure/safe,
@@ -2233,7 +2229,7 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = 30
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "gr" = (
 /obj/structure/safe,
@@ -2249,7 +2245,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "gs" = (
 /obj/machinery/door/firedoor,
@@ -2258,12 +2254,12 @@
 	id_tag = "casino_main";
 	name = "Main floor Blast Doors"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "gt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "gu" = (
 /obj/structure/table/woodentable,
@@ -2272,7 +2268,7 @@
 	dir = 1
 	},
 /obj/item/material/ashtray/bronze,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "gv" = (
 /obj/structure/table/woodentable,
@@ -2280,7 +2276,7 @@
 /obj/item/storage/fancy/smokable/cigar{
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "gw" = (
 /obj/structure/cable/yellow{
@@ -2325,7 +2321,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "gz" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -2356,7 +2352,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	id_tag = "casino_solar_pump"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "gA" = (
 /obj/structure/table/rack{
@@ -2364,43 +2360,46 @@
 	},
 /obj/item/stack/cable_coil,
 /obj/random/material,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "gB" = (
 /obj/decal/cleanable/generic,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "gC" = (
 /obj/structure/table/rack{
 	dir = 8
 	},
 /obj/random/tech_supply,
-/turf/simulated/floor/plating,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "gD" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "gE" = (
 /obj/item/trash/cigbutt/menthol,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "gG" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "gH" = (
 /obj/random/coin,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "gI" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "gJ" = (
 /obj/random/cash,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 5
+	},
 /area/casino/casino_mainfloor)
 "gK" = (
 /obj/structure/cable/yellow{
@@ -2428,22 +2427,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "gM" = (
 /turf/simulated/wall,
 /area/casino/casino_solar_control)
 "gX" = (
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "gY" = (
-/obj/random/cash,
-/turf/simulated/floor/tiled,
-/area/casino/casino_mainfloor)
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/casino/casino_kitchen)
 "gZ" = (
 /obj/decal/cleanable/blood/drip,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "ha" = (
 /obj/structure/cable/yellow{
@@ -2484,7 +2483,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "hc" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -2495,7 +2494,7 @@
 	dir = 1
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "hd" = (
 /obj/structure/table/rack{
@@ -2503,18 +2502,18 @@
 	},
 /obj/random/tech_supply,
 /obj/item/stack/cable_coil,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "hf" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "hg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/marble,
 /obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "hi" = (
 /obj/item/storage/secure/briefcase/money,
@@ -2525,12 +2524,12 @@
 /obj/random/cash,
 /obj/random/cash,
 /obj/random/cash,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "hj" = (
-/obj/random/ammo,
-/turf/simulated/floor/carpet,
-/area/casino/casino_mainfloor)
+/obj/random/loot/lootstructureartifact,
+/turf/simulated/floor/warhammer/plate,
+/area/casino/casino_bridge)
 "hk" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/solar{
@@ -2554,7 +2553,7 @@
 	dir = 1;
 	target_pressure = 200
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "hm" = (
 /obj/machinery/power/solar_control{
@@ -2568,7 +2567,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "hn" = (
 /turf/simulated/wall,
@@ -2577,78 +2576,80 @@
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = 30
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hq" = (
 /obj/machinery/cooker/cereal,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hr" = (
 /obj/machinery/cooker/candy,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hs" = (
 /obj/machinery/cooker/fryer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "ht" = (
 /obj/machinery/cooker/oven,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hu" = (
 /obj/machinery/cooker/grill,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hv" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hw" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Kitchen"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hy" = (
 /obj/item/material/shard,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "hz" = (
 /obj/item/device/flash,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "hA" = (
 /obj/machinery/light,
 /obj/structure/flora/pottedplant,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "hB" = (
 /obj/item/trash/cigbutt/cigarbutt,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 8
+	},
 /area/casino/casino_mainfloor)
 "hC" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/casino/roulette_chart,
 /obj/random/coin,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "hD" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/casino/roulette,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "hE" = (
 /obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "hF" = (
 /obj/structure/cable/yellow{
@@ -2657,7 +2658,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "hG" = (
 /obj/machinery/power/terminal,
@@ -2668,35 +2669,35 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "hH" = (
 /obj/random/trash,
 /obj/structure/table/rack{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "hJ" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hK" = (
 /obj/decal/cleanable/flour,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hL" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hM" = (
 /obj/structure/coatrack,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "hN" = (
 /obj/decal/cleanable/generic,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "hP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -2714,7 +2715,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "hR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2733,7 +2734,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "hS" = (
 /obj/machinery/light/small,
@@ -2748,7 +2749,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "hT" = (
 /obj/machinery/door/firedoor,
@@ -2766,21 +2767,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hV" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hW" = (
 /obj/decal/cleanable/egg_smudge,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hX" = (
 /obj/structure/table/marble,
 /obj/machinery/reagentgrinder/juicer,
 /obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "hY" = (
 /obj/machinery/light{
@@ -2788,46 +2789,50 @@
 	icon_state = "tube1"
 	},
 /obj/structure/coatrack,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "hZ" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 8
+	},
 /area/casino/casino_mainfloor)
 "ia" = (
 /obj/structure/table/woodentable,
 /obj/item/trash/plate,
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "ib" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "ic" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 4
+	},
 /area/casino/casino_mainfloor)
 "id" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "ie" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/casino/craps,
 /obj/random/coin,
 /obj/random/coin,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "if" = (
 /obj/random/smokes,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "ig" = (
 /obj/structure/cable/yellow{
@@ -2853,7 +2858,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "ii" = (
 /obj/machinery/door/firedoor,
@@ -2866,7 +2871,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "ij" = (
 /turf/simulated/wall/r_wall,
@@ -2884,7 +2889,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "il" = (
 /obj/structure/closet/fridge,
@@ -2900,7 +2905,7 @@
 /obj/item/storage/fancy/egg_box/full,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/sugar,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "im" = (
 /obj/structure/closet/fridge,
@@ -2909,12 +2914,12 @@
 	},
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/item/reagent_containers/food/snacks/sliceable/bread,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "in" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/condiment/flour,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "io" = (
 /obj/structure/table/marble,
@@ -2923,36 +2928,38 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/chem_master/condimaster,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "ip" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 4
 	},
 /obj/item/material/knife/table,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 8
+	},
 /area/casino/casino_mainfloor)
 "iq" = (
 /obj/structure/table/woodentable,
 /obj/item/trash/plate,
 /obj/item/reagent_containers/food/snacks/applepie,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "ir" = (
 /obj/structure/table/woodentable,
 /obj/item/trash/plate,
 /obj/item/reagent_containers/food/snacks/bigbiteburger,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "is" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/casino/craps/craps_down,
 /obj/item/dice,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "iu" = (
 /obj/structure/flora/pottedplant,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "iv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2963,7 +2970,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2974,7 +2981,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "ix" = (
 /obj/structure/cable{
@@ -2985,7 +2992,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iz" = (
 /obj/structure/fireaxecabinet{
@@ -3002,7 +3009,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iA" = (
 /obj/structure/cable{
@@ -3016,7 +3023,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iB" = (
 /obj/structure/cable{
@@ -3026,7 +3033,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "iC" = (
 /obj/structure/window/basic{
@@ -3061,12 +3068,12 @@
 /area/casino/casino_kitchen)
 "iF" = (
 /obj/machinery/vending/dinnerware,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "iG" = (
 /obj/structure/table/marble,
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "iH" = (
 /obj/floor_decal/industrial/warning{
@@ -3077,7 +3084,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iI" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide,
@@ -3085,7 +3092,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iJ" = (
 /obj/floor_decal/industrial/warning{
@@ -3093,13 +3100,13 @@
 	icon_state = "warning"
 	},
 /obj/machinery/floodlight,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iK" = (
 /obj/floor_decal/industrial/warning{
 	dir = 5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iL" = (
 /obj/machinery/light/small{
@@ -3113,7 +3120,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iM" = (
 /obj/structure/window/basic{
@@ -3130,29 +3137,30 @@
 /area/casino/casino_kitchen)
 "iP" = (
 /obj/decal/cleanable/pie_smudge,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "iQ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/marble,
 /obj/item/trash/tray,
 /obj/item/reagent_containers/food/snacks/stew,
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/human/heretic/trooper,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "iR" = (
 /obj/structure/table/woodentable,
 /obj/item/trash/plate,
 /obj/item/material/kitchen/utensil/spoon,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "iS" = (
 /obj/machinery/light,
 /obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "iT" = (
 /obj/random/coin,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "iU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -3164,17 +3172,17 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iW" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iX" = (
 /obj/machinery/atmospherics/omni/filter{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iY" = (
 /obj/floor_decal/industrial/warning{
@@ -3184,7 +3192,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "iZ" = (
 /obj/structure/cable{
@@ -3196,7 +3204,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "ja" = (
 /obj/machinery/light{
@@ -3204,7 +3212,7 @@
 	icon_state = "tube1"
 	},
 /obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "jb" = (
 /obj/structure/synthesized_instrument/synthesizer/piano,
@@ -3212,38 +3220,38 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "jc" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "jd" = (
-/obj/random/coin,
-/obj/random/ammo,
-/turf/simulated/floor/carpet,
-/area/casino/casino_mainfloor)
+/obj/structure/closet/warhammer/emcloset,
+/obj/random/loot/rigloot,
+/turf/simulated/floor/warhammer/plating,
+/area/casino/casino_bow)
 "je" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/wall/r_wall,
 /area/casino/casino_crew_atmos)
 "jf" = (
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "ji" = (
 /obj/floor_decal/industrial/warning{
@@ -3253,7 +3261,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jj" = (
 /obj/structure/cable{
@@ -3265,7 +3273,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jk" = (
 /obj/structure/cable{
@@ -3279,7 +3287,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "jl" = (
 /obj/machinery/door/firedoor,
@@ -3292,7 +3300,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "jm" = (
 /obj/machinery/light{
@@ -3304,7 +3312,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "jn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3313,7 +3321,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "jo" = (
 /obj/machinery/door/firedoor,
@@ -3326,7 +3334,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3335,7 +3343,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jq" = (
 /obj/structure/hygiene/sink/kitchen{
@@ -3345,25 +3353,25 @@
 	dir = 8;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jr" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "js" = (
 /obj/machinery/alarm{
 	pixel_y = 25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jt" = (
 /obj/machinery/vending/boozeomat{
 	req_access = list()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "ju" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -3389,23 +3397,23 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jx" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jy" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jA" = (
 /obj/floor_decal/industrial/warning{
@@ -3415,7 +3423,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jB" = (
 /obj/machinery/light/small{
@@ -3431,7 +3439,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jC" = (
 /obj/item/broken_bottle,
@@ -3442,11 +3450,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "jD" = (
 /obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "jE" = (
 /obj/structure/table/marble,
@@ -3464,52 +3472,52 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jF" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/bar_alc/full,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jG" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jH" = (
 /obj/structure/table/marble,
 /obj/item/material/ashtray/bronze,
 /obj/item/flame/lighter/zippo/random,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jI" = (
 /obj/item/stool/bar,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "jJ" = (
 /obj/structure/table/woodentable,
 /obj/item/material/ashtray/bronze,
 /obj/item/reagent_containers/food/snacks/cubancarp,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "jK" = (
 /obj/item/material/ashtray/bronze,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "jL" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4;
 	start_pressure = 740.5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jM" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jN" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jO" = (
 /obj/floor_decal/industrial/warning{
@@ -3519,7 +3527,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jP" = (
 /obj/decal/cleanable/generic,
@@ -3532,7 +3540,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jQ" = (
 /obj/structure/table/marble,
@@ -3542,7 +3550,7 @@
 /obj/item/storage/box/glasses/pint,
 /obj/item/storage/box/glasses/wine,
 /obj/item/device/radio,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "jR" = (
 /obj/structure/table/marble,
@@ -3553,24 +3561,24 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
 	pixel_x = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jS" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/bar_soft/full,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jT" = (
 /obj/structure/table/marble,
 /obj/random/coin,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "jU" = (
 /obj/structure/table/woodentable,
 /obj/item/trash/plate,
 /obj/item/reagent_containers/food/snacks/waffles,
 /obj/item/reagent_containers/food/drinks/cans/iced_tea,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "jV" = (
 /obj/structure/table/gamblingtable,
@@ -3580,7 +3588,7 @@
 	pixel_y = -5
 	},
 /obj/item/dice,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "jW" = (
 /obj/structure/table/gamblingtable,
@@ -3590,35 +3598,35 @@
 	pixel_y = -5
 	},
 /obj/random/coin,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "jX" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/casino/bj_table/bj_right,
 /obj/item/clothing/mask/smokable/cigarette/cigar/havana,
 /obj/item/material/ashtray/bronze,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "jY" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "jZ" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "ka" = (
 /obj/decal/cleanable/generic,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "kb" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "kc" = (
 /obj/structure/cable{
@@ -3628,7 +3636,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "kd" = (
 /obj/structure/table/marble,
@@ -3639,11 +3647,11 @@
 /obj/random/drinkbottle,
 /obj/random/drinkbottle,
 /obj/random/drinkbottle,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "ke" = (
 /obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "kf" = (
 /obj/structure/table/marble,
@@ -3653,38 +3661,38 @@
 /obj/random/drinkbottle,
 /obj/random/drinkbottle,
 /obj/random/drinkbottle,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "kg" = (
 /obj/item/trash/cigbutt/professionals,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "kh" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/drinks/bottle/cognac,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "ki" = (
 /obj/item/stool/bar,
 /obj/random/coin,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kj" = (
 /obj/item/broken_bottle,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kk" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/casino/craps/craps_down,
 /obj/random/coin,
 /obj/random/coin,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kl" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "km" = (
 /obj/floor_decal/industrial/warning{
@@ -3695,7 +3703,8 @@
 /obj/item/wrench,
 /obj/item/clothing/head/welding,
 /obj/item/weldingtool,
-/turf/simulated/floor/plating,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "kn" = (
 /obj/machinery/door/firedoor,
@@ -3709,52 +3718,51 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "ko" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/drinks/h_chocolate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "kp" = (
 /obj/structure/table/marble,
 /obj/item/storage/fancy/smokable/cigar{
 	pixel_y = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "kq" = (
 /obj/structure/table/marble,
 /obj/random/smokes,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "kr" = (
 /obj/structure/table/marble,
 /obj/random/loot,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "ks" = (
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "kt" = (
 /obj/structure/table/woodentable,
 /obj/item/pizzabox/meat,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "ku" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "kv" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "kw" = (
-/obj/random/ammo,
 /obj/decal/cleanable/blood/splatter,
 /obj/structure/cable{
 	d1 = 1;
@@ -3763,29 +3771,28 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kx" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "ky" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/random/ammo,
 /obj/structure/flora/pottedplant/overgrown,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kz" = (
 /obj/structure/flora/pottedplant/overgrown,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kA" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/casino/bj_table,
 /obj/random/coin,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "kB" = (
 /obj/structure/table/gamblingtable,
@@ -3795,14 +3802,14 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "kC" = (
 /turf/simulated/wall/r_wall,
 /area/casino/casino_bow)
 "kD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "kE" = (
 /obj/floor_decal/industrial/warning{
@@ -3815,10 +3822,10 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /obj/item/device/radio,
-/turf/simulated/floor/plating,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "kG" = (
-/obj/random/ammo,
 /obj/decal/cleanable/blood/splatter,
 /obj/structure/cable{
 	d1 = 4;
@@ -3831,7 +3838,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kH" = (
 /obj/random/loot,
@@ -3846,23 +3853,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kI" = (
-/obj/random/ammo,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/casino/casino_mainfloor)
+/obj/structure/table/rack,
+/obj/item/wrench,
+/obj/item/clothing/head/welding,
+/obj/item/weldingtool,
+/obj/random/loot/randomsupply/tech,
+/turf/simulated/floor/warhammer/plating,
+/area/casino/casino_crew_atmos)
 "kJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3875,7 +3879,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kN" = (
 /obj/machinery/light,
@@ -3890,7 +3894,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kO" = (
 /obj/structure/cable{
@@ -3904,11 +3908,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kP" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "kQ" = (
 /obj/machinery/door/firedoor,
@@ -3968,7 +3972,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kY" = (
 /obj/machinery/light,
@@ -3977,7 +3981,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "kZ" = (
 /obj/structure/cable{
@@ -3985,28 +3989,28 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "la" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "ld" = (
 /obj/floor_decal/industrial/warning,
 /obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "le" = (
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "lf" = (
 /obj/floor_decal/industrial/warning{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "lg" = (
 /obj/decal/cleanable/blood/splatter,
@@ -4210,20 +4214,24 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "lB" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "lD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/casino/casino_private_vip)
 "lE" = (
-/obj/random/ammo,
-/turf/simulated/floor/wood,
-/area/casino/casino_private_vip)
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/random/tech_supply,
+/obj/random/loot/randomcolonyitems,
+/turf/simulated/floor/warhammer/plating,
+/area/casino/casino_maintenance)
 "lF" = (
 /obj/decal/cleanable/blood/drip,
 /obj/decal/cleanable/blood/splatter,
@@ -4311,11 +4319,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "lV" = (
 /obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "lX" = (
 /obj/machinery/door/firedoor,
@@ -4329,7 +4337,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "lY" = (
 /obj/structure/bed/chair/comfy/red{
@@ -4407,28 +4415,28 @@
 /obj/item/clothing/mask/smokable/cigarette/cigar/havana,
 /obj/item/clothing/mask/smokable/cigarette/cigar/havana,
 /obj/item/flame/lighter/zippo/random,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "mk" = (
 /obj/machinery/computer/ship/engines{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "ml" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mm" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mn" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mo" = (
 /obj/decal/cleanable/blood/splatter,
@@ -4439,7 +4447,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mp" = (
 /obj/structure/bed/chair/comfy/red{
@@ -4457,6 +4465,7 @@
 /area/casino/casino_private_vip)
 "mr" = (
 /obj/structure/table/woodentable,
+/obj/random/loot/valuableloot,
 /turf/simulated/floor/wood,
 /area/casino/casino_private_vip)
 "ms" = (
@@ -4478,6 +4487,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/random/loot/tech1,
 /turf/simulated/floor/wood,
 /area/casino/casino_private1)
 "mv" = (
@@ -4496,6 +4506,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/random/loot/tech1,
 /turf/simulated/floor/wood,
 /area/casino/casino_private2)
 "my" = (
@@ -4533,7 +4544,7 @@
 /obj/structure/sign/warning/pods{
 	pixel_y = -30
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "mF" = (
 /obj/shuttle_landmark/nav_casino/nav2,
@@ -4543,23 +4554,23 @@
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mH" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mJ" = (
 /obj/decal/cleanable/blood/splatter,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mK" = (
 /obj/structure/cable,
@@ -4577,7 +4588,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mL" = (
 /obj/machinery/door/firedoor,
@@ -4589,23 +4600,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_mainfloor)
 "mN" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mQ" = (
 /obj/structure/cable{
@@ -4616,7 +4627,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mR" = (
 /obj/structure/cable{
@@ -4624,7 +4635,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mS" = (
 /obj/structure/cable{
@@ -4632,38 +4643,38 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mU" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mV" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mX" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = -30
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/door/airlock{
 	name = "Engines #1"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "mZ" = (
 /obj/wallframe_spawn/reinforced,
@@ -4671,7 +4682,7 @@
 	icon_state = "pdoor0";
 	id_tag = "Starboard wide window BD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "na" = (
 /obj/machinery/door/airlock/external{
@@ -4680,30 +4691,30 @@
 	locked = 1;
 	name = "Escape Pod"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "nb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/door/airlock{
 	name = "Engines #2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "nc" = (
 /obj/machinery/atmospherics/unary/tank/nitrogen{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "nd" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "ne" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "ng" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -4731,7 +4742,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "nk" = (
 /obj/shuttle_landmark/nav_casino/nav4,
@@ -4752,7 +4763,7 @@
 	name = "Casino escape pod Three controller";
 	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "nn" = (
 /obj/structure/bed/chair,
@@ -4763,7 +4774,7 @@
 	name = "Casino escape pod Two controller";
 	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "no" = (
 /obj/structure/bed/chair,
@@ -4774,11 +4785,11 @@
 	name = "Casino escape pod One controller";
 	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "nq" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
 "nr" = (
 /turf/simulated/wall/r_titanium,
@@ -4793,7 +4804,7 @@
 /obj/structure/casino/roulette_chart,
 /obj/random/coin,
 /obj/random/coin,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "oc" = (
 /obj/machinery/light{
@@ -4809,11 +4820,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
+/area/casino/casino_mainfloor)
+"oS" = (
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/casino/casino_mainfloor)
 "pb" = (
 /obj/item/ammo_casing/magnum/used,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "pc" = (
 /obj/machinery/vending/wallmed1{
@@ -4826,12 +4840,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
+/area/casino/casino_mainfloor)
+"pv" = (
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "qb" = (
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "qc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4850,18 +4867,18 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "qB" = (
 /obj/machinery/radio_beacon,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "rb" = (
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "rc" = (
 /obj/machinery/computer/arcade,
@@ -4877,14 +4894,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "sb" = (
 /obj/decal/cleanable/blood/splatter,
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "sc" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -4896,11 +4913,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
+"sk" = (
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 9
+	},
+/area/casino/casino_mainfloor)
 "tb" = (
 /obj/item/ammo_casing/rifle/used,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "tc" = (
 /obj/machinery/vending/snack,
@@ -4909,7 +4931,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "ub" = (
 /obj/structure/cable{
@@ -4922,7 +4944,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "uc" = (
 /obj/machinery/vending/fitness,
@@ -4931,12 +4953,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "uL" = (
 /obj/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_cutter)
+"uP" = (
+/obj/structure/table/marble,
+/turf/simulated/floor/warhammer/plate,
+/area/casino/casino_mainfloor)
 "vb" = (
 /obj/decal/cleanable/blood/splatter,
 /obj/item/ammo_casing/rifle/used,
@@ -4944,7 +4970,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "vc" = (
 /obj/machinery/vending/cola,
@@ -4953,7 +4979,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "wb" = (
 /obj/item/ammo_casing/rifle/used,
@@ -4968,7 +4994,7 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "wc" = (
 /obj/machinery/vending/coffee,
@@ -4977,7 +5003,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "xb" = (
 /obj/decal/cleanable/blood/splatter,
@@ -4994,7 +5020,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "xc" = (
 /obj/machinery/vending/cigarette,
@@ -5003,25 +5029,25 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "xu" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
 "xC" = (
 /obj/structure/bed/chair/comfy/captain{
 	dir = 1
 	},
 /obj/item/storage/bag/cash,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
 "yb" = (
 /obj/decal/cleanable/blood/splatter,
 /obj/item/ammo_casing/magnum/used,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "yc" = (
 /obj/structure/cable{
@@ -5029,8 +5055,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
+"yN" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/marble,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/casino/casino_mainfloor)
 "zb" = (
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
@@ -5043,7 +5074,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bunk)
 "zc" = (
 /obj/machinery/door/firedoor,
@@ -5055,7 +5086,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_mainfloor)
 "ze" = (
 /obj/structure/cable/green{
@@ -5063,13 +5094,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
+"zv" = (
+/obj/item/trash/cigbutt/cigarbutt,
+/turf/simulated/floor/warhammer/darkwood,
+/area/casino/casino_mainfloor)
 "Ab" = (
-/obj/item/gun/projectile/pistol/sec/MK,
 /obj/item/ammo_casing/magnum/used,
 /obj/item/ammo_casing/magnum/used,
-/turf/simulated/floor/tiled,
+/obj/random/loot/raregunslug,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "Ac" = (
 /obj/structure/cable{
@@ -5077,7 +5112,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 "AT" = (
 /obj/shuttle_landmark/nav_casino/cutter_hangar,
@@ -5089,12 +5124,12 @@
 /obj/machinery/door/airlock{
 	name = "Cutter door"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
 "Bb" = (
 /obj/item/material/shard,
 /obj/item/ammo_casing/magnum/used,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "Bc" = (
 /obj/machinery/door/firedoor,
@@ -5106,12 +5141,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_crew_cantina)
 "Cb" = (
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bathroom)
 "Cc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5121,7 +5156,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "Db" = (
 /obj/structure/cable{
@@ -5134,7 +5169,7 @@
 /obj/item/ammo_casing/rifle/used,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "Dc" = (
 /obj/structure/cable{
@@ -5150,11 +5185,10 @@
 	pixel_x = -24
 	},
 /obj/structure/cable,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
 "Eb" = (
 /obj/decal/cleanable/blood,
-/obj/item/gun/projectile/pistol/slug,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5169,14 +5203,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/random/loot/sidearmbundle,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "Ec" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "Fb" = (
 /obj/structure/bed/chair{
@@ -5197,10 +5232,15 @@
 	name = "Casino Checkpoint Blast Door contol";
 	pixel_y = -25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "Fc" = (
 /turf/simulated/wall/r_wall,
+/area/casino/casino_mainfloor)
+"Fr" = (
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 1
+	},
 /area/casino/casino_mainfloor)
 "FM" = (
 /obj/item/storage/backpack/dufflebag,
@@ -5212,7 +5252,7 @@
 /obj/structure/bed/chair/comfy/captain{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
 "Gb" = (
 /obj/item/ammo_casing/magnum/used,
@@ -5221,7 +5261,7 @@
 	level = 2
 	},
 /obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
 "Gc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5240,11 +5280,22 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_kitchen)
+"Gs" = (
+/obj/random/coin,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 8
+	},
+/area/casino/casino_mainfloor)
+"GB" = (
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 5
+	},
+/area/casino/casino_mainfloor)
 "Hb" = (
 /obj/item/ammo_casing/rifle/used,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "Hc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5261,7 +5312,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "Ic" = (
 /obj/structure/flora/pottedplant,
@@ -5269,13 +5320,13 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "Ik" = (
 /obj/structure/bed/chair/comfy/captain{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
 "In" = (
 /obj/structure/window/reinforced{
@@ -5284,8 +5335,18 @@
 /obj/structure/bed/chair/comfy/captain{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
+"ID" = (
+/obj/structure/sign/chaos2{
+	pixel_y = -9;
+	pixel_x = -35
+	},
+/turf/simulated/floor/warhammer/darkwood,
+/area/casino/casino_mainfloor)
+"IH" = (
+/turf/simulated/floor/warhammer/darkwood,
+/area/casino/casino_mainfloor)
 "Jb" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Solar - Starboard"
@@ -5295,7 +5356,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_solar_control)
 "Jc" = (
 /obj/decal/cleanable/blood/splatter,
@@ -5315,14 +5376,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "Kb" = (
 /obj/machinery/computer/modular{
 	dir = 8;
 	name = "Cameras console"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_bridge)
 "Kc" = (
 /obj/item/ammo_casing/rifle{
@@ -5340,7 +5401,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
+/area/casino/casino_mainfloor)
+"KW" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/warhammer/fancyfloor/carpet,
 /area/casino/casino_mainfloor)
 "Lb" = (
 /obj/structure/lattice,
@@ -5363,7 +5430,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
+/area/casino/casino_mainfloor)
+"Lr" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "Mb" = (
 /obj/machinery/shipsensors,
@@ -5388,12 +5461,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "Nb" = (
 /obj/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "Nc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5408,10 +5481,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/warhammer/darkwood,
 /area/casino/casino_mainfloor)
 "Nx" = (
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
 "NZ" = (
 /turf/simulated/wall/r_titanium,
@@ -5426,7 +5499,7 @@
 /obj/structure/cable{
 	icon_state = "4-9"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "Oc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5441,8 +5514,20 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
+"Og" = (
+/obj/decal/cleanable/generic,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 1
+	},
+/area/casino/casino_mainfloor)
+"Oj" = (
+/obj/random/coin,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 4
+	},
+/area/casino/casino_mainfloor)
 "OB" = (
 /obj/structure/window/basic{
 	dir = 4
@@ -5450,7 +5535,7 @@
 /obj/machinery/computer/shuttle_control/explore/casino_cutter{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
 "Pb" = (
 /obj/decal/cleanable/blood/splatter,
@@ -5468,7 +5553,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "Pc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5478,14 +5563,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_crew_atmos)
 "Px" = (
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
 "Qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5495,20 +5580,25 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "Qc" = (
 /obj/decal/cleanable/blood/splatter,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
+"Qg" = (
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 6
+	},
+/area/casino/casino_mainfloor)
 "Qi" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_cutter)
 "QB" = (
 /obj/structure/bed/chair{
@@ -5521,8 +5611,14 @@
 	id_tag = "casino_cutter";
 	pixel_y = 25
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
+"QD" = (
+/obj/random/loot,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 8
+	},
+/area/casino/casino_mainfloor)
 "Rb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5543,7 +5639,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "Rc" = (
 /obj/structure/cable{
@@ -5554,8 +5650,18 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_bow)
+"Rs" = (
+/obj/random/cash,
+/turf/simulated/floor/warhammer/darkwood,
+/area/casino/casino_mainfloor)
+"RG" = (
+/obj/decal/cleanable/generic,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 8
+	},
+/area/casino/casino_mainfloor)
 "Sb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -5573,7 +5679,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "Sc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -5585,6 +5691,12 @@
 	},
 /turf/simulated/floor,
 /area/casino/casino_bow)
+"Sm" = (
+/obj/decal/cleanable/generic,
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 4
+	},
+/area/casino/casino_mainfloor)
 "SP" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -5596,7 +5708,7 @@
 	pixel_y = 24;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_cutter)
 "Tc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -5607,6 +5719,11 @@
 	},
 /turf/simulated/floor,
 /area/casino/casino_bow)
+"TN" = (
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 8
+	},
+/area/casino/casino_mainfloor)
 "Uc" = (
 /obj/structure/hygiene/sink{
 	dir = 8;
@@ -5621,8 +5738,17 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_crew_bathroom)
+"UC" = (
+/obj/rune/chaos/armor,
+/turf/simulated/floor/warhammer/plating,
+/area/casino/casino_storage)
+"UQ" = (
+/turf/simulated/floor/warhammer/fancyfloor/carpet{
+	dir = 10
+	},
+/area/casino/casino_mainfloor)
 "Vb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -5636,7 +5762,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/mob/living/simple_animal/hostile/human/heretic/berserker,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "Vc" = (
 /obj/structure/hygiene/sink{
@@ -5681,7 +5808,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/casino/casino_maintenance)
 "Wc" = (
 /obj/structure/hygiene/sink{
@@ -5710,7 +5837,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
+/area/casino/casino_maintenance)
+"XN" = (
+/obj/structure/sign/chaos,
+/turf/simulated/wall/r_wall,
 /area/casino/casino_maintenance)
 "Yb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5734,8 +5865,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/casino/casino_security)
+"YR" = (
+/turf/simulated/floor/warhammer/fancyfloor/carpet,
+/area/casino/casino_mainfloor)
 "Zb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5752,7 +5886,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plate,
 /area/casino/casino_mainfloor)
 
 (1,1,1) = {"
@@ -9962,7 +10096,7 @@ aa
 aa
 aa
 an
-ap
+hj
 ap
 ap
 aF
@@ -10000,14 +10134,14 @@ ji
 jA
 jO
 kb
-km
+kI
 km
 kE
 kb
 lf
 jN
 kC
-mn
+jd
 mJ
 mP
 mV
@@ -10088,7 +10222,7 @@ Vb
 fD
 fD
 gi
-gC
+lE
 gi
 hd
 gC
@@ -10399,7 +10533,7 @@ rc
 fQ
 hp
 hJ
-hw
+gY
 il
 iC
 iM
@@ -10413,7 +10547,7 @@ kx
 kG
 kR
 lh
-lE
+lI
 lZ
 mq
 kC
@@ -10678,13 +10812,13 @@ aa
 aa
 aa
 aw
+XN
 aB
 aB
 aB
 aB
 aB
-aB
-aB
+XN
 bC
 ca
 cv
@@ -10716,7 +10850,7 @@ ga
 ga
 ga
 kz
-kI
+kJ
 kR
 lh
 lH
@@ -10811,7 +10945,7 @@ hw
 hV
 hw
 hw
-gt
+yN
 jp
 jE
 jR
@@ -10984,13 +11118,13 @@ aa
 aa
 aa
 aa
+XN
 aB
 aB
 aB
 aB
 aB
-aB
-aB
+XN
 bE
 ca
 cx
@@ -10998,7 +11132,7 @@ cO
 di
 dx
 dT
-ek
+UC
 ez
 eT
 bZ
@@ -11302,11 +11436,11 @@ cc
 cc
 cc
 cc
-dz
+cc
 dU
 em
 eA
-eV
+cA
 fg
 Yb
 fF
@@ -11315,19 +11449,19 @@ oc
 pc
 Ac
 hf
-ge
+IH
 hM
 hY
 hM
 hM
-ge
+IH
 ja
-ge
+IH
 jI
 jI
 ki
 jI
-ge
+IH
 kN
 kT
 ln
@@ -11413,23 +11547,23 @@ bq
 fq
 bq
 gc
-gp
-gG
-ks
+pv
+pv
+uP
 gt
 hy
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
+IH
+IH
+IH
+IH
+IH
+IH
+IH
+IH
+IH
 kj
-hB
-ge
+zv
+IH
 kJ
 kT
 lo
@@ -11519,19 +11653,19 @@ gq
 gH
 gX
 gt
-ge
-ge
+IH
+sk
 hZ
 ip
-ge
+TN
 hZ
 hZ
-ge
+TN
 hZ
 hZ
-ge
+TN
 hZ
-ge
+UQ
 kJ
 kT
 kT
@@ -11618,22 +11752,22 @@ Eb
 Gb
 bq
 gr
-gG
-gG
+pv
+pv
 gt
-ge
-hN
+IH
+Og
 ia
 iq
-ge
+oS
 iR
 ib
-ge
+oS
 ib
 jU
-ge
+oS
 kt
-ge
+YR
 Mc
 kU
 lp
@@ -11721,21 +11855,21 @@ fH
 bq
 gs
 gI
-gY
-gt
-ge
-ge
+pv
+gp
+IH
+Fr
 ib
 ir
-ge
+oS
 iR
 ib
-ge
+oS
 jJ
 ib
-ge
+oS
 ia
-ge
+YR
 kJ
 kV
 lq
@@ -11825,7 +11959,7 @@ gt
 gt
 gt
 hg
-ge
+IH
 gJ
 ic
 ic
@@ -11837,7 +11971,7 @@ ic
 ic
 ge
 ic
-ge
+Qg
 kJ
 kV
 lr
@@ -11923,23 +12057,23 @@ fh
 fv
 fI
 gd
-ge
-ge
-gJ
+IH
+IH
+Rs
 Hb
 hz
 Ec
-ge
-ge
+IH
+IH
 hN
-ge
+IH
 Ec
-ge
-ge
-ge
-ge
+IH
+IH
+IH
+IH
 Ec
-hj
+IH
 kJ
 kV
 ls
@@ -12026,19 +12160,19 @@ fw
 fJ
 bq
 gu
-gJ
+Rs
 gZ
 hi
 hA
 ga
 id
-ge
-ge
+IH
+IH
 iS
 ga
 id
-hj
-ge
+IH
+ID
 hA
 ga
 id
@@ -12128,22 +12262,22 @@ bq
 bq
 bq
 gv
-ge
-ge
-ge
-hB
+IH
+IH
+IH
+zv
 fK
-ge
-ge
-ge
+IH
+IH
+IH
 fx
 jb
-ge
-ge
-ge
-ge
+IH
+IH
+IH
+IH
 fK
-ge
+IH
 kO
 Nc
 lt
@@ -12228,25 +12362,25 @@ eY
 br
 fx
 fK
-ge
-ge
-ge
-ge
-hj
-ge
+IH
+IH
+IH
+IH
+IH
+IH
 hN
 ie
 is
-ge
-ge
+IH
+IH
 jc
-ge
-ge
+IH
+IH
 jV
 kk
-ge
-ge
-ge
+IH
+IH
+IH
 kX
 lu
 lR
@@ -12334,21 +12468,21 @@ gf
 fz
 fL
 gf
-ge
+IH
 hy
-ge
-ge
-ge
-ge
+IH
+IH
+IH
+IH
 hN
-ge
-ge
+IH
+IH
 jK
 hN
-ge
-ge
-ge
-ge
+IH
+IH
+IH
+IH
 kY
 lu
 lS
@@ -12436,21 +12570,21 @@ gf
 fz
 fL
 gf
-ge
-fx
-ge
-hN
-hN
-ge
-ge
-jd
+sk
+QD
+TN
+RG
+RG
+TN
+TN
+Gs
 hB
-ge
+TN
 hZ
-ge
-ge
+TN
+TN
 hZ
-ge
+UQ
 kZ
 lu
 lT
@@ -12538,21 +12672,21 @@ gf
 fz
 fL
 gf
-ge
+Fr
 hC
-ge
-ge
+oS
+oS
 ob
-ge
+oS
 iT
 hC
-ge
-ge
+oS
+eV
 jW
 kl
-ge
+oS
 kA
-kl
+KW
 kZ
 lu
 lu
@@ -12640,21 +12774,21 @@ gf
 fz
 fL
 gf
-ge
+Fr
 hD
-ge
+oS
 if
 hD
-ge
-ge
+oS
+oS
 hD
 iT
-ge
+oS
 jX
 kl
-ge
+oS
 kB
-kl
+KW
 la
 lv
 lU
@@ -12742,25 +12876,25 @@ gf
 fz
 fL
 gf
+GB
 ge
 ge
 ge
 ge
+Sm
 ge
-hN
-ge
-iT
-ge
-ge
-ic
+Oj
 ge
 ge
 ic
 ge
 ge
-ge
-hB
-ge
+ic
+Qg
+IH
+IH
+zv
+IH
 mE
 kC
 mH
@@ -12844,26 +12978,26 @@ gf
 fz
 fL
 gf
-ge
+IH
 hE
 Ec
-ge
+IH
 iu
-ge
-ge
+IH
+IH
 Ic
 hN
 hN
 hE
-ge
+IH
 Ec
 iu
-ge
-ge
-ge
+IH
+IH
+IH
 lV
 mj
-kl
+Lr
 kC
 kC
 kC

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -495,7 +495,7 @@
 "by" = (
 /obj/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/bridge)
 "bz" = (
 /obj/structure/grille,
@@ -509,7 +509,7 @@
 "bB" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/bridge)
 "bC" = (
 /obj/structure/table/standard,
@@ -533,9 +533,7 @@
 /turf/simulated/floor,
 /area/constructionsite/maintenance)
 "bH" = (
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/maintenance)
 "bI" = (
 /obj/structure/grille,
@@ -557,16 +555,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/derelict/ship)
-"bK" = (
-/turf/simulated/floor/tiled/dark,
-/area/constructionsite/bridge)
 "bL" = (
 /turf/simulated/floor,
 /area/constructionsite/bridge)
 "bM" = (
 /obj/random/trash,
 /obj/structure/table,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/bridge)
 "bN" = (
 /obj/random/closet,
@@ -590,15 +585,13 @@
 /turf/simulated/floor,
 /area/constructionsite/bridge)
 "bR" = (
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/bridge)
 "bS" = (
 /obj/random/hostile{
 	spawn_nothing_percentage = 60
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/bridge)
 "bT" = (
 /obj/structure/bed/chair,
@@ -718,7 +711,7 @@
 /area/constructionsite/bridge)
 "ck" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/bridge)
 "cl" = (
 /obj/machinery/door/airlock/hatch,
@@ -767,11 +760,11 @@
 /area/derelict/ship)
 "cs" = (
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/bridge)
 "ct" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/bridge)
 "cu" = (
 /obj/random/closet,
@@ -789,14 +782,10 @@
 /area/constructionsite/hallway/fore)
 "cx" = (
 /obj/structure/bookcase,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "cy" = (
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "cz" = (
 /obj/structure/bookcase/manuals/xenoarchaeology,
@@ -861,14 +850,9 @@
 /obj/item/book/manual/excavation,
 /turf/simulated/floor,
 /area/constructionsite/hallway/fore)
-"cN" = (
-/turf/simulated/floor/tiled/dark,
-/area/constructionsite/hallway/fore)
 "cO" = (
 /obj/structure/bookcase/manuals/xenoarchaeology,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "cP" = (
 /obj/random/trash,
@@ -936,7 +920,7 @@
 /area/derelict/ship)
 "cX" = (
 /obj/machinery/bookbinder,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "cY" = (
 /obj/structure/filingcabinet/filingcabinet,
@@ -947,7 +931,7 @@
 	name = "Bridge"
 	},
 /obj/machinery/door/blast/regular,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/bridge)
 "da" = (
 /obj/structure/closet/fridge,
@@ -963,10 +947,6 @@
 /obj/item/material/kitchen/rollingpin,
 /turf/simulated/floor,
 /area/constructionsite/hallway/fore)
-"dd" = (
-/obj/structure/table,
-/turf/simulated/floor/tiled/dark,
-/area/constructionsite/hallway/fore)
 "de" = (
 /obj/random/closet,
 /obj/random/voidhelmet,
@@ -981,15 +961,7 @@
 "dg" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/item/book/manual/nuclear,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
-/area/constructionsite/hallway/fore)
-"dh" = (
-/obj/random/trash,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "di" = (
 /obj/structure/table/rack,
@@ -1040,14 +1012,12 @@
 /area/constructionsite/hallway/fore)
 "ds" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dt" = (
 /obj/structure/table/standard,
 /obj/random/toy,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "du" = (
 /obj/structure/table/standard,
@@ -1084,21 +1054,15 @@
 /area/constructionsite/hallway/fore)
 "dC" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dD" = (
 /obj/structure/grille/broken,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dE" = (
 /obj/structure/grille,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dF" = (
 /obj/structure/sign/warning/secure_area,
@@ -1108,7 +1072,7 @@
 /obj/machinery/door/airlock/glass/command{
 	name = "Bridge"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dH" = (
 /obj/machinery/door/airlock/glass/command{
@@ -1125,9 +1089,7 @@
 "dJ" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dK" = (
 /obj/structure/table/marble,
@@ -1136,9 +1098,7 @@
 /area/constructionsite/hallway/fore)
 "dL" = (
 /obj/structure/table,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dM" = (
 /obj/structure/table,
@@ -1158,7 +1118,7 @@
 /area/constructionsite/hallway/fore)
 "dQ" = (
 /obj/random/smokes,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dR" = (
 /obj/structure/lattice,
@@ -1166,16 +1126,16 @@
 /area/constructionsite/hallway/fore)
 "dS" = (
 /obj/random/snack,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dT" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dU" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "dV" = (
 /obj/structure/lattice,
@@ -1230,9 +1190,7 @@
 "eg" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/storage)
 "eh" = (
 /turf/simulated/floor,
@@ -1251,7 +1209,7 @@
 	dir = 1
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "ek" = (
 /obj/machinery/shieldgen,
@@ -1262,7 +1220,7 @@
 	dir = 1
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "el" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -1273,7 +1231,7 @@
 	dir = 1
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "em" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -1284,7 +1242,7 @@
 	dir = 1
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "en" = (
 /obj/structure/table/reinforced,
@@ -1309,7 +1267,7 @@
 	},
 /obj/random/tech_supply,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "ep" = (
 /obj/structure/table/reinforced,
@@ -1318,7 +1276,7 @@
 	},
 /obj/random/tech_supply,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "eq" = (
 /obj/structure/table/reinforced,
@@ -1326,7 +1284,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "er" = (
 /obj/structure/table/rack,
@@ -1334,16 +1292,11 @@
 /obj/random/toolbox,
 /turf/simulated/floor,
 /area/constructionsite/storage)
-"es" = (
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
-/area/constructionsite/storage)
 "et" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/storage)
 "eu" = (
 /obj/machinery/optable{
@@ -1362,7 +1315,7 @@
 	dir = 8
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "ex" = (
 /obj/machinery/shieldgen,
@@ -1370,7 +1323,7 @@
 	dir = 4
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "ey" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -1378,7 +1331,7 @@
 	dir = 8
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "ez" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -1386,10 +1339,10 @@
 	dir = 4
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "eA" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "eB" = (
 /obj/structure/table/reinforced,
@@ -1402,7 +1355,7 @@
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "eC" = (
 /obj/structure/table/reinforced,
@@ -1413,7 +1366,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "eD" = (
 /obj/wallframe_spawn/reinforced,
@@ -1423,9 +1376,7 @@
 /obj/machinery/door/airlock/glass/science{
 	name = "Robotics"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/storage)
 "eF" = (
 /obj/structure/grille/broken,
@@ -1443,7 +1394,7 @@
 	pixel_y = -10;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "eI" = (
 /obj/machinery/access_button/airlock_interior{
@@ -1452,7 +1403,7 @@
 	pixel_y = -10;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "eJ" = (
 /turf/simulated/floor/tiled,
@@ -1464,7 +1415,7 @@
 	},
 /obj/machinery/power/port_gen/pacman,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "eL" = (
 /obj/structure/skele_stand,
@@ -1479,7 +1430,7 @@
 /turf/simulated/floor,
 /area/constructionsite/storage)
 "eO" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/storage)
 "eP" = (
 /obj/machinery/door/airlock/glass/science{
@@ -1511,7 +1462,7 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "eU" = (
 /obj/wallframe_spawn/reinforced,
@@ -1529,7 +1480,7 @@
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/power/terminal,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "eX" = (
 /obj/machinery/door/airlock/hatch,
@@ -1621,7 +1572,7 @@
 	icon_state = "0-2"
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fi" = (
 /obj/shuttle_landmark/derelict/nav1,
@@ -1635,21 +1586,17 @@
 "fk" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/storage)
 "fl" = (
 /obj/machinery/door/airlock/glass/science{
 	name = "Research"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/storage)
 "fm" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/storage)
 "fn" = (
 /obj/structure/window/basic{
@@ -1666,7 +1613,7 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
@@ -1696,7 +1643,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fs" = (
 /obj/structure/cable/blue{
@@ -1711,7 +1658,7 @@
 	},
 /obj/machinery/fabricator,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "ft" = (
 /obj/random/junk,
@@ -1723,13 +1670,13 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fw" = (
 /obj/structure/cable/blue,
@@ -1741,7 +1688,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fx" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen/prechilled,
@@ -1749,7 +1696,7 @@
 /area/constructionsite/storage)
 "fy" = (
 /obj/machinery/r_n_d/circuit_imprinter,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/storage)
 "fz" = (
 /obj/machinery/r_n_d/destructive_analyzer,
@@ -1768,28 +1715,28 @@
 /area/constructionsite/storage)
 "fC" = (
 /obj/machinery/pipedispenser,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fD" = (
 /obj/machinery/pipedispenser/disposal,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fE" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fF" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fG" = (
 /obj/machinery/light,
 /obj/structure/closet/crate/solar,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/random/loot,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fH" = (
 /obj/floor_decal/industrial/warning{
@@ -1797,7 +1744,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/constructable_frame/computerframe,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fI" = (
 /obj/machinery/tele_projector,
@@ -1805,7 +1752,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fJ" = (
 /obj/machinery/tele_pad,
@@ -1813,7 +1760,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "fK" = (
 /obj/structure/girder/displaced,
@@ -1836,11 +1783,8 @@
 /turf/space,
 /area/constructionsite/solar)
 "fP" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/solar)
-"fQ" = (
-/turf/simulated/floor/tiled/dark,
-/area/constructionsite/maintenance)
 "fR" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -1849,7 +1793,7 @@
 /area/constructionsite/hallway/fore)
 "fS" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "fT" = (
 /obj/overmap/visitable/sector/derelict,
@@ -1858,11 +1802,6 @@
 "fU" = (
 /turf/space,
 /area/constructionsite/solar)
-"fV" = (
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
-/area/constructionsite/solar)
 "fW" = (
 /obj/random/trash,
 /turf/simulated/floor,
@@ -1870,7 +1809,7 @@
 "fX" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/fore)
 "fY" = (
 /obj/structure/grille,
@@ -1916,7 +1855,7 @@
 /turf/simulated/wall,
 /area/constructionsite/ai)
 "gh" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/ai)
 "gi" = (
 /turf/simulated/floor/bluegrid,
@@ -1925,9 +1864,7 @@
 /turf/simulated/floor,
 /area/space)
 "gk" = (
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "gl" = (
 /obj/random/trash,
@@ -1950,15 +1887,12 @@
 /area/constructionsite/hallway/fore)
 "gp" = (
 /obj/machinery/porta_turret_construct,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/ai)
 "gq" = (
 /obj/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/ai)
-"gr" = (
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "gs" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
@@ -1972,7 +1906,7 @@
 /area/constructionsite/maintenance)
 "gu" = (
 /obj/random/loot,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/ai)
 "gv" = (
 /obj/random/trash,
@@ -1980,7 +1914,7 @@
 /area/constructionsite/ai)
 "gw" = (
 /obj/machinery/drone_fabricator/derelict,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/ai)
 "gx" = (
 /obj/structure/cable/blue{
@@ -1992,11 +1926,11 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/ai)
 "gy" = (
 /obj/machinery/computer/drone_control,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/ai)
 "gz" = (
 /obj/random/hostile,
@@ -2061,7 +1995,7 @@
 /area/space)
 "gK" = (
 /obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/ai)
 "gL" = (
 /obj/structure/lattice,
@@ -2073,25 +2007,20 @@
 /area/constructionsite/hallway/fore)
 "gM" = (
 /obj/machinery/porta_turret/stationary,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/ai)
 "gN" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/ai)
 "gO" = (
 /turf/simulated/wall,
 /area/constructionsite/hallway/aft)
 "gP" = (
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/aft)
 "gQ" = (
 /turf/simulated/floor,
-/area/constructionsite/hallway/aft)
-"gR" = (
-/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/aft)
 "gS" = (
 /obj/wallframe_spawn/reinforced,
@@ -2156,9 +2085,7 @@
 /area/constructionsite/maintenance)
 "he" = (
 /obj/random/trash,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/aft)
 "hf" = (
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -2168,16 +2095,12 @@
 /area/constructionsite/hallway/aft)
 "hg" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/aft)
 "hh" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/aft)
 "hi" = (
 /obj/shuttle_landmark/derelict/nav4,
@@ -2221,13 +2144,8 @@
 "hr" = (
 /turf/simulated/floor,
 /area/constructionsite/atmospherics)
-"hs" = (
-/turf/simulated/floor/tiled/dark,
-/area/constructionsite/atmospherics)
 "ht" = (
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/atmospherics)
 "hu" = (
 /obj/machinery/light_construct{
@@ -2360,7 +2278,7 @@
 /area/constructionsite/atmospherics)
 "hV" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/atmospherics)
 "hW" = (
 /obj/structure/lattice,
@@ -2396,6 +2314,7 @@
 	},
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
+/obj/random/loot/gunbundle,
 /turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "ie" = (
@@ -2443,7 +2362,7 @@
 /area/constructionsite/atmospherics)
 "in" = (
 /obj/random/tool,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/atmospherics)
 "io" = (
 /obj/random/junk,
@@ -2598,7 +2517,7 @@
 /obj/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/atmospherics)
 "iL" = (
 /obj/structure/girder,
@@ -2609,7 +2528,7 @@
 	desc = "In memory of Earl Whitenmeinster. We'll never forget you.";
 	name = "Whitenmeister Memorial Hall Plaque"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/aft)
 "iN" = (
 /obj/floor_decal/industrial/warning/dust{
@@ -2657,18 +2576,16 @@
 /turf/simulated/floor/reinforced/oxygen,
 /area/constructionsite/atmospherics)
 "iR" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/medical)
 "iS" = (
 /obj/random/material,
 /turf/simulated/floor,
 /area/constructionsite/medical)
 "iT" = (
-/obj/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/constructionsite/medical)
+/mob/living/simple_animal/hostile/viscerator,
+/turf/simulated/floor/warhammer/plating,
+/area/constructionsite/ai)
 "iU" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
@@ -2693,7 +2610,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/atmospherics)
 "iY" = (
 /turf/simulated/wall,
@@ -2757,7 +2674,7 @@
 /area/constructionsite/atmospherics)
 "jf" = (
 /obj/random/smokes,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jg" = (
 /obj/structure/lattice,
@@ -2781,12 +2698,12 @@
 "jk" = (
 /obj/structure/table/standard,
 /obj/random/gloves,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jl" = (
 /obj/structure/table/standard,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jm" = (
 /obj/structure/girder/displaced,
@@ -2833,9 +2750,7 @@
 "jt" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "ju" = (
 /turf/simulated/floor,
@@ -2849,10 +2764,10 @@
 /area/constructionsite)
 "jx" = (
 /obj/structure/lattice,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jy" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jz" = (
 /obj/structure/girder,
@@ -2864,16 +2779,11 @@
 /area/constructionsite)
 "jB" = (
 /obj/random/clothing,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jC" = (
 /obj/structure/coatrack,
-/turf/simulated/floor/tiled/dark,
-/area/constructionsite)
-"jD" = (
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jE" = (
 /obj/structure/closet/cabinet,
@@ -2881,7 +2791,7 @@
 /area/constructionsite)
 "jF" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jG" = (
 /obj/wallframe_spawn/reinforced,
@@ -2916,15 +2826,9 @@
 	},
 /turf/simulated/floor,
 /area/constructionsite)
-"jN" = (
-/obj/structure/girder/displaced,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
-/area/constructionsite)
 "jO" = (
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jP" = (
 /obj/random/loot,
@@ -2935,11 +2839,11 @@
 	icon_state = "extinguisher_empty";
 	pixel_x = 30
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/aft)
 "jR" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jS" = (
 /obj/random/maintenance/clean,
@@ -2954,13 +2858,6 @@
 /obj/random/clothing,
 /turf/simulated/floor,
 /area/constructionsite)
-"jV" = (
-/obj/structure/grille,
-/obj/structure/wall_frame,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
-/area/constructionsite)
 "jW" = (
 /obj/random/clothing,
 /turf/simulated/floor,
@@ -2968,7 +2865,7 @@
 "jX" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "jY" = (
 /obj/item/clothing/head/radiation,
@@ -3010,11 +2907,11 @@
 "kh" = (
 /obj/structure/table/standard,
 /obj/random/hardsuit,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "ki" = (
 /obj/random/hostile,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "kj" = (
 /obj/random/hostile,
@@ -3022,14 +2919,13 @@
 /area/constructionsite)
 "kk" = (
 /obj/structure/table,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "kl" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
 /obj/random/powercell,
+/obj/random/loot/lootcontraband,
 /turf/simulated/floor,
 /area/constructionsite)
 "km" = (
@@ -3046,10 +2942,12 @@
 /obj/structure/table/rack,
 /obj/random/tool,
 /obj/random/tool,
+/obj/random/loot/randomsupply/tech,
 /turf/simulated/floor,
 /area/constructionsite)
 "kp" = (
 /obj/structure/table/rack,
+/obj/random/loot/randomsupply/engineering,
 /turf/simulated/floor,
 /area/constructionsite)
 "kq" = (
@@ -3065,7 +2963,7 @@
 /area/constructionsite)
 "ks" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "kt" = (
 /obj/machinery/power/breakerbox,
@@ -3075,11 +2973,11 @@
 /obj/structure/table/rack,
 /obj/random/toolbox,
 /obj/random/loot,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "kv" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite)
 "kw" = (
 /obj/random/closet,
@@ -3094,7 +2992,7 @@
 /area/constructionsite)
 "ky" = (
 /obj/structure/closet/radiation,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/hallway/aft)
 "kz" = (
 /turf/simulated/wall,
@@ -3139,12 +3037,10 @@
 "kJ" = (
 /turf/space,
 /area/constructionsite/engineering)
-"kK" = (
-/turf/simulated/floor/tiled/dark,
-/area/constructionsite/engineering)
 "kL" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark,
+/obj/random/loot/tech1,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/engineering)
 "kM" = (
 /obj/structure/sign/warning/radioactive,
@@ -3168,9 +3064,7 @@
 /area/constructionsite/engineering)
 "kQ" = (
 /obj/random/maintenance,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/engineering)
 "kR" = (
 /obj/structure/grille/broken,
@@ -3179,6 +3073,7 @@
 /area/constructionsite/engineering)
 "kS" = (
 /obj/structure/table/standard,
+/obj/random/loot/rigloot,
 /turf/simulated/floor,
 /area/constructionsite/engineering)
 "kT" = (
@@ -3194,9 +3089,7 @@
 /turf/simulated/floor,
 /area/constructionsite/engineering)
 "kV" = (
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/engineering)
 "kW" = (
 /obj/structure/table/standard,
@@ -3249,10 +3142,6 @@
 /obj/random/tool,
 /turf/simulated/floor,
 /area/constructionsite/engineering)
-"lh" = (
-/obj/random/maintenance,
-/turf/simulated/floor/tiled/dark,
-/area/constructionsite/engineering)
 "li" = (
 /obj/structure/table/standard,
 /obj/random/tool,
@@ -3271,7 +3160,7 @@
 /area/constructionsite/engineering)
 "ll" = (
 /obj/structure/closet/radiation,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/engineering)
 "lm" = (
 /obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
@@ -3301,6 +3190,7 @@
 "lr" = (
 /obj/structure/table/rack,
 /obj/random/tool,
+/obj/random/loot/valuableloot,
 /turf/simulated/floor,
 /area/constructionsite/engineering)
 "ls" = (
@@ -3309,7 +3199,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/engineering)
 "lt" = (
 /obj/structure/table/rack,
@@ -3332,7 +3222,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/engineering)
 "lx" = (
 /obj/structure/cable/blue{
@@ -3366,7 +3256,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/engineering)
 "lA" = (
 /obj/machinery/power/terminal{
@@ -3455,7 +3345,7 @@
 "lM" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/engineering)
 "lN" = (
 /obj/structure/cable/blue,
@@ -3483,7 +3373,7 @@
 /area/constructionsite/AIsattele)
 "lT" = (
 /obj/random/hostile,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/engineering)
 "lU" = (
 /obj/structure/lattice,
@@ -3562,7 +3452,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Construction Site Teleporter"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/constructionsite/teleporter)
 "ob" = (
 /obj/machinery/camera/motion{
@@ -3577,6 +3467,11 @@
 	},
 /turf/simulated/floor,
 /area/constructionsite/teleporter)
+"tP" = (
+/obj/structure/table/standard,
+/obj/random/loot/tech2,
+/turf/simulated/floor/warhammer/plating,
+/area/constructionsite/engineering)
 "AR" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
@@ -3624,6 +3519,16 @@
 /obj/structure/wall_frame,
 /turf/simulated/floor,
 /area/constructionsite/hallway/fore)
+"SC" = (
+/obj/structure/table/rack,
+/obj/random/maintenance,
+/obj/random/loot/valuableloot,
+/turf/simulated/floor,
+/area/constructionsite/engineering)
+"Zr" = (
+/obj/random/loot/lootstructureartifact,
+/turf/simulated/floor,
+/area/constructionsite)
 
 (1,1,1) = {"
 aa
@@ -15801,7 +15706,7 @@ aa
 fO
 fL
 fN
-fV
+fP
 fL
 aR
 aa
@@ -16422,7 +16327,7 @@ aR
 aR
 gj
 aR
-gr
+gk
 aR
 gk
 dO
@@ -17214,7 +17119,7 @@ aR
 aR
 aR
 fL
-fV
+fP
 fN
 fL
 aR
@@ -17619,7 +17524,7 @@ fL
 fP
 fP
 fN
-fV
+fP
 fN
 fY
 aR
@@ -17634,7 +17539,7 @@ aR
 gj
 gj
 aW
-fQ
+bH
 bo
 bo
 aW
@@ -17822,7 +17727,7 @@ fN
 fN
 fW
 fN
-fV
+fP
 fZ
 aR
 aR
@@ -17836,7 +17741,7 @@ aR
 gj
 gj
 aW
-fQ
+bH
 bH
 bo
 aW
@@ -18040,7 +17945,7 @@ gj
 aW
 bo
 bo
-fQ
+bH
 aW
 aR
 aa
@@ -18626,10 +18531,10 @@ aa
 aR
 aW
 aW
-fQ
+bH
 bo
 bu
-fQ
+bH
 bo
 aW
 aR
@@ -18693,11 +18598,11 @@ iY
 iY
 jG
 jA
-jN
+kv
 iZ
 jA
 jA
-jV
+jX
 jA
 aa
 aa
@@ -18831,7 +18736,7 @@ bo
 bo
 bo
 bo
-fQ
+bH
 bo
 aW
 aW
@@ -18846,7 +18751,7 @@ aW
 aW
 aW
 aW
-fQ
+bH
 bo
 bo
 aW
@@ -19030,7 +18935,7 @@ aR
 aR
 dz
 dz
-cN
+cy
 cw
 dz
 dz
@@ -19038,15 +18943,15 @@ bo
 bo
 bo
 bo
-fQ
+bH
 bo
 bo
 bo
-fQ
+bH
 bo
 bo
 bo
-fQ
+bH
 bo
 bo
 bp
@@ -19216,9 +19121,9 @@ aa
 aR
 dz
 cw
-cN
+cy
 cw
-cN
+cy
 dz
 BO
 BO
@@ -19234,7 +19139,7 @@ dz
 cw
 cw
 cw
-cN
+cy
 dz
 dz
 dz
@@ -19252,7 +19157,7 @@ dz
 dz
 cy
 cw
-cN
+cy
 dz
 gO
 gO
@@ -19269,7 +19174,7 @@ gO
 gO
 gO
 gQ
-gR
+gP
 gQ
 gU
 gO
@@ -19417,61 +19322,61 @@ aR
 aR
 aR
 dz
-cN
-cN
+cy
+cy
 cy
 cw
-cN
-cw
-cN
-cN
-cN
-cw
-cN
+cy
 cw
 cy
-cN
-cN
-cN
+cy
+cy
+cw
+cy
+cw
+cy
+cy
+cy
+cy
 dR
 dR
 cy
-cN
+cy
 cw
 cw
 dR
 cw
 cw
-cN
-cw
-cy
-cN
 cy
 cw
-cN
+cy
+cy
+cy
+cw
+cy
 cw
 cw
-cN
-cN
+cy
+cy
 cw
 cw
 cw
 gP
-gR
+gP
 gQ
 gQ
-gR
-gR
+gP
+gP
 gX
 gQ
 gP
 gQ
-gR
-gR
-gR
+gP
+gP
+gP
 gQ
 gP
-gR
+gP
 gQ
 gQ
 hj
@@ -19620,61 +19525,61 @@ aW
 aW
 dz
 cy
-cN
-cN
-cw
-cw
-cN
-cN
-cw
 cy
-cN
-cN
-cN
-cN
-cw
-cw
-cN
-cN
-dR
-cw
-cN
-cw
-cw
-cw
-cN
 cy
 cw
-cN
 cw
-cN
+cy
+cy
 cw
+cy
+cy
+cy
+cy
+cy
+cw
+cw
+cy
 cy
 dR
 cw
-cN
-cw
-cN
+cy
 cw
 cw
-cN
+cw
+cy
+cy
+cw
+cy
+cw
+cy
+cw
+cy
+dR
+cw
+cy
+cw
+cy
+cw
+cw
+cy
 gQ
-gR
+gP
 gU
 gP
-gR
-gR
+gP
+gP
 gQ
-gR
+gP
 gQ
 gP
 gQ
 gP
-gR
-gR
+gP
+gP
 gQ
-gR
-gR
+gP
+gP
 gP
 hj
 gT
@@ -19716,7 +19621,7 @@ jy
 jg
 jg
 ju
-jD
+jy
 ju
 kj
 kp
@@ -19823,7 +19728,7 @@ bo
 dA
 cw
 cw
-cN
+cy
 cw
 dz
 dz
@@ -19838,7 +19743,7 @@ dz
 dz
 dz
 cw
-cN
+cy
 cw
 cw
 dz
@@ -19923,7 +19828,7 @@ jy
 ju
 kq
 jg
-jN
+kv
 jw
 jw
 aa
@@ -20024,8 +19929,8 @@ aW
 ce
 dz
 cw
-cN
-cN
+cy
+cy
 dz
 dz
 bo
@@ -20041,7 +19946,7 @@ bo
 dz
 dz
 cw
-cN
+cy
 dz
 dz
 aR
@@ -20059,7 +19964,7 @@ aW
 bo
 dA
 cw
-cN
+cy
 cw
 dA
 bo
@@ -20225,7 +20130,7 @@ df
 dp
 cw
 dz
-cN
+cy
 cy
 cw
 dz
@@ -20260,9 +20165,9 @@ aW
 aW
 bH
 dz
-cN
+cy
 cw
-cN
+cy
 dz
 bH
 aW
@@ -20280,7 +20185,7 @@ aa
 aR
 gS
 gQ
-gR
+gP
 gS
 hk
 hv
@@ -20428,7 +20333,7 @@ cy
 cw
 dz
 cw
-cN
+cy
 cw
 dz
 bo
@@ -20444,8 +20349,8 @@ dY
 dY
 bo
 dz
-cN
-cN
+cy
+cy
 Lk
 aR
 aR
@@ -20463,7 +20368,7 @@ bo
 bo
 dz
 cw
-cN
+cy
 cw
 dz
 bo
@@ -20481,7 +20386,7 @@ aR
 aR
 aR
 gS
-gR
+gP
 gQ
 hf
 hl
@@ -20523,7 +20428,7 @@ jw
 iY
 jg
 ju
-jD
+jy
 jy
 kh
 kk
@@ -20636,7 +20541,7 @@ dz
 bo
 dY
 ec
-es
+eO
 eD
 eh
 eh
@@ -20646,8 +20551,8 @@ fx
 dY
 bo
 dz
-cN
-cN
+cy
+cy
 BO
 aR
 aa
@@ -20683,8 +20588,8 @@ aa
 aa
 aR
 gW
-gR
-gR
+gP
+gP
 gQ
 hl
 hl
@@ -20832,7 +20737,7 @@ cy
 cw
 dz
 cw
-cN
+cy
 cy
 dA
 bo
@@ -20867,7 +20772,7 @@ dz
 cy
 cw
 cw
-cN
+cy
 cw
 gL
 gQ
@@ -20920,7 +20825,7 @@ iY
 jT
 jU
 jT
-jN
+kv
 aa
 aa
 jw
@@ -21034,8 +20939,8 @@ cw
 ds
 dj
 cw
-cN
-cN
+cy
+cy
 dz
 bu
 dY
@@ -21064,18 +20969,18 @@ dz
 dA
 dz
 cw
-cN
 cy
 cy
+cy
 cw
 cw
-cN
+cy
 cw
-cN
+cy
 gQ
 gQ
 gQ
-gR
+gP
 gO
 gY
 gO
@@ -21088,7 +20993,7 @@ aa
 aR
 DP
 gQ
-gR
+gP
 gO
 hn
 hn
@@ -21131,7 +21036,7 @@ iY
 ju
 jg
 ke
-ju
+Zr
 jy
 ks
 ju
@@ -21232,12 +21137,12 @@ cx
 cA
 cA
 dg
-cN
+cy
 cw
 dv
 cw
-cN
-cN
+cy
+cy
 dz
 bo
 dY
@@ -21253,7 +21158,7 @@ dY
 bo
 dz
 fR
-cN
+cy
 Lk
 aR
 aR
@@ -21265,16 +21170,16 @@ dz
 dz
 cw
 cw
-cN
-cN
+cy
+cy
 dm
-cN
+cy
 cw
 dm
 cy
 cy
 dR
-gR
+gP
 gT
 gQ
 gT
@@ -21290,7 +21195,7 @@ aR
 aR
 DP
 gQ
-gR
+gP
 gO
 hl
 hx
@@ -21336,7 +21241,7 @@ ju
 jy
 km
 jy
-jD
+jy
 jg
 kw
 iY
@@ -21431,15 +21336,15 @@ aW
 bo
 aW
 cy
-cN
+cy
 cw
-dh
-cN
+dT
+cy
 dt
 dC
-cN
+cy
 cw
-cN
+cy
 dz
 bo
 dY
@@ -21465,11 +21370,11 @@ aW
 dz
 dz
 cw
-cN
-cN
+cy
+cy
 cy
 dm
-cN
+cy
 cw
 cw
 cw
@@ -21479,7 +21384,7 @@ cw
 gQ
 gQ
 gQ
-gR
+gP
 gX
 gP
 gQ
@@ -21491,8 +21396,8 @@ aW
 aW
 aR
 gW
-gR
-gR
+gP
+gP
 gS
 ho
 hl
@@ -21535,7 +21440,7 @@ jw
 ka
 ju
 kf
-jD
+jy
 kn
 kt
 iY
@@ -21637,9 +21542,9 @@ cO
 cx
 cA
 cw
-dd
+dL
 dD
-cN
+cy
 dQ
 cw
 dz
@@ -21651,13 +21556,13 @@ eF
 eh
 eh
 fm
-es
+eO
 eh
 dY
 bu
 dz
-cN
-cN
+cy
+cy
 BO
 aR
 aW
@@ -21667,11 +21572,11 @@ bo
 dA
 cw
 cw
-cN
+cy
 cw
 cy
 cw
-cN
+cy
 dj
 dz
 dz
@@ -21693,7 +21598,7 @@ bo
 aW
 aR
 DP
-gR
+gP
 gQ
 gS
 hp
@@ -21713,7 +21618,7 @@ ib
 hW
 hC
 hv
-hl
+hv
 iS
 hC
 hW
@@ -21735,7 +21640,7 @@ jw
 jw
 jw
 kb
-jD
+jy
 jy
 iY
 jz
@@ -21761,11 +21666,11 @@ kz
 kB
 kB
 kB
-kK
-kK
-kK
+kV
+kV
+kV
 kB
-kK
+kV
 kF
 kz
 la
@@ -21842,13 +21747,13 @@ cw
 du
 dE
 cw
-cN
-cN
+cy
+cy
 dz
 bo
 dZ
 eh
-es
+eO
 eD
 eh
 eh
@@ -21859,7 +21764,7 @@ dY
 bo
 dz
 cw
-cN
+cy
 Lk
 aR
 aW
@@ -21868,9 +21773,9 @@ bo
 dz
 dz
 cw
-cN
 cy
-cN
+cy
+cy
 cw
 dP
 dv
@@ -21886,7 +21791,7 @@ gS
 gQ
 gQ
 gQ
-gR
+gP
 gQ
 gO
 gO
@@ -21895,8 +21800,8 @@ bo
 aW
 aR
 gS
-gR
-gR
+gP
+gP
 gS
 ho
 hl
@@ -21916,7 +21821,7 @@ ir
 hC
 hv
 hW
-hy
+hv
 hC
 hW
 jn
@@ -21962,7 +21867,7 @@ kB
 kB
 kQ
 kB
-kK
+kV
 kB
 lb
 le
@@ -21972,7 +21877,7 @@ kB
 kz
 kB
 kB
-kK
+kV
 le
 kz
 kB
@@ -22086,7 +21991,7 @@ aR
 aR
 gS
 gS
-gR
+gP
 gT
 gQ
 gT
@@ -22118,7 +22023,7 @@ hW
 iD
 hv
 hv
-iT
+hv
 iW
 hW
 jo
@@ -22161,18 +22066,18 @@ ju
 kz
 kz
 kB
-kK
-kK
+kV
+kV
 kB
 kB
 kB
-kK
-kK
-kK
-kK
-kK
+kV
+kV
+kV
+kV
+kV
 lo
-kK
+kV
 kB
 kB
 kB
@@ -22240,14 +22145,14 @@ bL
 bv
 bv
 cw
-cN
+cy
 cw
 cw
 cw
 dB
 cw
 dR
-cN
+cy
 dz
 bo
 dY
@@ -22262,8 +22167,8 @@ dY
 dY
 bo
 dz
-cN
-cN
+cy
+cy
 BO
 aR
 aW
@@ -22292,7 +22197,7 @@ gS
 gQ
 gQ
 gQ
-gR
+gP
 gO
 bo
 bo
@@ -22362,20 +22267,20 @@ iY
 ju
 kz
 kB
-kK
-kK
+kV
+kV
 kB
-kK
+kV
 kB
-kK
+kV
 kB
-kK
-kK
+kV
+kV
 kB
 kV
 kM
 lr
-kK
+kV
 lB
 lM
 kz
@@ -22435,7 +22340,7 @@ aa
 aR
 bx
 bC
-bK
+bR
 bL
 bL
 bO
@@ -22443,12 +22348,12 @@ bL
 cB
 bv
 cY
-cN
+cy
 cw
-dh
+dT
 dz
-cN
-cN
+cy
+cy
 dR
 dz
 bo
@@ -22472,7 +22377,7 @@ aW
 bo
 dz
 dz
-cN
+cy
 dm
 cw
 cw
@@ -22493,8 +22398,8 @@ aR
 gS
 gQ
 gP
-gR
-gR
+gP
+gP
 gO
 gO
 bo
@@ -22502,7 +22407,7 @@ aW
 aW
 gO
 gQ
-gR
+gP
 gO
 hp
 hy
@@ -22522,7 +22427,7 @@ gQ
 gQ
 gQ
 gQ
-gR
+gP
 gQ
 gQ
 gO
@@ -22564,7 +22469,7 @@ iY
 ju
 kz
 kB
-kL
+tP
 kO
 kB
 kU
@@ -22638,8 +22543,8 @@ aR
 bv
 bv
 bL
-bK
-bK
+bR
+bR
 cj
 bL
 bR
@@ -22649,8 +22554,8 @@ di
 dq
 cw
 dz
-cN
-cN
+cy
+cy
 cw
 dz
 bo
@@ -22659,7 +22564,7 @@ bu
 ev
 dY
 dY
-es
+eO
 dY
 bo
 dz
@@ -22667,15 +22572,15 @@ dz
 dz
 dz
 cw
-cN
+cy
 dz
 bo
 bo
 bo
 dz
-cN
+cy
 cw
-cN
+cy
 cw
 dj
 dj
@@ -22695,15 +22600,15 @@ aR
 gS
 gS
 gQ
-gR
-gR
+gP
+gP
 gQ
 gO
 bo
 bH
 bo
 gO
-gR
+gP
 gQ
 gO
 gO
@@ -22721,10 +22626,10 @@ ia
 gO
 gQ
 gQ
-gR
-gR
-gR
-gR
+gP
+gP
+gP
+gP
 gQ
 gQ
 gQ
@@ -22844,7 +22749,7 @@ bL
 bL
 bL
 bL
-bK
+bR
 bL
 bv
 dj
@@ -22852,7 +22757,7 @@ dj
 dv
 dF
 cw
-cN
+cy
 cy
 dz
 dz
@@ -22868,8 +22773,8 @@ dz
 dW
 cw
 cw
-cN
-cN
+cy
+cy
 dz
 dA
 dz
@@ -22878,7 +22783,7 @@ dz
 cw
 cy
 cw
-cN
+cy
 dz
 gg
 gg
@@ -22887,7 +22792,7 @@ gg
 gi
 gi
 gi
-gh
+iT
 gi
 gi
 gG
@@ -22897,19 +22802,19 @@ gg
 gg
 gO
 gQ
-gR
-gR
+gP
+gP
 gQ
 gO
 gO
 gO
 gY
 gO
-gR
+gP
 gQ
 gQ
 gQ
-gR
+gP
 gO
 gO
 gO
@@ -22925,10 +22830,10 @@ gQ
 gQ
 gQ
 gQ
-gR
+gP
 gQ
 gQ
-gR
+gP
 gQ
 gO
 gO
@@ -22980,7 +22885,7 @@ kE
 kE
 kz
 kB
-kK
+kV
 lw
 lG
 kB
@@ -23049,41 +22954,41 @@ cs
 ct
 bL
 cZ
-cN
-cN
+cy
+cy
 cw
 dG
-cN
-cN
+cy
+cy
 cy
 cw
-cN
-cN
-cw
-cw
+cy
 cy
 cw
-cN
-cN
-cw
-cw
-cw
-cN
-cN
-cw
-cN
-cy
-cN
-cw
-cN
 cw
 cy
 cw
-cN
+cy
+cy
+cw
+cw
+cw
+cy
+cy
+cw
+cy
+cy
+cy
+cw
+cy
+cw
+cy
+cw
+cy
 cw
 dz
 gh
-gh
+iT
 gh
 gm
 gi
@@ -23095,44 +23000,44 @@ gh
 gi
 gm
 gh
-gh
+iT
 gh
 gO
 gQ
 gQ
-gR
+gP
 gX
-gR
+gP
 gQ
 gQ
 gQ
 gQ
 gQ
-gR
+gP
 gQ
-gR
-gR
+gP
+gP
 gU
 gQ
 gQ
-gR
-gR
-gQ
+gP
 gP
 gQ
 gP
-gR
-gR
-gP
-gR
-gR
 gQ
-gR
-gR
+gP
+gP
+gP
+gP
+gP
 gP
 gQ
+gP
+gP
+gP
 gQ
-gR
+gQ
+gP
 gQ
 gQ
 gQ
@@ -23140,27 +23045,27 @@ gT
 gQ
 gT
 gQ
-gR
+gP
 gQ
 gQ
 gP
 gX
-gR
-gR
+gP
+gP
 gQ
 gP
-gR
+gP
 gQ
 gQ
 gQ
 gQ
-gQ
-gR
-gR
 gQ
 gP
-gR
-gR
+gP
+gQ
+gP
+gP
+gP
 gQ
 gQ
 ky
@@ -23185,7 +23090,7 @@ kB
 kB
 lx
 lz
-kK
+kV
 kB
 kP
 aR
@@ -23248,40 +23153,40 @@ bD
 bL
 bL
 cs
-bK
+bR
 bL
 cZ
 cw
-cN
+cy
 cw
 dH
-cN
-cw
-cw
-cN
 cy
-cN
-cN
-cN
 cw
-cw
-cN
-cy
-cN
-cN
-cN
-cN
 cw
 cy
-cN
-cN
+cy
+cy
+cy
+cy
+cw
+cw
+cy
+cy
+cy
+cy
+cy
+cy
+cw
+cy
+cy
+cy
 cP
-cN
-cN
+cy
+cy
 cw
 cw
 cw
-cN
+cy
 cw
 gf
 gi
@@ -23289,11 +23194,11 @@ gi
 gi
 gn
 gh
-gh
+iT
 gv
 gD
 gi
-gh
+iT
 gh
 gn
 gi
@@ -23302,66 +23207,66 @@ gi
 gZ
 gQ
 hb
-gR
+gP
 gQ
 gQ
 gQ
 gQ
-gR
-gR
-gR
-gQ
+gP
+gP
 gP
 gQ
 gP
 gQ
-gR
-gR
 gP
 gQ
-gR
+gP
+gP
+gP
+gQ
+gP
 gQ
 gQ
 gP
-gR
+gP
 gQ
-gR
-gR
-gR
+gP
+gP
+gP
 gX
 iM
 gQ
 gQ
 gQ
-gR
-gQ
-gR
 gP
-gR
+gQ
+gP
+gP
+gP
 gU
 gQ
-gR
-gR
-gR
-gQ
-gR
-gQ
-gQ
-gR
-gR
-gQ
-gR
-gR
 gP
-gR
-gR
-gR
-gR
+gP
+gP
 gQ
-gR
+gP
 gQ
 gQ
-gR
+gP
+gP
+gQ
+gP
+gP
+gP
+gP
+gP
+gP
+gP
+gQ
+gP
+gQ
+gQ
+gP
 gQ
 gQ
 gP
@@ -23388,7 +23293,7 @@ ls
 ly
 lH
 kB
-kK
+kV
 kP
 aR
 ma
@@ -23448,22 +23353,22 @@ aR
 by
 bQ
 bL
-bK
+bR
 cs
-bK
-bK
+bR
+bR
 cZ
 cw
 cy
 dw
 dG
-cN
+cy
 cw
-cN
+cy
 cw
-cN
+cy
 ea
-cN
+cy
 cw
 eH
 eQ
@@ -23471,18 +23376,18 @@ eS
 cw
 cw
 dR
-cN
-cN
 cy
-cN
+cy
+cy
+cy
 cw
-cN
-cN
-cN
+cy
+cy
+cy
 cw
-cN
+cy
 cw
-cN
+cy
 cy
 cw
 dz
@@ -23502,43 +23407,43 @@ gh
 gh
 gh
 gO
-gR
+gP
 gQ
 gQ
 gP
-gR
-gQ
-gR
-gR
-gQ
-gQ
-gR
-gQ
-gQ
-gR
-gQ
-gR
-gR
 gP
 gQ
-gR
+gP
+gP
 gQ
-gR
 gQ
 gP
 gQ
-gR
+gQ
+gP
+gQ
+gP
+gP
+gP
+gQ
+gP
+gQ
+gP
+gQ
+gP
+gQ
+gP
 gQ
 gQ
-gR
+gP
 gQ
-gR
-gR
+gP
+gP
 gQ
-gR
+gP
 gQ
-gR
-gR
+gP
+gP
 gQ
 gQ
 jQ
@@ -23546,7 +23451,7 @@ gQ
 gQ
 gP
 gQ
-gR
+gP
 gQ
 gP
 gQ
@@ -23557,16 +23462,16 @@ gQ
 gQ
 gQ
 gQ
-gR
-gR
+gP
+gP
 gQ
 gQ
 gP
 gQ
-gR
+gP
 gQ
-gR
-gR
+gP
+gP
 gQ
 kz
 kz
@@ -23585,12 +23490,12 @@ kz
 kz
 kz
 kz
-kK
-kK
+kV
+kV
 lz
 lx
 kB
-kK
+kV
 kP
 aR
 kB
@@ -23652,7 +23557,7 @@ bR
 bL
 bL
 ct
-bK
+bR
 cR
 bv
 dj
@@ -23661,7 +23566,7 @@ dj
 dF
 cw
 cw
-cN
+cy
 dz
 dz
 dz
@@ -23674,7 +23579,7 @@ eb
 dA
 dz
 cw
-cN
+cy
 cw
 fS
 cy
@@ -23683,8 +23588,8 @@ dA
 dz
 dz
 dz
-cN
-cN
+cy
+cy
 fS
 cy
 dz
@@ -23695,7 +23600,7 @@ gg
 gi
 gi
 gi
-gh
+iT
 gG
 gi
 gv
@@ -23704,9 +23609,9 @@ gg
 gg
 gg
 gO
-gR
-gR
-gR
+gP
+gP
+gP
 gQ
 gO
 gO
@@ -23715,9 +23620,9 @@ gY
 gO
 gQ
 gQ
-gR
-gR
-gR
+gP
+gP
+gP
 gO
 gO
 hT
@@ -23732,8 +23637,8 @@ gO
 gU
 gQ
 gP
-gR
-gR
+gP
+gP
 gQ
 gQ
 gP
@@ -23788,7 +23693,7 @@ kE
 kE
 kz
 le
-kK
+kV
 lA
 lA
 kB
@@ -23850,8 +23755,8 @@ aR
 bv
 bv
 bL
-bK
-bK
+bR
+bR
 ck
 bL
 cC
@@ -23862,8 +23767,8 @@ db
 dx
 dz
 cy
-cN
-cN
+cy
+cy
 dz
 bo
 bo
@@ -23878,8 +23783,8 @@ dz
 dz
 dz
 dz
-cN
-cN
+cy
+cy
 dz
 bo
 bo
@@ -23887,7 +23792,7 @@ bo
 dz
 cw
 cy
-cN
+cy
 cw
 dj
 dj
@@ -23908,14 +23813,14 @@ gS
 gS
 gQ
 gQ
-gR
+gP
 gQ
 gO
 bo
 bo
 bo
 gO
-gR
+gP
 gP
 gO
 gO
@@ -23936,9 +23841,9 @@ gQ
 gQ
 gQ
 gP
-gR
-gR
-gR
+gP
+gP
+gP
 gQ
 gO
 jg
@@ -24051,7 +23956,7 @@ aa
 aR
 by
 bD
-bK
+bR
 bS
 bL
 bL
@@ -24064,7 +23969,7 @@ cG
 cP
 dz
 cw
-cN
+cy
 cw
 dz
 bo
@@ -24080,8 +23985,8 @@ bH
 bo
 bo
 dz
-cN
-cN
+cy
+cy
 dz
 aW
 aW
@@ -24089,8 +23994,8 @@ bo
 dz
 dz
 cw
-cN
-cN
+cy
+cy
 cw
 dv
 aR
@@ -24109,7 +24014,7 @@ aR
 gS
 ha
 gQ
-gR
+gP
 gQ
 gO
 gO
@@ -24118,29 +24023,29 @@ aW
 aW
 gO
 gQ
-gR
+gP
 gO
 hr
 hr
 hr
 ht
-hs
+ht
 hr
-hs
-hs
-hs
-hs
-hs
+ht
+ht
+ht
+ht
+ht
 hr
 gO
 gO
 ix
-gR
+gP
 gQ
 gQ
 gQ
 gQ
-gR
+gP
 gO
 gO
 jg
@@ -24185,7 +24090,7 @@ kL
 kS
 kO
 kX
-kK
+kV
 kX
 kO
 kO
@@ -24263,11 +24168,11 @@ cS
 cG
 cw
 cw
-cN
+cy
 dI
 cy
-cN
-cN
+cy
+cy
 dz
 bo
 eb
@@ -24282,7 +24187,7 @@ eb
 eb
 bo
 dz
-cN
+cy
 cy
 fX
 aR
@@ -24291,8 +24196,8 @@ bo
 bo
 dz
 cy
-cN
-cN
+cy
+cy
 cy
 dP
 dP
@@ -24311,8 +24216,8 @@ gS
 gS
 gQ
 gQ
-gR
-gR
+gP
+gP
 gO
 bo
 bH
@@ -24322,17 +24227,17 @@ gS
 gQ
 gQ
 gS
-hs
+ht
 hr
 hF
-hs
-hs
-hr
-hs
+ht
+ht
 hr
 ht
-hs
-hs
+hr
+ht
+ht
+ht
 hr
 hr
 gO
@@ -24383,19 +24288,19 @@ ju
 kz
 kB
 kB
-kK
-kK
+kV
+kV
 kV
 kB
-kK
-kK
-kK
+kV
+kV
+kV
 kB
 lk
 kB
 kM
 lt
-lB
+SC
 kB
 kZ
 kz
@@ -24467,8 +24372,8 @@ cy
 cG
 cw
 dz
-cN
-cN
+cy
+cy
 cw
 dz
 bH
@@ -24485,7 +24390,7 @@ eb
 bo
 dz
 cw
-cN
+cy
 Lk
 aR
 aW
@@ -24494,7 +24399,7 @@ bn
 dz
 cw
 cw
-cN
+cy
 cw
 cw
 dj
@@ -24512,7 +24417,7 @@ gV
 gS
 gQ
 gQ
-gR
+gP
 gQ
 gQ
 gO
@@ -24522,20 +24427,20 @@ aW
 aR
 DP
 gQ
-gR
+gP
 hg
-hs
+ht
 hr
 hr
-hs
+ht
 hr
 hr
 ic
 hr
-hs
+ht
 hr
 hr
-hs
+ht
 hr
 hr
 hr
@@ -24585,21 +24490,21 @@ ju
 kz
 kH
 kB
-kK
-kK
+kV
+kV
 kB
 kB
 kB
 ld
-kK
+kV
 kB
 kB
-kK
+kV
 lo
 kB
 kB
 kB
-kK
+kV
 kz
 kB
 kB
@@ -24665,13 +24570,13 @@ aW
 cE
 cw
 cw
-cN
+cy
 cG
 cw
 dJ
-cN
-cN
-cN
+cy
+cy
+cy
 dz
 bo
 eb
@@ -24687,7 +24592,7 @@ eb
 bo
 dz
 cy
-cN
+cy
 Lk
 aR
 aW
@@ -24695,11 +24600,11 @@ bo
 bu
 dz
 dz
-cN
-cN
-cN
-cN
-cN
+cy
+cy
+cy
+cy
+cy
 dj
 dj
 dz
@@ -24712,9 +24617,9 @@ gS
 gS
 gS
 gQ
-gR
-gR
-gR
+gP
+gP
+gP
 gQ
 gO
 gO
@@ -24724,13 +24629,13 @@ aW
 aR
 DP
 gX
-gR
+gP
 gS
 hr
 hr
-hs
+ht
 hr
-hs
+ht
 hr
 hr
 hr
@@ -24739,13 +24644,13 @@ hV
 ie
 ie
 hr
-hs
+ht
 hr
 hr
 hr
-hs
-hs
-hs
+ht
+ht
+ht
 hr
 hP
 hP
@@ -24786,20 +24691,20 @@ iY
 ju
 kz
 kI
-kK
-kB
-kB
-kK
-kK
-kK
 kV
 kB
 kB
 kV
-kK
+kV
+kV
+kV
+kB
+kB
+kV
+kV
 lq
-kK
-kK
+kV
+kV
 kB
 kB
 kz
@@ -24873,7 +24778,7 @@ cy
 dK
 dy
 cw
-cN
+cy
 dz
 bo
 eb
@@ -24888,8 +24793,8 @@ fE
 eb
 bo
 dz
-cN
-cN
+cy
+cy
 BO
 aR
 aW
@@ -24898,10 +24803,10 @@ bo
 bo
 dA
 cw
-cN
-cN
 cy
-cN
+cy
+cy
+cy
 cw
 dj
 dz
@@ -24912,11 +24817,11 @@ dz
 dz
 gS
 gQ
-gR
-gR
+gP
+gP
 gP
 gQ
-gR
+gP
 gX
 gY
 bo
@@ -24928,23 +24833,23 @@ gS
 gQ
 gP
 gS
-hs
+ht
 hr
 hr
 hO
-hs
+ht
 hr
 hr
 hr
 hr
 hr
 hr
-hs
+ht
 hr
 hr
-hs
-hs
-hs
+ht
+ht
+ht
 hr
 hr
 hr
@@ -24994,9 +24899,9 @@ kT
 kB
 kF
 kB
-kK
+kV
 lg
-kK
+kV
 kB
 lm
 kz
@@ -25074,8 +24979,8 @@ cw
 cG
 dK
 cw
-cN
-cN
+cy
+cy
 dz
 bo
 eb
@@ -25090,8 +24995,8 @@ fF
 eb
 bo
 dz
-cN
-cN
+cy
+cy
 Lk
 aR
 aW
@@ -25103,21 +25008,21 @@ dz
 cw
 cw
 cw
-cN
-cN
+cy
+cy
 go
 cw
-cN
-cN
+cy
+cy
 cw
 cw
-cN
+cy
 gQ
 gP
-gR
+gP
 gQ
 gQ
-gR
+gP
 gQ
 gO
 gO
@@ -25127,7 +25032,7 @@ aW
 aW
 aR
 DP
-gR
+gP
 gQ
 hh
 hr
@@ -25143,11 +25048,11 @@ hP
 hr
 ht
 iu
-hs
+ht
 ht
 hG
-hs
-hs
+ht
+ht
 hF
 iX
 jb
@@ -25196,8 +25101,8 @@ kz
 kz
 kz
 kB
-kK
-lh
+kV
+kQ
 kB
 kI
 kz
@@ -25270,13 +25175,13 @@ bo
 aW
 cH
 cy
-dd
+dL
 dn
 cw
 cG
 dL
-cN
-cN
+cy
+cy
 cy
 dz
 bo
@@ -25303,21 +25208,21 @@ aR
 aR
 dz
 dz
-cN
+cy
 cP
 cw
-cN
+cy
 cw
-cN
+cy
 cy
 cw
 cw
-cN
+cy
 cw
-gR
-gR
+gP
+gP
 gQ
-gR
+gP
 gQ
 gQ
 gO
@@ -25329,11 +25234,11 @@ aR
 aR
 aR
 gW
-gR
+gP
 gQ
 gS
-hs
-hs
+ht
+ht
 hr
 hP
 hP
@@ -25345,11 +25250,11 @@ hP
 hr
 hr
 iu
-hs
+ht
 hr
 hr
-hs
-hs
+ht
+ht
 hr
 hr
 hr
@@ -25473,13 +25378,13 @@ aW
 cI
 cw
 db
-dd
+dL
 cG
 cG
 dM
-cN
+cy
 cw
-cN
+cy
 dz
 bo
 eb
@@ -25510,14 +25415,14 @@ dz
 cw
 cw
 cw
-cN
-cN
+cy
+cy
 cw
-cN
+cy
 cw
 cw
-gR
-gR
+gP
+gP
 gQ
 gQ
 gO
@@ -25531,30 +25436,30 @@ aa
 aa
 aR
 DP
-gR
-gR
+gP
+gP
 DP
 ht
 hr
 hr
 hr
 hr
-hs
+ht
 hr
 hr
 hr
 hr
 hr
 hr
-hs
-hs
-hs
-hr
-hs
+ht
+ht
+ht
 hr
 ht
 hr
-hs
+ht
+hr
+ht
 iu
 hP
 ju
@@ -25571,7 +25476,7 @@ ju
 ju
 ju
 ju
-jD
+jy
 iY
 ju
 ju
@@ -25679,7 +25584,7 @@ do
 cG
 cP
 dz
-cN
+cy
 cy
 cw
 dA
@@ -25696,8 +25601,8 @@ fI
 eb
 bo
 dz
-cN
-cN
+cy
+cy
 BO
 aR
 aR
@@ -25746,7 +25651,7 @@ hr
 hr
 hr
 hr
-hs
+ht
 hr
 hr
 hr
@@ -25881,9 +25786,9 @@ cG
 dr
 cy
 dN
-cN
+cy
 dS
-cN
+cy
 dz
 bo
 eb
@@ -25936,18 +25841,18 @@ aa
 aR
 gW
 gQ
-gR
+gP
 hh
 hr
-hs
-hs
+ht
+ht
 hr
-hs
-hs
-hs
+ht
+ht
+ht
 hr
-hs
-hs
+ht
+ht
 hr
 hr
 hr
@@ -26080,7 +25985,7 @@ aW
 aW
 de
 cG
-cN
+cy
 dy
 dz
 cw
@@ -26119,7 +26024,7 @@ ga
 bo
 dz
 cw
-cN
+cy
 cw
 dz
 bo
@@ -26137,21 +26042,21 @@ aR
 aR
 aR
 DP
-gR
+gP
 gQ
 gS
 hr
 hr
-hs
+ht
 hr
 hV
 hV
 ie
 ie
-hs
+ht
 hr
-hs
-hs
+ht
+ht
 hr
 hP
 iz
@@ -26283,7 +26188,7 @@ aW
 aW
 dm
 cG
-cN
+cy
 dz
 cw
 cw
@@ -26302,8 +26207,8 @@ eb
 bo
 bH
 dz
-cN
-cN
+cy
+cy
 BO
 aR
 aa
@@ -26322,7 +26227,7 @@ bo
 dz
 cw
 cw
-cN
+cy
 dz
 bo
 aW
@@ -26340,9 +26245,9 @@ aa
 aR
 gS
 gQ
-gR
+gP
 gO
-hs
+ht
 hr
 hr
 hr
@@ -26365,7 +26270,7 @@ hP
 jd
 jr
 hP
-jD
+jy
 iY
 jg
 jg
@@ -26489,7 +26394,7 @@ ce
 aW
 bo
 dT
-cN
+cy
 dz
 dz
 bo
@@ -26505,7 +26410,7 @@ bo
 dz
 dz
 cw
-cN
+cy
 dz
 dz
 aR
@@ -26522,8 +26427,8 @@ aR
 aW
 bo
 dA
-cN
-cN
+cy
+cy
 cw
 dA
 bo
@@ -26691,7 +26596,7 @@ bu
 ce
 bo
 cy
-cN
+cy
 cw
 dz
 dz
@@ -26707,7 +26612,7 @@ dz
 dz
 fM
 cw
-cN
+cy
 cw
 dz
 BO
@@ -26725,7 +26630,7 @@ dz
 dz
 dz
 cw
-cN
+cy
 cw
 dz
 gO
@@ -26742,7 +26647,7 @@ DP
 gW
 DP
 gO
-gR
+gP
 gQ
 gT
 gQ
@@ -26892,82 +26797,82 @@ aW
 aW
 aW
 bH
-cN
-cN
-cN
+cy
+cy
+cy
 cw
-cN
-cN
+cy
+cy
 cw
 cw
 cy
-cN
+cy
 cw
 cw
-cN
-cN
-cN
-cN
+cy
+cy
+cy
+cy
 cy
 do
 cw
-cN
-cw
-cN
-cw
-cN
-cN
-cN
-cw
-cN
 cy
 cw
-cN
+cy
+cw
+cy
+cy
+cy
+cw
+cy
+cy
+cw
+cy
 cw
 cP
 cw
 cy
-cN
+cy
 cw
-cN
-gR
+cy
+gP
 gP
 gU
-gR
+gP
 gQ
 gQ
 gQ
-gR
-gR
-gR
-gR
+gP
+gP
+gP
+gP
 gQ
-gR
+gP
 gQ
 gQ
 gT
-gR
+gP
 gQ
-gR
+gP
 gQ
-gR
+gP
 gQ
 gQ
-gR
-gR
+gP
+gP
 gQ
 gT
 gP
 gT
 gQ
 gQ
-gR
+gP
 gQ
 gP
-gR
+gP
 gQ
 gQ
-gR
+gP
 gQ
 gT
 gQ
@@ -27093,86 +26998,86 @@ aR
 aR
 aR
 dz
-cN
+cy
 do
 cw
-cN
-cN
-cN
-cw
-cN
-cw
-cN
-cN
+cy
+cy
+cy
 cw
 cy
-cN
-cN
+cw
+cy
+cy
+cw
+cy
+cy
+cy
 cP
 dm
-cN
+cy
 cw
 dR
 cw
-cN
+cy
 cy
 cw
-cN
+cy
 cw
-cN
+cy
 cw
 cy
 dR
-cN
-cN
+cy
+cy
 cw
-cN
-cN
+cy
+cy
 cw
 cw
-cN
-cN
+cy
+cy
 gQ
-gR
-gQ
-gQ
-gQ
-gR
-gR
-gR
 gP
-gR
+gQ
+gQ
+gQ
+gP
+gP
+gP
+gP
+gP
 gU
 gQ
-gR
+gP
 gQ
-gR
-gR
-gR
+gP
+gP
+gP
 gP
 gQ
 gQ
-gR
-gR
 gP
-gR
+gP
+gP
+gP
 gQ
 gQ
 gT
-gR
-gT
-gQ
-gR
-gR
-gR
-gR
-gQ
-gT
-gR
-gR
 gP
 gT
-gR
+gQ
+gP
+gP
+gP
+gP
+gQ
+gT
+gP
+gP
+gP
+gT
+gP
 gT
 iY
 jg
@@ -27295,7 +27200,7 @@ aa
 aa
 aR
 dz
-cN
+cy
 cy
 cw
 dW
@@ -27331,8 +27236,8 @@ dz
 dz
 dz
 cw
-cN
-cN
+cy
+cy
 dz
 gQ
 gO
@@ -27350,7 +27255,7 @@ gO
 gO
 gQ
 gQ
-gR
+gP
 gQ
 gO
 DP
@@ -27533,7 +27438,7 @@ bH
 bo
 aW
 bo
-fQ
+bH
 bo
 aW
 gt
@@ -27734,9 +27639,9 @@ aW
 aW
 aW
 aW
-fQ
+bH
 bo
-fQ
+bH
 aW
 aW
 aW
@@ -27938,7 +27843,7 @@ aR
 dO
 gj
 gI
-gr
+gk
 dO
 aR
 aR
@@ -28138,7 +28043,7 @@ aa
 aa
 aa
 dO
-gr
+gk
 gj
 aR
 dO
@@ -28341,7 +28246,7 @@ aa
 aa
 dO
 gj
-gr
+gk
 gk
 dO
 aR
@@ -28528,10 +28433,10 @@ aa
 aa
 aa
 fO
-fV
+fP
 fL
 fN
-fV
+fP
 fN
 aa
 aa
@@ -28745,7 +28650,7 @@ aa
 aa
 aR
 gj
-gr
+gk
 gj
 dO
 aa
@@ -28947,7 +28852,7 @@ aa
 aa
 aR
 gj
-gr
+gk
 gj
 aR
 aa
@@ -29352,7 +29257,7 @@ aa
 aR
 gj
 gk
-gr
+gk
 aR
 aa
 aa
@@ -29742,7 +29647,7 @@ aa
 aa
 aR
 aa
-fV
+fP
 fN
 fO
 aa
@@ -29754,7 +29659,7 @@ aa
 aa
 aa
 aa
-gr
+gk
 aR
 gj
 aR
@@ -30350,7 +30255,7 @@ aR
 aR
 fN
 fN
-fV
+fP
 aa
 aa
 aa
@@ -30564,7 +30469,7 @@ aa
 aR
 aa
 aR
-gr
+gk
 aR
 aa
 aa

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -907,6 +907,7 @@
 "cC" = (
 /obj/landmark/corpse/engineer,
 /obj/decal/cleanable/blood,
+/obj/random/loot/raregunslug,
 /turf/simulated/floor/plating,
 /area/errant_pisces/enginering)
 "cD" = (
@@ -1717,16 +1718,16 @@
 "ek" = (
 /obj/structure/table/standard,
 /obj/item/towel/random,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "el" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "em" = (
 /obj/machinery/door/airlock,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "en" = (
 /obj/machinery/alarm{
@@ -1734,11 +1735,12 @@
 	},
 /obj/landmark/corpse/carp_fisher,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/obj/item/grenade/frag/homemade,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "eo" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "ep" = (
 /obj/structure/hygiene/toilet{
@@ -1747,7 +1749,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "eq" = (
 /obj/structure/cable{
@@ -1808,27 +1810,27 @@
 /obj/structure/hygiene/toilet{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "ew" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "ex" = (
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "ey" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "ez" = (
 /obj/structure/table/standard,
 /obj/item/towel/random,
 /obj/item/towel/random,
 /obj/item/towel/random,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "eA" = (
 /obj/structure/cable{
@@ -1866,7 +1868,6 @@
 	id_tag = "xyn_solar_port_sensor";
 	pixel_y = 25
 	},
-/mob/living/simple_animal/hostile/carp/shark,
 /turf/simulated/floor/plating,
 /area/errant_pisces/solar_port)
 "eC" = (
@@ -1967,7 +1968,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "eJ" = (
 /turf/simulated/wall,
@@ -1977,7 +1978,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "eL" = (
 /obj/machinery/light/small{
@@ -1987,7 +1988,7 @@
 	dir = 10
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "eM" = (
 /obj/machinery/power/terminal,
@@ -2077,20 +2078,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "eT" = (
 /obj/structure/closet/athletic_mixed,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "eU" = (
 /obj/structure/hygiene/shower{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "eV" = (
 /obj/machinery/door/airlock/external{
@@ -2137,8 +2138,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/blood,
-/mob/living/simple_animal/hostile/carp/shark,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "eZ" = (
 /obj/structure/closet/athletic_mixed,
@@ -2146,7 +2146,8 @@
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/tiled/white,
+/obj/random/loot/randomcolonyitems,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "fa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2154,7 +2155,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "fb" = (
 /obj/structure/cable{
@@ -2222,20 +2223,21 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "fh" = (
 /obj/structure/closet/athletic_mixed,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "fi" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "fj" = (
 /obj/structure/cable{
@@ -2365,7 +2367,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "fu" = (
 /turf/simulated/floor/plating,
@@ -2398,7 +2400,7 @@
 "fy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "fA" = (
 /obj/structure/cable{
@@ -2527,7 +2529,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "fK" = (
 /obj/machinery/light/small{
@@ -2568,13 +2570,14 @@
 /obj/structure/closet/crate/radiation,
 /obj/item/stack/material/tritium/ten,
 /obj/item/stack/material/tritium/ten,
+/obj/random/loot/randomcolonyitems,
 /turf/simulated/floor/plating,
 /area/errant_pisces/smes_room)
 "fO" = (
 /obj/structure/hygiene/urinal{
 	pixel_y = 30
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "fP" = (
 /obj/structure/cable/green{
@@ -2584,7 +2587,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "fR" = (
 /obj/item/stool,
@@ -2666,10 +2669,10 @@
 	icon_state = "tube1"
 	},
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "fZ" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "ga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2678,7 +2681,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2687,7 +2690,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gc" = (
 /obj/machinery/light,
@@ -2698,7 +2701,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gd" = (
 /obj/structure/cable/green{
@@ -2712,7 +2715,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "ge" = (
 /obj/structure/cable/green{
@@ -2732,7 +2735,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gf" = (
 /obj/machinery/light,
@@ -2743,7 +2746,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2752,7 +2755,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gh" = (
 /obj/machinery/light{
@@ -2760,7 +2763,7 @@
 	icon_state = "tube1"
 	},
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gi" = (
 /turf/simulated/wall/r_wall,
@@ -2774,7 +2777,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gl" = (
 /obj/structure/cable/green{
@@ -2790,7 +2793,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gm" = (
 /obj/machinery/power/apc{
@@ -2803,7 +2806,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gn" = (
 /turf/simulated/wall,
@@ -2814,27 +2817,27 @@
 "gp" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/rainbow,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gq" = (
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gr" = (
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gs" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/orange,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gt" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gu" = (
 /obj/machinery/light{
@@ -2842,20 +2845,20 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/jukebox,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gv" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gw" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	level = 2
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gx" = (
 /obj/wallframe_spawn/reinforced,
@@ -2867,7 +2870,7 @@
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gz" = (
 /obj/structure/cable/green{
@@ -2881,13 +2884,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gB" = (
 /obj/wallframe_spawn/reinforced,
@@ -2899,7 +2902,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gD" = (
 /obj/machinery/vending/fitness,
@@ -2907,38 +2910,38 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gE" = (
 /obj/machinery/vending/cola,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gF" = (
 /obj/structure/closet,
 /obj/random/clothing,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gG" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gH" = (
 /obj/structure/closet,
 /obj/random/accessory,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gI" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet,
 /obj/random/plushie,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gJ" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gK" = (
 /obj/structure/cable/yellow{
@@ -2959,17 +2962,23 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gM" = (
-/mob/living/simple_animal/hostile/carp/shark,
-/turf/simulated/floor/wood,
-/area/errant_pisces/rooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/daemon/headcrab/infestor,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/errant_pisces/science_wing)
 "gN" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/suit/armor/vest,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gO" = (
 /obj/structure/bed/chair/comfy/teal,
@@ -2977,23 +2986,23 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gP" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gQ" = (
 /obj/structure/table/gamblingtable,
 /obj/item/deck/cards,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gR" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "gS" = (
 /obj/structure/cable/green{
@@ -3003,14 +3012,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "gT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gU" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gV" = (
 /obj/machinery/power/apc{
@@ -3022,55 +3031,57 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gW" = (
 /obj/structure/closet,
 /obj/random/cash,
 /obj/random/drinkbottle,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gX" = (
 /obj/structure/closet,
 /obj/random/hat,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gY" = (
 /obj/structure/curtain/black,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "gZ" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "ha" = (
 /obj/structure/closet,
 /obj/random/smokes,
-/obj/random/projectile,
-/turf/simulated/floor/wood,
+/obj/random/loot/armorinsertsrare,
+/obj/random/loot/raresidearmbundle,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "hb" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
 /obj/item/device/flashlight/lamp,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "hc" = (
 /obj/structure/closet,
 /obj/random/snack,
 /obj/random/tool,
-/obj/random/suit,
-/turf/simulated/floor/wood,
+/obj/random/loot/armorinsertsrare,
+/obj/random/loot/rigloot,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "hd" = (
 /obj/structure/table/gamblingtable,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "he" = (
 /obj/structure/table/woodentable,
 /obj/item/material/ashtray/bronze,
 /obj/random/smokes,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "hf" = (
 /obj/structure/cable/green{
@@ -3084,7 +3095,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "hg" = (
 /obj/machinery/door/airlock,
@@ -3100,7 +3111,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/rooms)
 "hi" = (
 /obj/structure/cable/green{
@@ -3120,7 +3131,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "hj" = (
 /obj/machinery/door/airlock,
@@ -3136,7 +3147,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hk" = (
 /obj/structure/cable/green{
@@ -3150,7 +3161,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hl" = (
 /obj/structure/cable/green{
@@ -3158,7 +3169,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hm" = (
 /obj/structure/cable/green{
@@ -3166,18 +3177,18 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hn" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "ho" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hp" = (
 /obj/floor_decal/solarpanel,
@@ -3198,12 +3209,11 @@
 /area/errant_pisces/infirmary)
 "hr" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "hs" = (
-/obj/landmark/corpse/bridgeofficer,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "ht" = (
 /obj/structure/bed/chair/comfy/brown,
@@ -3213,33 +3223,34 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "hu" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hv" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hw" = (
 /obj/structure/closet,
-/turf/simulated/floor/tiled,
+/obj/random/loot/randomsupply/tech,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hx" = (
-/obj/decal/cleanable/blood,
-/turf/simulated/floor/wood,
-/area/errant_pisces/rooms)
+/mob/living/simple_animal/hostile/daemon/large,
+/turf/simulated/floor/tiled/freezer,
+/area/errant_pisces/fishing_wing)
 "hy" = (
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "hz" = (
 /obj/machinery/alarm{
@@ -3250,7 +3261,7 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "hA" = (
 /obj/machinery/power/apc{
@@ -3263,25 +3274,25 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/rooms)
 "hB" = (
 /obj/machinery/vending/games,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hC" = (
 /obj/machinery/vending/generic,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hD" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hE" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet,
 /obj/random/plushie/large,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hF" = (
 /turf/simulated/wall/r_wall,
@@ -3327,11 +3338,11 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "hN" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hO" = (
 /obj/machinery/light{
@@ -3339,7 +3350,7 @@
 	icon_state = "tube1"
 	},
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "hP" = (
 /obj/structure/crematorium,
@@ -3368,7 +3379,6 @@
 /turf/simulated/floor/tiled/white,
 /area/errant_pisces/infirmary)
 "hU" = (
-/mob/living/simple_animal/hostile/carp/shark,
 /turf/simulated/floor/tiled/white,
 /area/errant_pisces/infirmary)
 "hV" = (
@@ -3378,17 +3388,17 @@
 "hW" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "hX" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "hY" = (
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "hZ" = (
 /obj/structure/table/standard,
@@ -3396,7 +3406,7 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "ia" = (
 /obj/structure/table/standard,
@@ -3404,26 +3414,26 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "ib" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "ic" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "id" = (
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "ie" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "if" = (
 /obj/wallframe_spawn/reinforced,
@@ -3432,34 +3442,35 @@
 /area/errant_pisces/infirmary)
 "ig" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "ih" = (
 /obj/item/material/knife/table,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "ii" = (
 /obj/item/stool,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "ij" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "ik" = (
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "il" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "im" = (
 /obj/landmark/corpse/chef,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "in" = (
 /obj/machinery/door/airlock/freezer,
@@ -3528,7 +3539,7 @@
 "iz" = (
 /obj/machinery/door/airlock,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iA" = (
 /obj/wallframe_spawn/reinforced,
@@ -3536,42 +3547,42 @@
 /area/errant_pisces/infirmary)
 "iB" = (
 /obj/structure/curtain/medical,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iC" = (
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iD" = (
 /obj/structure/closet,
 /obj/random/firstaid,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iE" = (
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iF" = (
 /obj/structure/table/standard,
 /obj/item/trash/plate,
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "iG" = (
 /obj/structure/table/marble,
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "iH" = (
 /obj/structure/table/marble,
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "iI" = (
-/mob/living/simple_animal/hostile/carp/shark,
+/obj/item/grenade/frag/homemade,
 /turf/simulated/floor/tiled/freezer,
 /area/errant_pisces/dorms)
 "iJ" = (
@@ -3601,9 +3612,9 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/infirmary)
 "iO" = (
-/mob/living/simple_animal/hostile/carp/shark,
-/turf/simulated/floor/plating,
-/area/errant_pisces/infirmary)
+/mob/living/simple_animal/hostile/daemon/headcrab/infestor,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/errant_pisces/bridge)
 "iP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -3628,7 +3639,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3637,7 +3648,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iT" = (
 /obj/machinery/light{
@@ -3655,7 +3666,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3666,7 +3677,7 @@
 	},
 /obj/landmark/corpse/doctor,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3676,7 +3687,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iW" = (
 /obj/machinery/door/firedoor,
@@ -3686,7 +3697,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3695,7 +3706,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3704,7 +3715,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "iZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3713,7 +3724,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "ja" = (
 /obj/machinery/body_scanconsole,
@@ -3721,20 +3732,20 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jb" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jc" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jd" = (
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "je" = (
 /obj/machinery/light/small{
@@ -3766,24 +3777,24 @@
 /area/errant_pisces/infirmary)
 "jj" = (
 /obj/structure/iv_stand,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jn" = (
 /obj/machinery/bodyscanner,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3792,7 +3803,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jp" = (
 /obj/structure/cable/green{
@@ -3806,7 +3817,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jq" = (
 /obj/machinery/door/airlock,
@@ -3822,7 +3833,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jr" = (
 /obj/structure/cable/green{
@@ -3841,24 +3852,24 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/hallway)
 "js" = (
 /obj/structure/table/standard,
 /obj/item/material/kitchen/utensil/fork/plastic,
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "jt" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "ju" = (
 /obj/structure/table/marble,
 /obj/machinery/reagentgrinder/juicer,
 /obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "jv" = (
 /obj/landmark/corpse/carp_fisher,
@@ -3897,12 +3908,12 @@
 /area/errant_pisces/science_wing)
 "jB" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jC" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/freezer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jD" = (
 /obj/structure/table/standard,
@@ -3911,7 +3922,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jE" = (
 /obj/structure/table/standard,
@@ -3919,7 +3930,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3928,7 +3939,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jG" = (
 /obj/machinery/door/airlock,
@@ -3948,7 +3959,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jI" = (
 /obj/item/stool,
@@ -3960,7 +3971,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jJ" = (
 /obj/machinery/power/apc{
@@ -3972,25 +3983,25 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/infirmary)
 "jK" = (
 /obj/structure/table/standard,
 /obj/item/material/kitchen/utensil/fork,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "jL" = (
 /obj/machinery/vending/dinnerware,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "jM" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "jN" = (
 /obj/machinery/cooker/oven,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/dorms)
 "jO" = (
 /obj/decal/cleanable/blood,
@@ -4018,7 +4029,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "jT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4029,29 +4040,29 @@
 	},
 /obj/structure/closet,
 /obj/item/clothing/under/carp,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "jU" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "jV" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "jW" = (
 /obj/machinery/photocopier,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "jX" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "jY" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "jZ" = (
 /obj/machinery/door/airlock,
@@ -4063,7 +4074,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "ka" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -4097,7 +4108,7 @@
 	dir = 8
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "ke" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4105,27 +4116,27 @@
 	},
 /obj/structure/closet,
 /obj/item/clothing/suit/armor/grim/toggle/labcoat/genetics,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kf" = (
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kg" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kh" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "ki" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kj" = (
 /turf/simulated/wall/r_wall,
@@ -4134,14 +4145,14 @@
 /obj/machinery/sleeper{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kl" = (
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "km" = (
 /obj/machinery/alarm{
@@ -4150,13 +4161,13 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "ko" = (
 /obj/structure/cable/green{
@@ -4175,7 +4186,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kp" = (
 /obj/structure/cable/green{
@@ -4186,7 +4197,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kq" = (
 /obj/machinery/power/apc{
@@ -4201,13 +4212,13 @@
 /obj/structure/window/basic{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kr" = (
 /obj/machinery/sleeper{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "ks" = (
 /turf/simulated/wall/r_wall,
@@ -4235,7 +4246,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4245,7 +4256,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4254,7 +4265,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "ky" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4265,7 +4276,7 @@
 	},
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4277,7 +4288,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4289,24 +4300,24 @@
 /obj/structure/bookcase,
 /obj/item/book/manual/anomaly_testing,
 /obj/item/book/manual/anomaly_spectroscopy,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kB" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/mass_spectrometry,
 /obj/item/book/manual/research_and_development,
 /obj/item/book/manual/engineering_guide,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kC" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/materials_chemistry_analysis,
 /obj/item/book/manual/hydroponics_pod_people,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kD" = (
 /obj/machinery/vending/generic,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kE" = (
 /obj/machinery/light{
@@ -4315,33 +4326,33 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kF" = (
 /obj/structure/closet/fridge,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "kG" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/armor/grim/toggle/labcoat/blue,
 /obj/random/coin,
 /obj/random/coin,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kH" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kI" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/apron/overalls,
 /obj/random/drinkbottle,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kJ" = (
 /obj/structure/window/basic{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4351,23 +4362,23 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kL" = (
 /obj/structure/window/basic{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kM" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/armor/grim/toggle/labcoat/xyn_machine,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kN" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/apron/overalls,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "kO" = (
 /obj/structure/closet/crate/warhammer/freezer/rations,
@@ -4452,24 +4463,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/rack,
 /obj/item/material/harpoon,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "le" = (
 /obj/landmark/corpse/scientist,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lf" = (
 /obj/structure/table/rack,
 /obj/item/gun/launcher/net,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lh" = (
 /obj/machinery/light/small{
@@ -4526,49 +4537,49 @@
 	dir = 5
 	},
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lr" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "ls" = (
 /turf/simulated/wall,
 /area/errant_pisces/science_wing)
 "lt" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lu" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/freezer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lv" = (
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lw" = (
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/electrical,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lx" = (
 /obj/structure/table/standard,
 /obj/item/tape_roll,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "ly" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/latexgloves,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lz" = (
 /obj/structure/closet,
@@ -4578,18 +4589,18 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "lA" = (
 /obj/structure/closet,
 /obj/random/loot,
 /obj/random/soap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "lB" = (
 /obj/structure/closet,
 /obj/item/clothing/under/hazard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "lC" = (
 /obj/structure/closet,
@@ -4599,7 +4610,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "lD" = (
 /obj/structure/table/rack,
@@ -4637,24 +4648,24 @@
 /area/errant_pisces/science_wing)
 "lK" = (
 /obj/structure/closet/l3closet/scientist,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lL" = (
 /obj/structure/closet/secure_closet/scientist{
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lM" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lN" = (
 /obj/machinery/door/window/northright,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lO" = (
 /obj/machinery/vending/hydronutrients,
@@ -4664,7 +4675,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lP" = (
 /obj/structure/window/reinforced{
@@ -4674,7 +4685,7 @@
 	dir = 1
 	},
 /obj/machinery/chem_master,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lQ" = (
 /obj/structure/window/reinforced{
@@ -4682,7 +4693,7 @@
 	},
 /obj/machinery/reagentgrinder,
 /obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lR" = (
 /obj/structure/window/reinforced{
@@ -4694,7 +4705,7 @@
 /obj/structure/table/standard,
 /obj/item/book/manual/mass_spectrometry,
 /obj/item/device/scanner/spectrometer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "lS" = (
 /obj/structure/window/reinforced{
@@ -4814,7 +4825,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mi" = (
 /obj/structure/closet/secure_closet/scientist{
@@ -4824,31 +4835,31 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mj" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mk" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "ml" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/machinery/chemical_dispenser/full,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mm" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mn" = (
 /obj/structure/window/reinforced{
@@ -4869,12 +4880,13 @@
 "mp" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/armor/grim/storage/hooded/wintercoat,
-/turf/simulated/floor/tiled,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "mq" = (
 /obj/structure/closet,
 /obj/random/plushie,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "mr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -4905,9 +4917,10 @@
 /turf/simulated/floor/tiled/freezer,
 /area/errant_pisces/prod_storage)
 "mv" = (
-/mob/living/simple_animal/hostile/carp/shark,
-/turf/simulated/floor/tiled/freezer,
-/area/errant_pisces/prod_storage)
+/obj/structure/table/steel,
+/obj/random/loot/tech2,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/errant_pisces/bridge)
 "mw" = (
 /obj/structure/window/basic{
 	dir = 8
@@ -4952,7 +4965,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mD" = (
 /obj/machinery/power/apc{
@@ -4966,11 +4979,11 @@
 /obj/structure/closet/secure_closet/scientist{
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mE" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mF" = (
 /obj/structure/window/reinforced{
@@ -4979,11 +4992,11 @@
 /obj/structure/table/standard,
 /obj/item/storage/box/beakers,
 /obj/item/reagent_containers/dropper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mG" = (
 /obj/machinery/biogenerator,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mH" = (
 /obj/structure/window/reinforced{
@@ -4992,7 +5005,7 @@
 /obj/machinery/computer/modular{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mI" = (
 /obj/machinery/optable,
@@ -5004,15 +5017,16 @@
 /obj/machinery/light,
 /obj/landmark/corpse/carp_fisher,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/obj/item/grenade/frag/homemade,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "mK" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "mL" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "mM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5130,13 +5144,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 "mY" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "mZ" = (
 /obj/machinery/door/airlock,
@@ -5148,7 +5162,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/cryo)
 "na" = (
 /obj/machinery/door/airlock,
@@ -5308,7 +5322,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "np" = (
 /obj/structure/cable/green{
@@ -5322,7 +5336,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nq" = (
 /obj/structure/cable/green{
@@ -5336,7 +5350,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nr" = (
 /obj/structure/cable/green{
@@ -5353,7 +5367,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "ns" = (
 /obj/structure/cable/green{
@@ -5370,7 +5384,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nt" = (
 /obj/structure/cable/green{
@@ -5389,7 +5403,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nu" = (
 /obj/machinery/door/firedoor,
@@ -5404,7 +5418,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5418,7 +5432,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5435,7 +5449,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nx" = (
 /obj/machinery/alarm{
@@ -5457,7 +5471,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "ny" = (
 /obj/structure/cable/green{
@@ -5471,7 +5485,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5487,7 +5501,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5501,7 +5515,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5516,7 +5530,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5531,7 +5545,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5548,7 +5562,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5570,7 +5584,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5586,7 +5600,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5598,20 +5612,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5669,24 +5683,24 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nP" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nR" = (
 /obj/landmark/corpse/scientist,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nS" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nU" = (
 /obj/machinery/power/apc{
@@ -5694,23 +5708,23 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nX" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5720,18 +5734,18 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "nZ" = (
 /obj/machinery/door/firedoor,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "oa" = (
-/obj/landmark/corpse/bridgeofficer,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
-/area/errant_pisces/aft_hallway)
+/mob/living/simple_animal/hostile/daemon/large,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/errant_pisces/dorms)
 "ob" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -5773,7 +5787,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "og" = (
 /turf/simulated/wall/r_wall,
@@ -5799,7 +5813,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "ok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5900,7 +5914,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "ot" = (
 /turf/simulated/wall,
@@ -5980,8 +5994,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/landmark/corpse/bridgeofficer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "oH" = (
 /obj/structure/cable/green{
@@ -6006,7 +6019,7 @@
 	pixel_x = -25;
 	rcon_setting = 3
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "oJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6033,23 +6046,24 @@
 	},
 /obj/structure/cable/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "oM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "oN" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/obj/random/loot/tech1,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "oO" = (
 /obj/structure/table/steel,
 /obj/random/drinkbottle,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "oP" = (
 /obj/machinery/light{
@@ -6057,39 +6071,41 @@
 	},
 /obj/structure/table/steel,
 /obj/random/drinkbottle,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "oQ" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/tiled,
-/area/errant_pisces/bridge)
+/obj/structure/closet,
+/obj/item/clothing/under/hazard,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/errant_pisces/cryo)
 "oR" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/tiled,
+/obj/random/loot/lootstructureartifact,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "oS" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "oT" = (
 /obj/structure/bed/chair/comfy/captain,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "oU" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "oV" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "oW" = (
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "oX" = (
 /obj/machinery/light{
@@ -6101,7 +6117,7 @@
 /obj/random/ammo,
 /obj/random/cash,
 /obj/random/cash,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "oY" = (
 /obj/machinery/computer/modular/preset/filemanager{
@@ -6110,13 +6126,13 @@
 	name = "command terminal"
 	},
 /obj/computer_file_creator/ahabs_harpoon01,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "oZ" = (
 /obj/machinery/vending/medical{
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "pa" = (
 /obj/structure/cable/green{
@@ -6124,7 +6140,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "pb" = (
 /obj/structure/cable/green{
@@ -6133,7 +6149,7 @@
 	icon_state = "4-8"
 	},
 /obj/landmark/corpse/carp_fisher,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "pc" = (
 /obj/structure/cable/green{
@@ -6141,7 +6157,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "pd" = (
 /obj/structure/cable/green{
@@ -6159,7 +6175,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "pe" = (
 /obj/structure/closet/crate/secure/biohazard,
@@ -6173,38 +6189,38 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "ph" = (
 /obj/random/tool,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pi" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pj" = (
 /obj/machinery/computer/modular/preset/filemanager{
 	dir = 1
 	},
 /obj/computer_file_creator/ahabs_harpoon01,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pk" = (
 /obj/structure/table/steel,
 /obj/random/toy,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pl" = (
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "pm" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "pn" = (
 /obj/structure/table/woodentable,
@@ -6212,7 +6228,7 @@
 	desc = "A small, portable microcomputer. This one has a Xynergy logo in purple, and a serial number stamped into the case."
 	},
 /obj/computer_file_creator/ahabs_harpoon03,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "po" = (
 /obj/wallframe_spawn/reinforced,
@@ -6238,7 +6254,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "ps" = (
 /obj/structure/cable/green,
@@ -6251,7 +6267,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "pt" = (
 /obj/structure/kitchenspike,
@@ -6276,51 +6292,50 @@
 	pixel_x = -25;
 	rcon_setting = 3
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "py" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pz" = (
 /obj/overmap/visitable/ship/errant_pisces,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pA" = (
 /obj/structure/table/steel,
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pB" = (
 /obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "pC" = (
 /obj/structure/table/woodentable,
 /obj/random/toy,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "pD" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/fishing_wing)
 "pE" = (
-/mob/living/simple_animal/hostile/carp/shark,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/fishing_wing)
 "pF" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/fishing_wing)
 "pG" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "pH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "pI" = (
 /obj/machinery/door/airlock/freezer,
@@ -6334,16 +6349,16 @@
 	},
 /obj/structure/table/steel,
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pK" = (
 /obj/structure/table/steel,
 /obj/random/firstaid,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pL" = (
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pM" = (
 /obj/machinery/light{
@@ -6352,31 +6367,31 @@
 	},
 /obj/structure/table/steel,
 /obj/random/handgun,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "pN" = (
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "pO" = (
 /obj/structure/hygiene/shower{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/fishing_wing)
 "pP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "pQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "pR" = (
 /obj/machinery/door/airlock,
@@ -6458,35 +6473,34 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/fishing_wing)
 "pZ" = (
-/obj/structure/net,
-/mob/living/simple_animal/hostile/carp,
-/turf/space,
-/area/space)
+/obj/structure/table/standard,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/errant_pisces/dorms)
 "qa" = (
 /obj/machinery/computer/ship/sensors{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "qb" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "qc" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "qd" = (
 /obj/structure/table/steel,
 /obj/random/toolbox,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "qe" = (
 /obj/structure/table/steel,
 /obj/random/advdevice,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "qf" = (
 /obj/structure/table/steel,
@@ -6494,24 +6508,24 @@
 	id_tag = "xynergy_perimeter_blast";
 	name = "perimeter blast door-control"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "qg" = (
 /obj/machinery/computer/ship/helm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "qh" = (
 /obj/machinery/computer/ship/engines{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/bridge)
 "qi" = (
 /obj/item/bedsheet/captain,
 /obj/structure/bed/padded,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/warhammer/darkwood,
 /area/errant_pisces/bridge)
 "qj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6532,6 +6546,7 @@
 /area/errant_pisces/fishing_wing)
 "qm" = (
 /obj/structure/closet/l3closet/janitor,
+/obj/random/loot/rarearmorbundle,
 /turf/simulated/floor/plating,
 /area/errant_pisces/fishing_wing)
 "qn" = (
@@ -6564,13 +6579,13 @@
 "qq" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "qr" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "qs" = (
 /obj/machinery/light/small{
@@ -6610,11 +6625,11 @@
 /area/errant_pisces/bridge)
 "qy" = (
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "qz" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/fishing_wing)
 "qA" = (
 /obj/structure/table/rack,
@@ -6830,10 +6845,10 @@
 /turf/space,
 /area/space)
 "rc" = (
-/obj/structure/net,
-/mob/living/simple_animal/hostile/carp/shark,
-/turf/space,
-/area/space)
+/obj/structure/closet/firecloset,
+/obj/random/loot/lootcontraband,
+/turf/simulated/floor/plating,
+/area/errant_pisces/bow_maint)
 "sb" = (
 /obj/structure/hygiene/sink{
 	dir = 8;
@@ -6843,7 +6858,7 @@
 /obj/item/storage/mirror{
 	pixel_x = -30
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_f)
 "si" = (
 /obj/machinery/radio_beacon,
@@ -6857,7 +6872,7 @@
 /obj/item/storage/mirror{
 	pixel_x = 30
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
 "ub" = (
 /obj/structure/hygiene/sink{
@@ -6875,21 +6890,43 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/errant_pisces/head_m)
+"JG" = (
+/obj/structure/hygiene/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/storage/mirror{
+	pixel_x = -30
+	},
+/mob/living/simple_animal/hostile/daemon/headcrab/infestor,
+/turf/simulated/floor/warhammer/ceramic/surgery2,
+/area/errant_pisces/head_f)
+"JP" = (
+/obj/structure/closet/crate,
+/obj/random/loot/swordmelee,
+/turf/simulated/floor/tiled/freezer,
+/area/errant_pisces/fishing_wing)
+"MA" = (
+/obj/structure/closet,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/errant_pisces/dorms)
 "Ph" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile{
 	dir = 4;
 	name = "Airlock"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/aft_hallway)
 "Ti" = (
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/errant_pisces/science_wing)
 
 (1,1,1) = {"
@@ -21534,7 +21571,7 @@ hq
 hq
 hQ
 iw
-iO
+hS
 hq
 jz
 jR
@@ -22953,7 +22990,7 @@ hq
 jz
 jV
 kh
-kx
+gM
 jX
 ls
 lK
@@ -23166,7 +23203,7 @@ nt
 nS
 og
 oy
-oC
+JP
 oK
 pt
 og
@@ -23369,7 +23406,7 @@ nS
 og
 oz
 oK
-oK
+hx
 pt
 og
 pV
@@ -24153,10 +24190,10 @@ dR
 fZ
 gj
 gq
-gM
+gq
 gq
 hr
-hx
+hs
 hI
 hX
 iB
@@ -24346,7 +24383,7 @@ aW
 dt
 dF
 dS
-ei
+rc
 dR
 dR
 fq
@@ -24358,7 +24395,7 @@ gr
 gN
 ha
 gj
-hx
+hs
 hI
 hW
 iA
@@ -24762,7 +24799,7 @@ gs
 gO
 hb
 gj
-hx
+hs
 hI
 hY
 ib
@@ -24802,7 +24839,7 @@ pf
 pf
 pf
 pf
-rc
+pf
 pf
 pf
 pf
@@ -25166,7 +25203,7 @@ gr
 gP
 hc
 gj
-hx
+hs
 hI
 hY
 ib
@@ -25368,7 +25405,7 @@ gj
 gj
 gj
 gj
-hx
+hs
 hI
 ia
 iC
@@ -25561,7 +25598,7 @@ dU
 el
 eK
 eZ
-sb
+JG
 sb
 eJ
 gb
@@ -25772,7 +25809,7 @@ gq
 gq
 gq
 gq
-hx
+hs
 hI
 ic
 hI
@@ -25802,7 +25839,7 @@ pf
 pf
 pf
 pf
-pZ
+pf
 pf
 pw
 aa
@@ -25999,7 +26036,7 @@ aa
 pw
 pf
 pf
-pZ
+pf
 pf
 pf
 pf
@@ -26407,7 +26444,7 @@ pf
 pf
 pf
 pf
-pZ
+pf
 pf
 pf
 pw
@@ -26604,7 +26641,7 @@ aa
 aa
 pw
 pf
-pZ
+pf
 pf
 pf
 pf
@@ -26810,7 +26847,7 @@ pf
 pf
 pf
 pf
-pZ
+pf
 pf
 pf
 pf
@@ -27212,7 +27249,7 @@ pw
 pf
 pf
 pf
-pZ
+pf
 pf
 pf
 pf
@@ -27601,7 +27638,7 @@ go
 kr
 kM
 kr
-lB
+oQ
 kr
 mq
 kH
@@ -27614,12 +27651,12 @@ aa
 aa
 pw
 pf
-pZ
 pf
 pf
 pf
 pf
-pZ
+pf
+pf
 pf
 pf
 pw
@@ -27999,7 +28036,7 @@ hO
 ii
 ii
 gU
-ij
+pZ
 jK
 go
 kr
@@ -28198,7 +28235,7 @@ hn
 gn
 gn
 gn
-ij
+pZ
 iF
 gU
 js
@@ -28400,8 +28437,8 @@ gU
 hw
 gF
 gn
-ij
-ij
+pZ
+pZ
 gU
 ii
 ii
@@ -28604,7 +28641,7 @@ hD
 gn
 ii
 ii
-il
+oa
 gU
 gU
 go
@@ -28802,7 +28839,7 @@ gH
 gX
 gU
 gF
-hw
+MA
 gn
 ik
 il
@@ -30016,7 +30053,7 @@ ho
 gY
 gJ
 gn
-io
+iI
 iJ
 iJ
 jw
@@ -30034,9 +30071,9 @@ nv
 nS
 oi
 oi
-oQ
+qc
 oS
-oS
+iO
 oS
 qd
 po
@@ -30455,7 +30492,7 @@ aa
 pw
 pf
 pf
-rc
+pf
 pf
 pf
 pf
@@ -30637,7 +30674,7 @@ kV
 mR
 nb
 nF
-oa
+nP
 oi
 oi
 oS
@@ -31037,7 +31074,7 @@ kW
 kU
 kW
 kW
-mv
+kV
 kV
 la
 nv
@@ -32058,7 +32095,7 @@ oS
 pk
 pA
 pM
-qc
+mv
 po
 pp
 pq

--- a/maps/away/lar_maria/lar_maria-1.dmm
+++ b/maps/away/lar_maria/lar_maria-1.dmm
@@ -47,7 +47,7 @@
 	dir = 4;
 	icon_state = "16-0"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "aj" = (
 /obj/structure/cable{
@@ -64,7 +64,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "al" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -76,21 +76,21 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "am" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "an" = (
 /obj/structure/closet/crate/trashcart,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "ao" = (
 /obj/structure/disposalpipe/segment,
@@ -99,7 +99,7 @@
 "ap" = (
 /obj/structure/ladder/up,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "aq" = (
 /obj/structure/cable{
@@ -112,7 +112,7 @@
 	},
 /obj/landmark/corpse/lar_maria/zhp_guard/dark,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "as" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -126,7 +126,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "at" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -144,7 +144,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -158,7 +158,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "av" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -172,7 +172,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "aw" = (
 /obj/machinery/door/airlock/virology,
@@ -188,7 +188,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "ax" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -202,17 +202,17 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "ay" = (
 /obj/machinery/smartfridge/chemistry/virology,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aA" = (
 /obj/structure/table/glass,
 /obj/item/paper,
 /obj/item/folder/white,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aB" = (
 /obj/structure/table/glass,
@@ -224,30 +224,30 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aG" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aH" = (
 /obj/structure/hygiene/sink{
 	pixel_y = 20
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aI" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aJ" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aK" = (
 /obj/structure/bed,
@@ -255,16 +255,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aL" = (
 /obj/structure/closet/warhammer/secure_closet/personal/patient,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aM" = (
 /obj/machinery/door/airlock/virology,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "aN" = (
 /turf/simulated/wall,
@@ -281,43 +281,45 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "aP" = (
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aQ" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aR" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aS" = (
-/turf/simulated/floor/tiled/white,
-/area/lar_maria/vir_main)
+/obj/structure/closet/warhammer/emcloset,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/brick,
+/area/lar_maria/vir_access)
 "aT" = (
 /obj/machinery/door/window/westleft,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "aU" = (
 /obj/structure/bed/padded,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "aV" = (
 /obj/structure/bed/padded,
 /obj/item/contraband/poster,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "aW" = (
 /obj/structure/bed/padded,
 /obj/landmark/corpse/lar_maria/test_subject,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "aX" = (
 /obj/structure/bed/padded,
@@ -325,12 +327,12 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "aY" = (
 /obj/structure/bed/padded,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "aZ" = (
 /obj/wallframe_spawn/reinforced,
@@ -339,7 +341,7 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_ld_BD"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "ba" = (
 /obj/structure/disposalpipe/trunk{
@@ -349,17 +351,17 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bb" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bc" = (
 /obj/landmark/corpse/lar_maria/test_subject,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bd" = (
 /obj/machinery/door/window/eastright,
@@ -368,13 +370,13 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_ld_BD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "be" = (
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bf" = (
 /obj/machinery/door/window/westleft,
@@ -383,29 +385,29 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_ld_BD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bg" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bh" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bi" = (
 /obj/structure/morgue,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "bj" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "bk" = (
 /obj/structure/morgue{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -415,7 +417,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "bm" = (
 /obj/structure/window/reinforced,
@@ -427,59 +429,59 @@
 	},
 /obj/landmark/corpse/lar_maria/virologist,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bn" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/door/window/northleft,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bo" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bp" = (
 /obj/landmark/corpse/lar_maria/virologist_female,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bq" = (
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "br" = (
 /obj/structure/table/glass,
 /obj/item/paper,
 /obj/item/pen/blue,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bs" = (
 /obj/structure/table/glass,
 /obj/item/paper/lar_maria/note_4,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bt" = (
 /obj/structure/table/glass,
 /obj/item/device/flashlight/pen,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bv" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bw" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "bx" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "by" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "bz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -490,7 +492,7 @@
 	},
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "bA" = (
 /obj/machinery/door/airlock/security,
@@ -506,7 +508,7 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_ld_BD"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -515,11 +517,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bC" = (
 /obj/structure/mattress/dirty,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bD" = (
 /obj/wallframe_spawn/reinforced,
@@ -528,20 +530,20 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_ld_BD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bE" = (
 /obj/structure/mattress/dirty,
 /obj/landmark/corpse/lar_maria/test_subject,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bF" = (
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bG" = (
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/plating,
+/mob/living/simple_animal/hostile/human/heretic,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "bH" = (
 /obj/structure/window/reinforced,
@@ -551,7 +553,7 @@
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -560,7 +562,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -570,86 +572,86 @@
 /obj/item/storage/box/masks,
 /obj/item/storage/box/latexgloves,
 /obj/item/reagent_containers/spray/sterilizine,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bK" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bL" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bM" = (
 /obj/structure/table/glass,
 /obj/item/paper,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bN" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bO" = (
 /obj/structure/table/glass,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bP" = (
 /obj/structure/closet/crate/warhammer/freezer,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "bQ" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "bR" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "bS" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/newspaper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "bT" = (
 /obj/machinery/light,
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "bU" = (
 /obj/structure/closet/crate/warhammer/freezer/rations,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "bV" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "bX" = (
 /obj/structure/morgue,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "bY" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "bZ" = (
 /obj/machinery/power/apc{
@@ -661,7 +663,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "ca" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -671,7 +673,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -679,15 +681,15 @@
 	},
 /obj/structure/table/glass,
 /obj/item/storage/box/bodybags,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cc" = (
 /obj/machinery/door/airlock/security,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/cells)
 "cd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "ce" = (
 /obj/machinery/door/window/westleft,
@@ -697,12 +699,12 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_ld_BD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cf" = (
 /obj/landmark/corpse/lar_maria/virologist,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "cg" = (
 /obj/structure/morgue{
@@ -713,7 +715,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "ch" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -731,7 +733,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "ci" = (
 /obj/machinery/door/airlock/virology,
@@ -741,25 +743,25 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cj" = (
 /obj/machinery/door/airlock/virology,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "ck" = (
 /obj/machinery/door/window/northright,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cl" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/item/clothing/head/surgery,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cm" = (
 /obj/structure/window/reinforced{
@@ -768,19 +770,19 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cn" = (
 /obj/machinery/door/window/northright,
 /obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "co" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cp" = (
 /obj/structure/window/reinforced{
@@ -790,15 +792,15 @@
 	dir = 1
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cq" = (
 /obj/structure/closet/fridge,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cr" = (
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/tiled/white,
+/mob/living/simple_animal/hostile/human/heretic,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cs" = (
 /obj/structure/hygiene/sink{
@@ -809,13 +811,13 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/cells)
 "ct" = (
 /obj/structure/hygiene/toilet{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/cells)
 "cu" = (
 /obj/structure/hygiene/toilet{
@@ -823,7 +825,7 @@
 	},
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/cells)
 "cv" = (
 /obj/structure/hygiene/sink{
@@ -834,18 +836,18 @@
 	dir = 4
 	},
 /obj/decal/cleanable/blood,
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/tiled/white,
+/mob/living/simple_animal/hostile/human/heretic,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/cells)
 "cw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cx" = (
 /obj/structure/mattress/dirty,
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/plating,
+/mob/living/simple_animal/hostile/human/heretic,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cy" = (
 /obj/structure/crematorium{
@@ -854,7 +856,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "cz" = (
 /obj/machinery/button/crematorium{
@@ -864,7 +866,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "cA" = (
 /obj/machinery/power/apc{
@@ -881,8 +883,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/mob/living/simple_animal/hostile/lar_maria/virologist/female,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "cB" = (
 /obj/machinery/door/airlock/virology,
@@ -898,7 +899,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "cC" = (
 /obj/structure/cable{
@@ -917,7 +918,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "cD" = (
 /obj/structure/cable{
@@ -925,35 +926,34 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/mob/living/simple_animal/hostile/lar_maria/virologist,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cF" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/surgery,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/obj/random/loot/lightmelee,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cG" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/optable,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cH" = (
-/mob/living/simple_animal/hostile/lar_maria/virologist/female,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cI" = (
 /obj/structure/table/glass,
 /obj/item/scalpel/basic,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cJ" = (
 /obj/structure/window/reinforced{
@@ -962,17 +962,17 @@
 /obj/machinery/optable,
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cK" = (
 /obj/structure/closet/fridge,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cL" = (
 /obj/structure/bed,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_main)
 "cM" = (
 /obj/machinery/light/small{
@@ -981,14 +981,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cN" = (
 /obj/machinery/door/airlock/security,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cO" = (
 /turf/simulated/wall/r_wall,
@@ -996,7 +996,7 @@
 "cP" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/deck/cards,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "cQ" = (
 /obj/machinery/light{
@@ -1005,19 +1005,20 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "cR" = (
 /obj/structure/closet/crate/warhammer/freezer/rations,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "cS" = (
 /obj/structure/closet/warhammer/emcloset,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/obj/random/loot/heavymelee,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "cT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1026,7 +1027,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1035,7 +1036,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1044,8 +1045,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/plating,
+/mob/living/simple_animal/hostile/human/heretic/trooper,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cW" = (
 /obj/machinery/light/small{
@@ -1057,7 +1058,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1071,12 +1072,12 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_ld_BD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1089,7 +1090,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "da" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1098,13 +1099,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "db" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "dc" = (
 /obj/decal/cleanable/blood,
@@ -1113,7 +1114,7 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_ld_BD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "dd" = (
 /obj/structure/sign/warning/biohazard{
@@ -1121,7 +1122,7 @@
 	},
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "de" = (
 /obj/machinery/door/firedoor,
@@ -1134,18 +1135,18 @@
 	icon_state = "pdoor0";
 	id_tag = "CellsBD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "df" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "dg" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "dh" = (
 /obj/machinery/door/airlock/virology,
@@ -1155,13 +1156,13 @@
 	icon_state = "pdoor0";
 	id_tag = "CellsBD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "di" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1176,7 +1177,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dk" = (
 /obj/structure/sign/warning/biohazard{
@@ -1191,7 +1192,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dl" = (
 /obj/structure/cable{
@@ -1204,7 +1205,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1214,7 +1215,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dn" = (
 /obj/structure/sign/warning/biohazard{
@@ -1226,7 +1227,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "do" = (
 /obj/structure/cable{
@@ -1234,7 +1235,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dp" = (
 /obj/structure/cable{
@@ -1242,11 +1243,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dq" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dr" = (
 /turf/simulated/wall/r_wall,
@@ -1256,22 +1257,22 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "du" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "dv" = (
 /obj/structure/closet/warhammer/secure_closet/personal/patient,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "dw" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "dx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1280,7 +1281,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "dy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1289,11 +1290,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "dz" = (
 /obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "dA" = (
 /obj/machinery/door/airlock/security{
@@ -1306,14 +1307,14 @@
 	icon_state = "pdoor0";
 	id_tag = "CellsBD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "dB" = (
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "dC" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "dD" = (
 /obj/machinery/door/airlock/virology,
@@ -1324,12 +1325,12 @@
 	icon_state = "pdoor0";
 	id_tag = "CellsBD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "dE" = (
 /obj/landmark/corpse/lar_maria/virologist,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1339,7 +1340,7 @@
 	dir = 5
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1349,7 +1350,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1358,23 +1359,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/lar_maria/guard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/lar_maria/vir_hallway)
+/obj/structure/closet/l3closet/virology,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/warhammer/brick,
+/area/lar_maria/vir_access)
 "dK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -1387,36 +1383,36 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dL" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "dM" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "dN" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "dO" = (
 /obj/structure/bed,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "dP" = (
 /obj/structure/bed/padded,
 /obj/item/deck/tarot,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "dQ" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "dR" = (
 /obj/structure/bed/padded,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "dS" = (
 /turf/simulated/wall,
@@ -1424,7 +1420,7 @@
 "dT" = (
 /obj/structure/bed/padded,
 /obj/item/clothing/suit/armor/riot,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "dU" = (
 /obj/structure/hygiene/toilet{
@@ -1433,8 +1429,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/mob/living/simple_animal/hostile/lar_maria/guard/ranged,
-/turf/simulated/floor/tiled/white,
+/mob/living/simple_animal/hostile/human/heretic/trooper,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/sec_wing)
 "dW" = (
 /obj/wallframe_spawn/reinforced,
@@ -1443,7 +1439,7 @@
 	icon_state = "pdoor0";
 	id_tag = "CellsBD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "dX" = (
 /turf/simulated/wall/r_wall,
@@ -1453,13 +1449,13 @@
 /area/lar_maria/vir_ward)
 "dZ" = (
 /obj/machinery/door/window/southright,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "ea" = (
 /obj/machinery/door/window/southright,
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "eb" = (
 /obj/machinery/light/small{
@@ -1467,48 +1463,48 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "ec" = (
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "ed" = (
 /obj/structure/curtain/open/bed,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "ee" = (
 /obj/machinery/door/airlock/security,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/sec_wing)
 "ef" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/shield/riot,
 /obj/item/shield/riot,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/suit/armor/riot,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eg" = (
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eh" = (
 /obj/structure/roller_bed,
 /obj/landmark/corpse/lar_maria/test_subject,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "ei" = (
 /obj/structure/roller_bed,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "ej" = (
 /obj/structure/roller_bed,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	level = 2
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "ek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1519,22 +1515,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "el" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "em" = (
 /obj/item/storage/box/freezer,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "en" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/machinery/disposal,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "eo" = (
 /obj/structure/disposalpipe/segment{
@@ -1556,7 +1552,7 @@
 /obj/structure/bed/padded,
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "er" = (
 /obj/structure/bed/padded,
@@ -1564,14 +1560,14 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "es" = (
 /obj/structure/closet/crate/warhammer/freezer/rations,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "et" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eu" = (
 /obj/structure/table/steel_reinforced,
@@ -1581,20 +1577,20 @@
 	tag_exterior_door = "ZHPcells_access_airlock_outer";
 	tag_interior_door = "ZHPcells_access_airlock_inner"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "ev" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "ew" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/landmark/corpse/lar_maria/zhp_guard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "ex" = (
 /obj/structure/table/steel_reinforced,
@@ -1626,32 +1622,32 @@
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "ey" = (
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "ez" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "eA" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "eB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "eC" = (
 /obj/machinery/light,
 /obj/machinery/smartfridge/chemistry/virology,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "eD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1661,26 +1657,26 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "eE" = (
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "eF" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "eG" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/table/glass,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "eH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1689,40 +1685,41 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/human/heretic,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "eI" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eJ" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/smokes,
-/obj/item/gun/energy/taser,
-/turf/simulated/floor/tiled,
+/obj/random/loot/sidearmbundle,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eK" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eL" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/storage/box/handcuffs,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eM" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eN" = (
 /obj/structure/closet,
 /obj/item/clothing/under/color/red,
 /obj/item/gun/projectile/shotgun/pump/voxlegis,
-/turf/simulated/floor/tiled,
+/obj/random/loot/randomcolonyitems,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eO" = (
 /obj/machinery/power/apc{
@@ -1736,7 +1733,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eP" = (
 /obj/structure/table/steel_reinforced,
@@ -1746,11 +1743,12 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "eQ" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "eR" = (
 /obj/machinery/power/apc{
@@ -1761,7 +1759,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "eS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1775,7 +1773,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "eT" = (
 /obj/machinery/door/firedoor,
@@ -1794,7 +1792,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "eU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1813,78 +1811,82 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "eV" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "eX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/warning/biohazard{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "eY" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/freezer,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "eZ" = (
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "fa" = (
-/mob/living/simple_animal/hostile/lar_maria/virologist,
-/turf/simulated/floor/tiled/white,
-/area/lar_maria/vir_aux)
+/obj/structure/table/rack/dark,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/random/loot/basicarmorbundle,
+/turf/simulated/floor/warhammer/brick,
+/area/lar_maria/sec_wing)
 "fb" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
 /obj/item/storage/box/pillbottles,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "fc" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "fd" = (
 /obj/machinery/light,
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/human/heretic,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "fe" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/random/loot/lootcontraband,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "ff" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/spray/pepper,
 /obj/item/deck/cards,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fg" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/item/melee/baton,
 /obj/item/melee/baton,
 /obj/item/melee/baton,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fh" = (
-/obj/structure/table/rack,
-/obj/item/clothing/head/helmet/ballistic,
-/turf/simulated/floor/tiled,
+/obj/structure/table/rack/dark,
+/obj/random/loot/rarearmorbundle,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fi" = (
 /obj/structure/closet,
@@ -1894,7 +1896,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1906,7 +1908,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fk" = (
 /obj/structure/table/steel_reinforced,
@@ -1919,7 +1921,7 @@
 	tag_exterior_door = "ZHPsec__access_airlock_outer";
 	tag_interior_door = "ZHPsec__access_airlock_inner"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fl" = (
 /obj/structure/table/steel_reinforced,
@@ -1927,24 +1929,24 @@
 	id_tag = "Tech_access_BD";
 	name = "Communications Access"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fm" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fn" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/handcuffs,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fo" = (
 /obj/structure/roller_bed,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_ward)
 "fp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1958,7 +1960,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "fq" = (
 /obj/machinery/power/apc{
@@ -1972,23 +1974,23 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "fr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/glass,
 /obj/item/storage/box/masks,
 /obj/item/storage/box/latexgloves,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "fs" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/autoinjectors,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "ft" = (
 /obj/machinery/chem_master,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "fu" = (
 /obj/structure/closet/crate/warhammer/freezer/rations,
@@ -2002,24 +2004,25 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "fv" = (
-/obj/structure/table/rack,
-/obj/item/flamethrower/full,
+/obj/structure/table/rack/dark,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/obj/item/flamethrower/full/loaded,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fw" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/glowsticks,
+/obj/structure/table/rack/dark,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/obj/random/loot/lasbundle,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fx" = (
 /obj/structure/closet,
 /obj/item/clothing/under/color/red,
-/turf/simulated/floor/tiled,
+/obj/random/loot/randomcolonyitems,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fy" = (
 /obj/machinery/door/airlock/security,
@@ -2031,7 +2034,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2054,7 +2057,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "fA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2068,7 +2071,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2084,7 +2087,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "fD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2101,7 +2104,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "fE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2111,17 +2114,17 @@
 	dir = 1
 	},
 /obj/machinery/door/window/eastright,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "fG" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "fH" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/tiled/white,
+/mob/living/simple_animal/hostile/human/heretic,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/cells)
 "fI" = (
 /obj/structure/hygiene/sink{
@@ -2131,7 +2134,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/cells)
 "fJ" = (
 /obj/machinery/light/small{
@@ -2143,7 +2146,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "fK" = (
 /obj/landmark/corpse/lar_maria/test_subject,
@@ -2157,7 +2160,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "fL" = (
 /obj/machinery/door/blast/regular{
@@ -2181,7 +2184,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2201,7 +2204,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2215,7 +2218,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2234,7 +2237,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fP" = (
 /obj/structure/reagent_dispensers/peppertank{
@@ -2249,7 +2252,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fQ" = (
 /obj/structure/reagent_dispensers/peppertank{
@@ -2264,7 +2267,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fR" = (
 /obj/machinery/door/airlock/security,
@@ -2280,7 +2283,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -2300,7 +2303,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fT" = (
 /obj/machinery/light{
@@ -2321,7 +2324,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2336,7 +2339,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2353,7 +2356,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fW" = (
 /obj/structure/sign/warning/biohazard{
@@ -2370,7 +2373,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fX" = (
 /obj/machinery/door/airlock/virology{
@@ -2394,7 +2397,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fY" = (
 /obj/machinery/light/small{
@@ -2411,7 +2414,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "fZ" = (
 /obj/machinery/door/airlock/virology{
@@ -2435,7 +2438,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "ga" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2454,13 +2457,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "gb" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "gc" = (
 /obj/structure/window/reinforced{
@@ -2472,28 +2475,28 @@
 /obj/structure/hygiene/shower{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "gd" = (
-/mob/living/simple_animal/hostile/lar_maria/virologist/female,
-/turf/simulated/floor/tiled/white,
-/area/lar_maria/vir_aux)
+/obj/structure/closet/l3closet/security,
+/turf/simulated/floor/warhammer/plating,
+/area/lar_maria/sec_wing)
 "ge" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_aux)
 "gf" = (
 /obj/structure/closet/crate,
 /obj/item/folder/white,
 /obj/item/material/knife/folding,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "gg" = (
 /obj/structure/closet,
 /obj/item/clothing/under/color/orange,
 /obj/item/clothing/under/color/orange,
 /obj/item/clothing/shoes/orange,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2508,11 +2511,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "gi" = (
 /obj/machinery/door/airlock/security,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "gj" = (
 /obj/structure/bed/chair{
@@ -2520,18 +2523,18 @@
 	},
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "gk" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/dice/d12,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "gl" = (
 /obj/structure/closet,
 /obj/item/clothing/under/color/orange,
 /obj/item/clothing/shoes/orange,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "gm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2541,36 +2544,36 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "gn" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "go" = (
 /obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gp" = (
 /obj/machinery/vending/cola,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gq" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/vending/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gr" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gs" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "gt" = (
 /obj/structure/closet/crate/radiation,
@@ -2578,14 +2581,14 @@
 /obj/item/stack/material/tritium/ten,
 /obj/item/wirecutters,
 /obj/item/wrench,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "gu" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "gv" = (
 /obj/machinery/power/apc{
@@ -2596,11 +2599,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "gx" = (
-/mob/living/simple_animal/hostile/lar_maria/guard/ranged,
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/human/heretic/trooper,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gy" = (
 /obj/machinery/light{
@@ -2615,14 +2618,14 @@
 	tag_exterior_sensor = "ZHPvirology_access_airlock_sensor";
 	tag_interior_door = "ZHPvirology_access_airlock_inner"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gz" = (
 /turf/simulated/wall/r_wall,
 /area/lar_maria/vir_access)
 "gA" = (
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/human/heretic,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "gB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2632,13 +2635,13 @@
 	dir = 9
 	},
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "gC" = (
 /obj/structure/closet/crate,
 /obj/item/contraband/poster,
 /obj/item/inflatable_duck,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "gD" = (
 /obj/machinery/light{
@@ -2652,28 +2655,28 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "gE" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gF" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gG" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gH" = (
 /obj/machinery/power/smes/buildable,
 /obj/structure/cable,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "gI" = (
 /obj/structure/cable/yellow{
@@ -2684,7 +2687,7 @@
 	dir = 8
 	},
 /obj/landmark/corpse/lar_maria/zhp_guard,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "gJ" = (
 /obj/machinery/power/port_gen/pacman/mrs,
@@ -2692,19 +2695,20 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "gK" = (
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "gL" = (
 /obj/machinery/suit_storage_unit/security,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "gM" = (
 /obj/structure/closet/l3closet/security,
-/turf/simulated/floor/plating,
+/obj/random/loot/randomsupply/tech,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2713,7 +2717,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "gO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2727,7 +2731,7 @@
 	master_tag = "ZHPvirology_access_airlock";
 	pixel_y = -25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_hallway)
 "gP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2745,7 +2749,7 @@
 	frequency = 1039;
 	id_tag = "ZHPvirology_access_airlock_outer"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2754,7 +2758,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gR" = (
 /obj/decal/cleanable/blood,
@@ -2764,21 +2768,21 @@
 	master_tag = "ZHPvirology_access_airlock";
 	pixel_x = 25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gS" = (
 /obj/structure/bed/padded,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "gT" = (
 /obj/structure/bed/padded,
 /obj/item/newspaper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/cells)
 "gU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "gV" = (
 /obj/structure/closet,
@@ -2786,18 +2790,18 @@
 /obj/item/clothing/under/color/orange,
 /obj/item/clothing/shoes/orange,
 /obj/item/clothing/shoes/orange,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "gW" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gX" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gY" = (
 /obj/machinery/door/airlock/virology{
@@ -2806,21 +2810,21 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "gZ" = (
 /obj/machinery/door/airlock/virology{
 	frequency = 1039;
 	id_tag = "ZHPvirology_access_airlock_outer"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "ha" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "hb" = (
 /obj/structure/bed/chair{
@@ -2830,41 +2834,41 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/plating,
+/mob/living/simple_animal/hostile/human/heretic/trooper,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "hc" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "hd" = (
 /obj/structure/stairs/south,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "he" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hf" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hg" = (
 /obj/structure/closet,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hh" = (
 /obj/structure/closet,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hi" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/towel,
 /obj/random/soap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hj" = (
 /turf/simulated/wall,
@@ -2873,30 +2877,31 @@
 /obj/structure/hygiene/shower,
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "hl" = (
 /obj/structure/hygiene/shower,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "hm" = (
 /obj/structure/hygiene/shower,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "hn" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "ho" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hp" = (
 /obj/structure/closet/l3closet/virology,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hq" = (
 /obj/structure/sign/warning/biohazard{
@@ -2904,7 +2909,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hr" = (
 /obj/structure/sign/warning/biohazard{
@@ -2916,7 +2921,7 @@
 	pixel_x = 25;
 	pixel_y = 15
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hs" = (
 /obj/machinery/door/airlock/security,
@@ -2932,11 +2937,11 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_dock_BD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "ht" = (
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hu" = (
 /obj/machinery/power/apc{
@@ -2948,34 +2953,34 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hx" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "hy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hA" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/material/ashtray/plastic,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "hB" = (
 /obj/wallframe_spawn/reinforced,
@@ -2985,19 +2990,19 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_dock_BD"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "hC" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "hD" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/taser,
-/turf/simulated/floor/tiled,
+/obj/structure/table/rack/dark,
+/obj/random/loot/raresidearmbundle,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "hE" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/structure/sign/warning/smoking{
 	pixel_x = -30
 	},
@@ -3006,7 +3011,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hF" = (
 /obj/structure/bed/chair{
@@ -3015,7 +3020,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hG" = (
 /obj/structure/cable{
@@ -3023,7 +3028,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hH" = (
 /obj/machinery/door/airlock/virology,
@@ -3033,13 +3038,13 @@
 	icon_state = "pdoor0";
 	id_tag = "VirAccessBD"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3052,7 +3057,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hK" = (
 /obj/machinery/light,
@@ -3062,7 +3067,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3071,7 +3076,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hM" = (
 /obj/machinery/door/airlock/virology,
@@ -3081,7 +3086,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3091,7 +3096,7 @@
 	dir = 4
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "hO" = (
 /obj/machinery/light/small,
@@ -3101,7 +3106,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "hP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3112,14 +3117,14 @@
 	},
 /obj/landmark/corpse/lar_maria/zhp_guard/dark,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "hQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hR" = (
 /obj/machinery/light,
@@ -3127,7 +3132,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3140,7 +3145,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hT" = (
 /obj/machinery/door/airlock/virology,
@@ -3155,7 +3160,7 @@
 	icon_state = "pdoor0";
 	id_tag = "VirAccessBD"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3164,7 +3169,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hV" = (
 /obj/structure/hygiene/shower{
@@ -3175,31 +3180,33 @@
 	},
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "hW" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/contraband/poster,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "hX" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/obj/random/loot/basicarmorbundle,
+/obj/random/loot/armorinsertsrare,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "hY" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/item/paper/lar_maria/note_7,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "hZ" = (
 /obj/structure/bed/chair{
@@ -3209,7 +3216,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "ia" = (
 /obj/machinery/light{
@@ -3221,22 +3228,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "ib" = (
 /obj/item/paper/lar_maria/note_8,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "ic" = (
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "id" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "ie" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3250,7 +3257,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "if" = (
 /obj/machinery/door/airlock/security,
@@ -3271,7 +3278,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3285,7 +3292,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "ih" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3299,7 +3306,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "ii" = (
 /obj/structure/cable{
@@ -3307,7 +3314,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "ij" = (
 /obj/structure/cable{
@@ -3315,13 +3322,13 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "ik" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "il" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3333,7 +3340,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "im" = (
 /obj/machinery/light{
@@ -3345,7 +3352,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "in" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3354,7 +3361,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "io" = (
 /obj/machinery/light/small{
@@ -3366,7 +3373,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "ip" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3375,7 +3382,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "iq" = (
 /obj/machinery/light{
@@ -3387,7 +3394,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "ir" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3399,7 +3406,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "is" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3409,7 +3416,7 @@
 	dir = 4
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "it" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3418,12 +3425,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "iu" = (
 /obj/machinery/door/airlock/security,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "iv" = (
 /obj/wallframe_spawn/reinforced,
@@ -3433,15 +3440,15 @@
 	icon_state = "pdoor0";
 	id_tag = "VirAccessBD"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "iw" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "ix" = (
 /obj/decal/cleanable/blood,
-/mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/tiled/white,
+/mob/living/simple_animal/hostile/human/heretic,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "iy" = (
 /obj/structure/hygiene/shower{
@@ -3450,17 +3457,17 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "iz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "iA" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/material/ashtray/plastic,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "iB" = (
 /obj/structure/table/steel_reinforced,
@@ -3476,7 +3483,7 @@
 	name = "Cells Dock Lockdown";
 	pixel_y = 7
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "iC" = (
 /obj/structure/table/steel_reinforced,
@@ -3484,7 +3491,7 @@
 	id_tag = "VirAccessBD";
 	name = "Virology Access Lockdown"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "iD" = (
 /obj/machinery/light{
@@ -3493,7 +3500,7 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/item/gun/energy/taser,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "iE" = (
 /obj/structure/closet,
@@ -3501,20 +3508,20 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "iF" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "iG" = (
 /obj/structure/hygiene/shower{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "iH" = (
 /obj/structure/hygiene/shower{
@@ -3522,7 +3529,7 @@
 	},
 /obj/landmark/corpse/lar_maria/virologist,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/vir_access)
 "iI" = (
 /obj/structure/closet/l3closet/virology,
@@ -3530,33 +3537,31 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "iJ" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/vir_access)
 "iK" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /obj/item/gun/energy/taser,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "iL" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/sec_wing)
 "iM" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/lar_maria/guard,
-/turf/simulated/floor/tiled,
-/area/lar_maria/sec_wing)
+/obj/structure/closet/crate/warhammer/freezer,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/lar_maria/vir_main)
 "iN" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1439;
@@ -3569,14 +3574,14 @@
 	icon_state = "pdoor0";
 	id_tag = "Cells_dock_BD"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "iO" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	id_tag = "ZHPCells_airlock_pump"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "iP" = (
 /obj/machinery/door/airlock/external{
@@ -3584,7 +3589,7 @@
 	id_tag = "ZHPCells_airlock_outer"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/cells)
 "iQ" = (
 /obj/shuttle_landmark/automatic,
@@ -3594,7 +3599,7 @@
 /obj/machinery/atmospherics/valve/shutoff/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "kb" = (
 /obj/structure/cable{
@@ -3605,7 +3610,7 @@
 /obj/machinery/atmospherics/valve/shutoff/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/morgue)
 "lb" = (
 /obj/structure/hygiene/sink{
@@ -3615,7 +3620,7 @@
 /obj/item/storage/mirror{
 	pixel_x = 25
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/sec_wing)
 "ts" = (
 /obj/machinery/door/airlock/security,
@@ -3624,7 +3629,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
 "FB" = (
 /obj/structure/cable{
@@ -3632,8 +3637,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/sec_wing)
+"Yy" = (
+/obj/structure/closet/warhammer/secure_closet/personal/patient,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/lar_maria/vir_main)
 
 (1,1,1) = {"
 aa
@@ -23728,7 +23738,7 @@ cO
 dR
 ed
 et
-ef
+fa
 fg
 fv
 fP
@@ -23743,7 +23753,7 @@ hZ
 ih
 iv
 hC
-iM
+ev
 cO
 cO
 aa
@@ -26562,7 +26572,7 @@ cO
 fX
 cO
 gu
-gM
+gd
 cO
 hj
 hj
@@ -26745,7 +26755,7 @@ aa
 aa
 ag
 ag
-aS
+cH
 aR
 bo
 bJ
@@ -26764,7 +26774,7 @@ cO
 fY
 cO
 dC
-gM
+gd
 cO
 hn
 hy
@@ -26948,15 +26958,15 @@ aa
 ag
 ag
 aA
-aS
+cH
 bp
-aS
-aS
+cH
+cH
 ck
-aS
+cH
 ag
 do
-dJ
+dH
 dY
 dY
 dY
@@ -27150,10 +27160,10 @@ aa
 ag
 ag
 aB
-aS
+cH
 bq
 bK
-aS
+cH
 cl
 cF
 ag
@@ -27176,7 +27186,7 @@ hS
 hj
 ir
 gW
-hp
+dJ
 gz
 gz
 aa
@@ -27351,8 +27361,8 @@ aa
 aa
 ag
 ag
-aS
-aS
+cH
+cH
 br
 bL
 aR
@@ -27553,11 +27563,11 @@ aa
 aa
 ag
 ag
-aS
-aS
+cH
+cH
 bq
 bM
-aS
+cH
 cn
 cH
 ag
@@ -27755,11 +27765,11 @@ aa
 aa
 ag
 ag
-aS
-aS
+cH
+cH
 bs
 bN
-aS
+cH
 co
 cI
 ag
@@ -27957,11 +27967,11 @@ aa
 aa
 ag
 ag
-aS
-aS
+cH
+cH
 bq
 bO
-aS
+cH
 cp
 cJ
 ag
@@ -27983,7 +27993,7 @@ gW
 gG
 ib
 gX
-gn
+aS
 gz
 gz
 gz
@@ -28160,10 +28170,10 @@ aa
 ag
 ag
 aG
-aS
+cH
 bt
 bL
-aS
+cH
 cq
 cK
 ag
@@ -28363,11 +28373,11 @@ ag
 ag
 aH
 aR
-aS
-aS
-aS
-aS
-aS
+cH
+cH
+cH
+cH
+cH
 ag
 fG
 fG
@@ -28564,12 +28574,12 @@ ab
 ah
 ah
 aI
-aS
+cH
 bP
+iM
 bP
-bP
-aS
-aS
+cH
+cH
 ag
 dv
 dM
@@ -28579,7 +28589,7 @@ fG
 fG
 fG
 fG
-gd
+fG
 dr
 dr
 aa
@@ -28968,11 +28978,11 @@ aa
 ag
 ag
 aK
-aS
+cH
 bv
 aJ
 bv
-aS
+cH
 cL
 ag
 dw
@@ -28980,7 +28990,7 @@ dN
 ea
 dN
 dN
-fa
+fG
 fG
 fG
 ge
@@ -29170,10 +29180,10 @@ aa
 ag
 ag
 aL
-aS
+cH
 aL
 aJ
-aL
+Yy
 cr
 aL
 ag

--- a/maps/away/lar_maria/lar_maria-2.dmm
+++ b/maps/away/lar_maria/lar_maria-2.dmm
@@ -169,16 +169,16 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "au" = (
 /obj/machinery/power/port_gen/pacman/mrs,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aw" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "ax" = (
 /obj/structure/closet/crate/radiation,
@@ -186,7 +186,7 @@
 /obj/item/stack/cable_coil/orange,
 /obj/item/wrench,
 /obj/item/wirecutters,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "az" = (
 /obj/machinery/power/solar_control/autostart{
@@ -196,7 +196,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aA" = (
 /obj/floor_decal/solarpanel,
@@ -271,7 +271,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aG" = (
 /obj/structure/cable/yellow{
@@ -296,7 +296,7 @@
 	tag_exterior_door = "ZHP_west_solar_exterior_door";
 	tag_interior_door = "ZHP_west_solar_interior_door"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aH" = (
 /obj/machinery/door/firedoor,
@@ -312,7 +312,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aI" = (
 /obj/structure/cable/yellow{
@@ -337,10 +337,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aJ" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aK" = (
 /obj/structure/cable/yellow{
@@ -365,7 +365,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aL" = (
 /obj/machinery/door/firedoor,
@@ -382,7 +382,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aM" = (
 /obj/structure/cable/yellow{
@@ -408,7 +408,7 @@
 	master_tag = "ZHPWestSolar";
 	pixel_y = 25
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aN" = (
 /obj/machinery/door/firedoor,
@@ -422,7 +422,7 @@
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aO" = (
 /obj/structure/cable/yellow{
@@ -549,7 +549,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aY" = (
 /obj/structure/cable{
@@ -557,7 +557,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "aZ" = (
 /obj/structure/cable{
@@ -565,11 +565,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "ba" = (
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bb" = (
 /obj/structure/cable{
@@ -578,7 +578,7 @@
 	icon_state = "2-4"
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bc" = (
 /obj/machinery/power/smes/buildable,
@@ -586,7 +586,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bd" = (
 /obj/floor_decal/solarpanel,
@@ -620,7 +620,7 @@
 /area/space)
 "bg" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -631,7 +631,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -640,7 +640,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -649,7 +649,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bl" = (
 /obj/structure/cable/yellow{
@@ -666,20 +666,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bp" = (
 /obj/landmark/corpse/lar_maria/zhp_guard,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "br" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bs" = (
 /obj/structure/cable{
@@ -688,17 +688,17 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bt" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bu" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/random/toolbox,
 /obj/random/material,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -719,7 +719,7 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -735,7 +735,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -747,7 +747,7 @@
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bB" = (
 /obj/machinery/power/apc{
@@ -761,13 +761,13 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bC" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/random/toolbox,
 /obj/random/smokes,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "bD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -785,24 +785,24 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/engineering,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bH" = (
 /obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "bI" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "bJ" = (
 /obj/machinery/atmospherics/unary/tank/nitrogen{
@@ -811,19 +811,19 @@
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bM" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bN" = (
 /obj/machinery/portable_atmospherics/powered/pump,
@@ -831,7 +831,7 @@
 	dir = 10;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bO" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -839,7 +839,7 @@
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -848,36 +848,37 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bR" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/random/tool,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bS" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/random/tank,
 /obj/random/tool,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
 	},
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/plating,
+/obj/random/loot/tech1,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "bV" = (
 /turf/simulated/floor/wood,
@@ -916,36 +917,36 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cd" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "ce" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cf" = (
 /obj/landmark/corpse/lar_maria/virologist,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cg" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "ch" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/red,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "ci" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -957,29 +958,29 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "ck" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cm" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cn" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "co" = (
 /turf/simulated/wall,
@@ -996,60 +997,60 @@
 "cr" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/engineering_guide,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cs" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/stasis,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "ct" = (
 /obj/structure/bookcase,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cu" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/medical_diagnostics_manual,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cv" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/detective,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cw" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/medical_cloning,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cx" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/hydroponics_pod_people,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cy" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/anomaly_spectroscopy,
 /obj/item/book/manual/anomaly_testing,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cA" = (
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cC" = (
 /obj/machinery/atmospherics/valve/open,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cD" = (
 /obj/structure/table/woodentable,
@@ -1086,9 +1087,9 @@
 /obj/structure/window/basic{
 	dir = 1
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cK" = (
 /obj/structure/window/basic{
@@ -1100,16 +1101,16 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cL" = (
 /obj/structure/window/basic{
 	dir = 1
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper_bin,
 /obj/item/pen/red,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cM" = (
 /obj/structure/window/basic{
@@ -1121,15 +1122,15 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cN" = (
 /obj/structure/window/basic{
 	dir = 1
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cO" = (
 /obj/structure/window/basic{
@@ -1138,9 +1139,9 @@
 /obj/structure/window/basic{
 	dir = 8
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper/lar_maria/note_2,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cP" = (
 /obj/structure/window/basic{
@@ -1149,24 +1150,24 @@
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "cQ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cR" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1177,32 +1178,32 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cX" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "cY" = (
 /obj/structure/bed/chair/comfy/purple{
@@ -1226,7 +1227,8 @@
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
 "dc" = (
-/mob/living/simple_animal/hostile/lar_maria/guard/ranged,
+/obj/random/closet,
+/obj/random/loot/gunbundle,
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
 "dd" = (
@@ -1256,20 +1258,20 @@
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "di" = (
 /obj/structure/window/basic{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "dj" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4;
 	icon_state = "officechair_white_preview"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "dk" = (
 /obj/machinery/light{
@@ -1279,7 +1281,7 @@
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "dl" = (
 /obj/machinery/atmospherics/unary/tank/oxygen{
@@ -1288,38 +1290,39 @@
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dm" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dn" = (
 /obj/machinery/atmospherics/omni/mixer{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "do" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dp" = (
 /obj/machinery/atmospherics/omni/filter{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "ds" = (
-/mob/living/simple_animal/hostile/lar_maria/virologist,
+/obj/random/closet,
+/obj/random/loot/sidearmbundle,
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
 "dt" = (
@@ -1351,62 +1354,62 @@
 /obj/structure/window/basic{
 	dir = 8
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/folder/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "dz" = (
 /obj/structure/window/basic,
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper_bin,
 /obj/item/pen/blue,
 /obj/item/paper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "dA" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dD" = (
 /obj/machinery/atmospherics/binary/oxyregenerator,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dF" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/floor_decal/industrial/warning{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dG" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dH" = (
 /obj/machinery/portable_atmospherics/canister/hydrogen,
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dI" = (
 /obj/machinery/light{
@@ -1421,20 +1424,20 @@
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "dK" = (
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "dL" = (
 /obj/machinery/photocopier,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "dM" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/photocopier/faxmachine,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm{
@@ -1442,18 +1445,18 @@
 	pixel_x = 25;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "dN" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 5
 	},
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -1463,7 +1466,7 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -1480,7 +1483,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -1492,7 +1495,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dS" = (
 /obj/machinery/power/apc{
@@ -1504,21 +1507,21 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dV" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dW" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "dX" = (
 /obj/structure/bed/padded,
@@ -1537,9 +1540,9 @@
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
 "ea" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "eb" = (
 /obj/structure/window/basic{
@@ -1548,18 +1551,18 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "ec" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/pen/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "ed" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/pen/crayon/orange,
 /obj/item/paper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "ee" = (
 /obj/structure/window/basic{
@@ -1569,16 +1572,16 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "ef" = (
 /obj/structure/closet/crate/paper_refill,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "eg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "eh" = (
 /obj/machinery/power/apc{
@@ -1591,7 +1594,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "ei" = (
 /obj/structure/bed/chair/comfy/beige,
@@ -1640,7 +1643,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "et" = (
 /obj/machinery/door/firedoor,
@@ -1651,25 +1654,21 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/library)
 "eu" = (
 /turf/simulated/wall,
 /area/lar_maria/office)
-"ev" = (
-/mob/living/simple_animal/hostile/lar_maria/virologist,
-/turf/simulated/floor/tiled/white,
-/area/lar_maria/office)
 "ew" = (
 /obj/machinery/optable,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/office)
 "ex" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "ey" = (
 /obj/structure/bed/padded,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "ez" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1680,34 +1679,34 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eB" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eC" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
 /obj/item/pen/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eD" = (
 /obj/structure/bed/chair/office/light,
 /obj/landmark/corpse/lar_maria/virologist_female,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eE" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eF" = (
 /obj/structure/table/woodentable,
@@ -1731,22 +1730,18 @@
 	dir = 1
 	},
 /obj/random/trash,
-/mob/living/simple_animal/hostile/lar_maria/virologist,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "eJ" = (
-/obj/structure/hygiene/toilet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/random/trash,
-/turf/simulated/floor/tiled/white,
-/area/lar_maria/head_m)
+/obj/random/closet,
+/obj/random/loot/valuableloot,
+/turf/simulated/floor/wood,
+/area/lar_maria/dorms)
 "eK" = (
 /obj/structure/hygiene/urinal{
 	pixel_x = -30
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "eL" = (
 /obj/machinery/light{
@@ -1755,11 +1750,11 @@
 /obj/random/trash,
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "eO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1768,19 +1763,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "eP" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/office)
 "eQ" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/office)
 "eR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1789,71 +1784,71 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eT" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eU" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eV" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eW" = (
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "eX" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "eY" = (
 /obj/structure/hygiene/urinal{
 	pixel_x = -30
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "eZ" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fb" = (
 /obj/machinery/door/airlock/medical,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/office)
 "fc" = (
 /obj/machinery/door/airlock/medical,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fe" = (
 /obj/machinery/door/window/southleft,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "ff" = (
 /obj/structure/window/basic,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fg" = (
 /obj/structure/window/basic,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fh" = (
 /obj/machinery/door/firedoor,
@@ -1872,11 +1867,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fk" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fl" = (
 /obj/machinery/power/apc{
@@ -1889,7 +1884,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fm" = (
 /obj/structure/closet,
@@ -1899,7 +1894,7 @@
 /obj/item/clothing/suit/armor/grim/toggle/labcoat,
 /obj/item/clothing/suit/armor/grim/toggle/labcoat,
 /obj/random/gloves,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fn" = (
 /obj/machinery/light{
@@ -1908,40 +1903,40 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fo" = (
 /obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fp" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/folder/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fq" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/steel,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fr" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/towel,
 /obj/random/soap,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fs" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "ft" = (
 /obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1955,7 +1950,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fw" = (
 /obj/machinery/door/airlock,
@@ -1972,7 +1967,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1986,7 +1981,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "fy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2002,7 +1997,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "fz" = (
 /obj/machinery/light{
@@ -2011,30 +2006,30 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fA" = (
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fB" = (
 /obj/structure/bed/chair/office/light,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fD" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/pen/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fE" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/obj/structure/table/steel,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fF" = (
 /obj/structure/table/woodentable,
@@ -2066,32 +2061,28 @@
 "fK" = (
 /obj/machinery/door/airlock,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "fL" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "fM" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/random/gloves,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fN" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
-/area/lar_maria/office)
-"fO" = (
-/obj/structure/table/steel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fP" = (
 /obj/structure/table/steel,
 /obj/random/firstaid,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2105,7 +2096,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fR" = (
 /obj/machinery/power/apc{
@@ -2118,18 +2109,18 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fS" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper_bin,
 /obj/item/paper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fT" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper/lar_maria/note_9,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "fU" = (
 /obj/machinery/vending/engivend{
@@ -2137,16 +2128,8 @@
 	},
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
-"fV" = (
-/mob/living/simple_animal/hostile/lar_maria/guard,
-/turf/simulated/floor/wood,
-/area/lar_maria/dorms)
 "fW" = (
 /obj/structure/bookcase,
-/turf/simulated/floor/wood,
-/area/lar_maria/dorms)
-"fX" = (
-/mob/living/simple_animal/hostile/lar_maria/virologist/female,
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
 "fY" = (
@@ -2159,23 +2142,23 @@
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "ga" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "gb" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "gc" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "gd" = (
 /obj/structure/hygiene/toilet{
@@ -2185,7 +2168,7 @@
 	dir = 4
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "ge" = (
 /turf/simulated/wall,
@@ -2198,19 +2181,19 @@
 	icon_state = "1-2"
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "gg" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/random/firstaid,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "gh" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "gi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2222,23 +2205,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "gj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "gk" = (
 /obj/machinery/door/airlock/glass,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "gl" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "gm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -2270,15 +2253,15 @@
 /obj/random/trash,
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "gq" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/towel,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "gr" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "gs" = (
 /obj/machinery/door/airlock,
@@ -2289,13 +2272,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "gt" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "gu" = (
 /turf/simulated/wall,
@@ -2322,23 +2305,23 @@
 /area/lar_maria/mess_hall)
 "gy" = (
 /obj/structure/closet/athletic_mixed,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "gz" = (
 /turf/simulated/wall,
 /area/lar_maria/hallway)
 "gA" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "gB" = (
 /obj/structure/closet/l3closet/janitor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "gC" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "gD" = (
 /turf/simulated/open,
@@ -2352,7 +2335,7 @@
 	dir = 8
 	},
 /obj/item/stool,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "gF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2363,13 +2346,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "gG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "gH" = (
 /obj/structure/window/basic{
@@ -2383,27 +2366,27 @@
 	dir = 8
 	},
 /obj/item/stool,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "gI" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gJ" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gK" = (
 /obj/machinery/vending/games,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2412,68 +2395,68 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gN" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gO" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/obj/structure/table/steel,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gP" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gQ" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gR" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/trash/plate,
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gS" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gT" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "gU" = (
 /obj/machinery/door/window/westright,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "gV" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "gW" = (
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = 25
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "gX" = (
 /obj/machinery/alarm{
 	pixel_y = 23;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "gY" = (
 /obj/machinery/door/airlock/freezer,
@@ -2491,11 +2474,11 @@
 /area/lar_maria/mess_hall)
 "hb" = (
 /obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "hc" = (
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "hd" = (
 /obj/structure/bed/chair{
@@ -2504,7 +2487,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "he" = (
 /obj/machinery/light{
@@ -2517,14 +2500,14 @@
 	dir = 8
 	},
 /obj/item/stool,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hg" = (
 /obj/structure/window/basic{
 	dir = 4
 	},
 /obj/item/stool,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hh" = (
 /obj/machinery/light{
@@ -2544,26 +2527,26 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "hj" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "hk" = (
 /obj/structure/table/marble,
 /obj/machinery/door/firedoor,
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "hl" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "hm" = (
 /obj/machinery/cooker/grill,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "hn" = (
 /obj/structure/closet/fridge/meat,
@@ -2582,38 +2565,37 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/mob/living/simple_animal/hostile/lar_maria/virologist/female,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "hr" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/random/soap,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm{
 	pixel_y = 23;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "hs" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/towel,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "ht" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "hu" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "hv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "hw" = (
 /obj/structure/cable{
@@ -2630,7 +2612,7 @@
 	pixel_x = -24;
 	req_access = list()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hx" = (
 /obj/structure/cable{
@@ -2638,7 +2620,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2657,7 +2639,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2670,7 +2652,7 @@
 	},
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2682,7 +2664,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2696,7 +2678,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hC" = (
 /obj/machinery/door/firedoor,
@@ -2708,7 +2690,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "hD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -2722,7 +2704,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "hE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2733,7 +2715,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "hF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2745,7 +2727,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "hG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2756,21 +2738,21 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "hH" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "hI" = (
 /obj/structure/table/marble,
 /obj/machinery/door/firedoor,
 /obj/item/material/kitchen/rollingpin,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "hJ" = (
 /obj/machinery/cooker/fryer,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "hK" = (
 /obj/structure/closet/fridge/meat,
@@ -2792,40 +2774,40 @@
 	dir = 4
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "hO" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/towel,
 /obj/random/soap,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "hP" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "hQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "hR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "hS" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "hT" = (
 /obj/landmark/corpse/lar_maria/zhp_guard/dark,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hU" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hV" = (
 /obj/structure/cable{
@@ -2836,7 +2818,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2844,13 +2826,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "hY" = (
 /obj/machinery/door/firedoor,
@@ -2860,44 +2842,44 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "hZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "ia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "ib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "ic" = (
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "id" = (
 /obj/structure/table/marble,
 /obj/machinery/door/firedoor,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/storage/fancy/egg_box/full,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "ie" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "if" = (
 /obj/machinery/cooker/oven,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "ig" = (
 /obj/structure/closet/fridge,
@@ -2918,15 +2900,15 @@
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "ik" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "il" = (
 /obj/structure/closet/athletic_mixed,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "in" = (
 /obj/machinery/power/apc{
@@ -2940,7 +2922,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "io" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2949,7 +2931,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "ip" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2965,7 +2947,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2976,7 +2958,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "ir" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2991,7 +2973,7 @@
 	pixel_y = 23;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "is" = (
 /obj/machinery/light{
@@ -3005,7 +2987,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "it" = (
 /obj/machinery/door/firedoor,
@@ -3017,7 +2999,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iu" = (
 /obj/structure/cable{
@@ -3028,7 +3010,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iv" = (
 /obj/structure/cable{
@@ -3040,17 +3022,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/obj/random/loot/rigloot,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iw" = (
 /obj/item/paper/lar_maria/note_6,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "ix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "iy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3058,7 +3041,7 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "iz" = (
 /obj/structure/bed/chair{
@@ -3066,33 +3049,33 @@
 	},
 /obj/landmark/corpse/lar_maria/virologist,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "iA" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper/lar_maria/note_3,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "iB" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "iC" = (
 /obj/structure/table/marble,
 /obj/machinery/door/firedoor,
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "iD" = (
 /obj/landmark/corpse/lar_maria/virologist_female,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "iE" = (
 /obj/structure/table/marble,
 /obj/machinery/cooker/cereal,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "iF" = (
 /obj/structure/closet/fridge,
@@ -3110,7 +3093,7 @@
 	},
 /obj/landmark/corpse/lar_maria/test_subject,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "iI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3125,7 +3108,7 @@
 	icon_state = "1-4"
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "iJ" = (
 /obj/machinery/door/airlock,
@@ -3142,7 +3125,7 @@
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "iK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3155,7 +3138,7 @@
 	icon_state = "1-8"
 	},
 /obj/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3164,13 +3147,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3178,34 +3161,34 @@
 	},
 /obj/decal/cleanable/blood,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "iR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "iS" = (
 /obj/machinery/vending/snack,
@@ -3213,47 +3196,47 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "iT" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "iU" = (
 /obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "iV" = (
 /obj/machinery/light,
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "iW" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/mess_hall)
 "iX" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "iY" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "iZ" = (
 /obj/structure/table/marble,
 /obj/item/trash/plate,
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "ja" = (
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/mess_hall)
 "jb" = (
 /obj/machinery/gibber,
@@ -3279,18 +3262,18 @@
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "jf" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "jg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "jh" = (
 /obj/machinery/access_button/airlock_interior{
@@ -3301,7 +3284,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "ji" = (
 /obj/machinery/door/airlock/external{
@@ -3312,7 +3295,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "jj" = (
 /obj/machinery/door/airlock/external{
@@ -3324,7 +3307,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "jk" = (
 /obj/structure/grille,
@@ -3335,7 +3318,7 @@
 	dir = 1;
 	id_tag = "ZHP_south_airlock_pump"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "jm" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -3350,7 +3333,7 @@
 	tag_exterior_door = "ZHP_south_airlock_exterior_door";
 	tag_interior_door = "ZHP_south_airlock_interior_door"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "jn" = (
 /obj/machinery/airlock_sensor{
@@ -3358,7 +3341,7 @@
 	master_tag = "ZHPWestSolar";
 	pixel_x = 25
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "jo" = (
 /obj/machinery/door/airlock/external{
@@ -3366,14 +3349,14 @@
 	id_tag = "ZHP_south_airlock_exterior_door";
 	locked = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "jp" = (
 /obj/structure/lattice,
 /turf/space,
 /area/space)
 "jq" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "jr" = (
 /obj/machinery/access_button/airlock_exterior{
@@ -3381,7 +3364,7 @@
 	pixel_x = 25;
 	pixel_y = 15
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "kb" = (
 /obj/structure/bed/chair{
@@ -3390,7 +3373,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "lb" = (
 /obj/structure/bed/chair{
@@ -3399,14 +3382,14 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "lD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "mb" = (
 /obj/structure/lattice,
@@ -3428,14 +3411,14 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "ni" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "ob" = (
 /obj/structure/ladder,
@@ -3443,7 +3426,7 @@
 	dir = 4;
 	pixel_y = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/solar_control)
 "pb" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -3452,16 +3435,16 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "qb" = (
-/obj/structure/table/rack,
+/obj/structure/table/rack/dark,
 /obj/random/tank,
 /obj/random/tool,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "rb" = (
 /obj/machinery/atmospherics/unary/tank/nitrogen{
@@ -3473,7 +3456,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "sb" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -3484,14 +3467,14 @@
 	dir = 4;
 	pixel_y = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "tb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "ub" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -3500,7 +3483,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/atmos)
 "vb" = (
 /obj/structure/hygiene/sink{
@@ -3514,11 +3497,11 @@
 	pixel_y = 23;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "vM" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/hallway)
 "wb" = (
 /obj/structure/hygiene/sink{
@@ -3529,7 +3512,7 @@
 	pixel_x = 30
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_m)
 "xb" = (
 /obj/structure/hygiene/sink{
@@ -3540,27 +3523,27 @@
 /obj/item/storage/mirror{
 	pixel_x = -30
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/lar_maria/head_f)
 "DG" = (
 /obj/machinery/computer/modular{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/brick,
 /area/lar_maria/office)
 "VZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /obj/wallframe_spawn,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 "Yw" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/warhammer/plating,
 /area/lar_maria/hallway)
 
 (1,1,1) = {"
@@ -20626,7 +20609,7 @@ cd
 dJ
 ec
 er
-eJ
+eI
 eX
 eZ
 eZ
@@ -22443,7 +22426,7 @@ dl
 dl
 dl
 bx
-ev
+eP
 eP
 fb
 ex
@@ -23054,7 +23037,7 @@ ex
 fc
 ex
 fA
-fO
+fE
 ex
 eu
 gz
@@ -25469,7 +25452,7 @@ bV
 bV
 bV
 bV
-ds
+bV
 bV
 bV
 bV
@@ -26078,7 +26061,7 @@ cZ
 du
 co
 bY
-ds
+bV
 bV
 cp
 bV
@@ -26279,7 +26262,7 @@ cE
 da
 dv
 co
-dw
+eJ
 ej
 eG
 co
@@ -26882,7 +26865,7 @@ bE
 bV
 cq
 bZ
-dc
+bV
 du
 co
 bY
@@ -26892,7 +26875,7 @@ cp
 bV
 cp
 bV
-fV
+bV
 du
 gu
 gS
@@ -27903,7 +27886,7 @@ bV
 co
 fI
 da
-dw
+ds
 gu
 gX
 hm
@@ -28508,7 +28491,7 @@ cp
 cZ
 cq
 bZ
-fX
+bV
 du
 gu
 ha
@@ -28701,9 +28684,9 @@ cb
 co
 cI
 dg
-dw
+dc
 co
-dw
+eJ
 ep
 cI
 co
@@ -28711,7 +28694,7 @@ cb
 co
 fJ
 fY
-dw
+eJ
 gu
 gZ
 ho

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -17,7 +17,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ae" = (
 /obj/shuttle_landmark/nav_lost_supply_base/nav3,
@@ -29,7 +29,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ag" = (
 /obj/structure/cable/yellow{
@@ -41,7 +41,7 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/floor_decal/solarpanel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ah" = (
 /obj/structure/cable/yellow{
@@ -50,7 +50,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/stack/material/steel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ai" = (
 /obj/structure/cable/yellow{
@@ -63,7 +63,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "aj" = (
 /obj/structure/cable/yellow{
@@ -81,7 +81,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ak" = (
 /obj/structure/cable/yellow{
@@ -89,7 +89,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "al" = (
 /obj/structure/cable/yellow{
@@ -107,7 +107,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "am" = (
 /obj/structure/cable/yellow{
@@ -125,7 +125,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "an" = (
 /obj/structure/cable/yellow{
@@ -138,7 +138,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ao" = (
 /obj/structure/cable/yellow,
@@ -147,10 +147,10 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/floor_decal/solarpanel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ap" = (
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "aq" = (
 /obj/item/stack/material/rods,
@@ -166,7 +166,7 @@
 	amount = 50
 	},
 /obj/item/stack/material/steel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "as" = (
 /obj/machinery/power/solar{
@@ -174,7 +174,7 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/floor_decal/solarpanel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "at" = (
 /obj/shuttle_landmark/nav_lost_supply_base/nav1,
@@ -187,7 +187,7 @@
 	},
 /obj/structure/cable/yellow,
 /obj/floor_decal/solarpanel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "av" = (
 /obj/structure/girder/displaced,
@@ -197,25 +197,19 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /obj/structure/grille,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ax" = (
 /turf/simulated/wall/r_wall,
 /area/lost_supply_base/solar)
 "ay" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "solar_outer";
-	locked = 1;
-	name = "Solar External Access"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/shield_diffuser,
+/obj/machinery/door/airlock/warhammer/engineering,
 /turf/simulated/floor/plating,
 /area/lost_supply_base/solar)
 "az" = (
@@ -251,19 +245,13 @@
 /turf/simulated/wall/r_wall,
 /area/lost_supply_base)
 "aB" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "solar_inner";
-	locked = 1;
-	name = "Solar Access"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/warhammer/engineering,
 /turf/simulated/floor/plating,
 /area/lost_supply_base/solar)
 "aC" = (
@@ -279,16 +267,16 @@
 "aF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "aG" = (
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "aH" = (
 /obj/machinery/light_construct{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "aI" = (
 /obj/structure/cable{
@@ -300,7 +288,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "aJ" = (
 /obj/structure/table/rack,
@@ -308,7 +296,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/toolbox,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "aK" = (
 /turf/simulated/wall,
@@ -375,7 +363,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "aP" = (
 /obj/structure/cable{
@@ -386,7 +374,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "aQ" = (
 /obj/structure/cable{
@@ -409,7 +397,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "aS" = (
 /obj/structure/cable{
@@ -421,27 +409,24 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "aT" = (
 /obj/structure/bed/chair/comfy/captain,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "aU" = (
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/lost_supply_base/office)
-"aV" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "aW" = (
 /obj/item/paper,
 /obj/structure/safe,
 /obj/random/drinkbottle,
 /obj/random/handgun,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "aX" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -458,14 +443,14 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "aY" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
 	target_pressure = 200
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "aZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -480,23 +465,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bb" = (
 /obj/floor_decal/industrial/warning{
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bc" = (
 /obj/random/projectile,
 /obj/landmark/corpse/infardi,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bd" = (
 /obj/random/trash,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "be" = (
 /obj/structure/cable{
@@ -504,7 +489,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bf" = (
 /obj/structure/closet/crate/solar,
@@ -540,19 +525,19 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "bj" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "bk" = (
 /obj/structure/table/steel_reinforced,
-/obj/random/handgun,
-/turf/simulated/floor/tiled,
+/obj/random/loot/gunbundle,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bl" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bm" = (
 /obj/item/stack/tile/floor_dark{
@@ -560,14 +545,11 @@
 	pixel_y = -3
 	},
 /obj/item/stack/material/steel,
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned0"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bn" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned0"
-	},
+/mob/living/simple_animal/hostile/retaliate/jelly/mega,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bo" = (
 /obj/item/stack/tile/floor_dark{
@@ -582,18 +564,11 @@
 /area/space)
 "bq" = (
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "br" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	glass = 1380;
-	icon_state = "door_locked";
-	id_tag = "centcom_shuttle_bay_door";
-	locked = 1;
-	name = "Transport Airlock"
-	},
-/turf/simulated/floor,
+/obj/machinery/door/airlock/warhammer/engineering,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bs" = (
 /obj/floor_decal/industrial/hatch/yellow,
@@ -606,22 +581,21 @@
 	pixel_y = 24;
 	req_access = newlist()
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bt" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken4"
-	},
-/area/lost_supply_base)
+/obj/item/device/cassette/fart,
+/turf/simulated/floor/warhammer/metal/alt,
+/area/lost_supply_base/common)
 "bu" = (
 /obj/decal/cleanable/blood,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bv" = (
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bw" = (
 /obj/structure/cable{
@@ -629,7 +603,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bx" = (
 /obj/structure/cable{
@@ -637,7 +611,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "by" = (
 /obj/structure/cable{
@@ -649,7 +623,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bz" = (
 /obj/structure/cable{
@@ -712,29 +686,22 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "bE" = (
 /obj/item/pen/red,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bF" = (
 /obj/landmark/corpse/engineer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bG" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken4"
-	},
-/area/lost_supply_base/office)
-"bH" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken1"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bI" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base/office)
 "bJ" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -751,18 +718,18 @@
 	pixel_x = 24;
 	pixel_y = 12
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bK" = (
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bL" = (
 /obj/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bM" = (
 /obj/structure/table/rack,
@@ -771,7 +738,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/item/device/radio,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -780,34 +747,35 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/obj/machinery/door/airlock/warhammer/glass/engineering,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base/solar)
 "bO" = (
 /obj/random/ammo,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bP" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bQ" = (
 /turf/space,
 /area/lost_supply_base/office)
 "bR" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bS" = (
 /obj/random/trash,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bT" = (
 /obj/item/stack/tile/floor_dark{
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -816,38 +784,32 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bV" = (
 /turf/simulated/wall,
 /area/lost_supply_base)
 "bW" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken1"
-	},
+/obj/machinery/door/airlock/warhammer/glass/engineering,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "bX" = (
 /obj/machinery/door/airlock{
 	name = "Control room"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "bZ" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "ca" = (
 /obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
-/area/lost_supply_base/office)
-"cb" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken0"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/office)
 "cc" = (
 /obj/item/stack/material/steel,
@@ -857,18 +819,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cf" = (
 /obj/item/stack/material/rods,
 /obj/item/stack/material/steel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cg" = (
 /obj/structure/cable{
@@ -880,15 +842,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken4"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "ch" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "ci" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -910,13 +870,11 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cm" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken1"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "cn" = (
 /obj/floor_decal/industrial/warning{
@@ -924,17 +882,17 @@
 	icon_state = "warning"
 	},
 /obj/random/trash,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "co" = (
 /obj/decal/cleanable/blood/gibs/body,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cp" = (
 /obj/structure/door_assembly,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cq" = (
 /obj/machinery/atmospherics/omni/mixer{
@@ -945,7 +903,7 @@
 	tag_west = 2;
 	use_power = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cr" = (
 /obj/structure/cable,
@@ -957,7 +915,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cs" = (
 /obj/item/stack/tile/floor_dark{
@@ -968,26 +926,26 @@
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "ct" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "cu" = (
 /obj/item/stack/tile/floor_dark{
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "cv" = (
 /turf/simulated/wall,
 /area/lost_supply_base/common)
 "cw" = (
 /obj/machinery/fabricator/replicator,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "cx" = (
 /obj/structure/table/standard,
@@ -1003,97 +961,79 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "cy" = (
 /obj/machinery/gibber,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "cz" = (
 /obj/structure/closet/fridge/meat,
 /obj/machinery/cooker/oven,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "cA" = (
 /obj/structure/closet/fridge/meat,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned1"
-	},
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "cB" = (
 /obj/structure/closet/fridge/meat,
 /obj/structure/closet/fridge/meat,
-/turf/simulated/floor/tiled,
+/obj/random/loot/randomsupply,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "cC" = (
 /obj/structure/closet/crate/warhammer/freezer,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cD" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cE" = (
 /obj/item/stack/material/cardboard,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cF" = (
 /obj/item/device/scanner/price,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cH" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
-/area/lost_supply_base)
-"cI" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken0"
-	},
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned1"
-	},
+/mob/living/simple_animal/hostile/retaliate/jelly/mega/half,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cK" = (
-/turf/simulated/floor/tiled,
-/area/lost_supply_base/common)
-"cL" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned1"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "cN" = (
 /obj/machinery/light_construct{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cO" = (
 /obj/structure/closet/crate/warhammer/freezer/rations,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1108,50 +1048,43 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cS" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cT" = (
 /obj/structure/girder/displaced,
 /turf/space,
 /area/lost_supply_base)
 "cU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned0"
-	},
-/area/lost_supply_base)
+/obj/random/trash,
+/obj/item/device/cassette/western1,
+/turf/simulated/floor/warhammer/metal/alt,
+/area/lost_supply_base/common)
 "cV" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "cW" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base/common)
 "cX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1174,13 +1107,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "db" = (
 /obj/machinery/door/window/southleft,
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned1"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "dc" = (
 /obj/structure/table/standard,
@@ -1188,28 +1119,28 @@
 	pixel_x = 10
 	},
 /obj/item/trash/tray,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "dd" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "de" = (
 /obj/structure/table/standard,
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "df" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "dg" = (
 /obj/structure/closet/crate/secure/phoron{
 	name = "mineral crate";
 	req_access = newlist()
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dh" = (
 /obj/floor_decal/industrial/warning{
@@ -1219,33 +1150,33 @@
 	name = "mineral crate";
 	req_access = newlist()
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "di" = (
 /obj/random/junk,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dj" = (
 /obj/random/ammo,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dk" = (
 /obj/structure/mech_wreckage/powerloader,
 /obj/decal/cleanable/blood,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dl" = (
 /obj/machinery/light_construct,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dm" = (
 /obj/item/stack/material/steel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dn" = (
 /obj/structure/closet/firecloset,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "do" = (
 /obj/machinery/light{
@@ -1261,15 +1192,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "dp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned1"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "dq" = (
 /obj/machinery/door/airlock{
@@ -1278,23 +1207,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "dr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "ds" = (
 /obj/structure/closet/crate/secure/gear,
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dt" = (
 /obj/floor_decal/industrial/warning,
 /obj/structure/closet/crate/hydroponics,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "du" = (
 /obj/floor_decal/industrial/warning{
@@ -1302,12 +1231,12 @@
 	icon_state = "warning"
 	},
 /obj/item/storage/backpack/dufflebag,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dv" = (
 /obj/decal/cleanable/blood/drip,
 /obj/decal/cleanable/blood/writing,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1315,33 +1244,33 @@
 /area/lost_supply_base)
 "dx" = (
 /obj/item/material/kitchen/utensil/spoon,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "dy" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "dz" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "dA" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "dB" = (
 /obj/item/material/kitchen/utensil/fork,
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "dC" = (
 /obj/random/trash,
@@ -1349,20 +1278,20 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "dJ" = (
 /obj/random/junk,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dL" = (
 /obj/machinery/atmospherics/unary/tank/oxygen,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dM" = (
 /obj/machinery/atmospherics/unary/tank/air,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dN" = (
 /obj/structure/cable{
@@ -1372,73 +1301,69 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/lost_supply_base)
-"dO" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned0"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "dP" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned0"
-	},
-/area/lost_supply_base/common)
+/obj/structure/closet,
+/obj/random/clothing,
+/obj/random/loot/gunbundle,
+/turf/simulated/floor/warhammer/metal/alt,
+/area/lost_supply_base/supply)
 "dX" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dY" = (
 /obj/item/stack/tile/floor_dark,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "dZ" = (
 /obj/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "eb" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "ec" = (
 /obj/random/tank,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "ed" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "ee" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "ef" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "el" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "em" = (
 /obj/decal/cleanable/blood/splatter,
 /obj/landmark/corpse/engineer,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "en" = (
 /obj/floor_decal/industrial/warning{
@@ -1446,64 +1371,62 @@
 	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "eo" = (
 /obj/random/tool,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "ep" = (
 /obj/random/tank,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "eq" = (
 /obj/structure/closet/medical_wall{
 	pixel_x = -30
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "er" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/flame/lighter/random,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "es" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "et" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned0"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "ey" = (
 /obj/item/stack/material/cardboard,
 /obj/item/grenade/fake,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "ez" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "eA" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken4"
-	},
-/area/lost_supply_base/common)
+/obj/structure/closet,
+/obj/random/clothing,
+/turf/simulated/floor/warhammer/metal/alt,
+/area/lost_supply_base/supply)
 "eD" = (
 /obj/machinery/atmospherics/unary/tank/phoron{
 	volume = 3200
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "eE" = (
 /obj/item/bedsheet,
@@ -1514,52 +1437,41 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "eF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "eG" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "eH" = (
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "eI" = (
 /obj/machinery/light,
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "eJ" = (
-/obj/machinery/jukebox,
-/turf/simulated/floor/tiled,
+/obj/item/device/boombox,
+/obj/item/device/cassette/forbidden1,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "eQ" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "eS" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor,
-/area/lost_supply_base)
-"eT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "eU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1574,16 +1486,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/common)
 "eY" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "eZ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fa" = (
 /obj/floor_decal/industrial/warning{
@@ -1591,13 +1503,11 @@
 	icon_state = "warning"
 	},
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fb" = (
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken0"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "fc" = (
 /obj/machinery/light{
@@ -1609,7 +1519,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "fd" = (
 /obj/structure/cable{
@@ -1621,7 +1531,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "fe" = (
 /obj/machinery/door/airlock{
@@ -1635,18 +1545,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/lost_supply_base/supply)
-"ff" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fg" = (
 /obj/structure/closet/warhammer/emcloset,
@@ -1659,34 +1558,37 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/obj/random/loot/raregunsenergy,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fh" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fi" = (
 /obj/structure/closet,
 /obj/random/clothing,
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled,
+/obj/random/loot/randomcolonyitems,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fj" = (
 /obj/structure/bed,
 /obj/random/plushie,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fk" = (
 /obj/structure/closet,
 /obj/random/clothing,
-/turf/simulated/floor/tiled,
+/obj/random/loot/randomcolonyitems,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fl" = (
 /turf/simulated/wall/r_wall,
 /area/lost_supply_base/supply)
 "fm" = (
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fn" = (
 /obj/floor_decal/industrial/warning{
@@ -1694,7 +1596,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fo" = (
 /obj/random/junk,
@@ -1705,28 +1607,24 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "fp" = (
 /turf/simulated/wall,
 /area/lost_supply_base/supply)
 "fq" = (
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled,
-/area/lost_supply_base/supply)
-"fr" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned0"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fs" = (
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/retaliate/jelly/mega,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "ft" = (
 /obj/structure/table/standard,
 /obj/random/smokes,
 /obj/item/device/radio,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fu" = (
 /obj/shuttle_landmark/nav_lost_supply_base/nav2,
@@ -1735,27 +1633,27 @@
 "fv" = (
 /obj/structure/window/reinforced,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fw" = (
 /obj/structure/window/reinforced,
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fz" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fA" = (
 /obj/structure/table/standard,
 /obj/item/storage/briefcase,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fB" = (
 /obj/structure/sign/warning{
@@ -1763,30 +1661,30 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fC" = (
 /obj/random/energy,
 /obj/landmark/corpse/infardi,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fD" = (
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/landmark/corpse/engineer,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fF" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fG" = (
 /obj/machinery/light,
 /obj/structure/bed,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fH" = (
 /obj/structure/largecrate,
@@ -1794,17 +1692,18 @@
 	dir = 8;
 	target_pressure = 200
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fI" = (
 /obj/decal/cleanable/blood,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fJ" = (
-/obj/item/material/twohanded/fireaxe,
 /obj/decal/cleanable/blood,
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/obj/random/loot/rigloot,
+/obj/random/loot/heavymelee,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fK" = (
 /obj/floor_decal/industrial/hatch/yellow,
@@ -1813,14 +1712,14 @@
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fL" = (
 /obj/decal/cleanable/blood/writing{
 	dir = 4
 	},
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fM" = (
 /obj/structure/cable{
@@ -1832,16 +1731,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned1"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/item/stack/material/steel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "fO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1860,14 +1757,14 @@
 /area/lost_supply_base/supply)
 "fQ" = (
 /obj/structure/door_assembly,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fR" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fS" = (
 /obj/structure/cable{
@@ -1882,7 +1779,7 @@
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "fT" = (
 /obj/structure/cable{
@@ -1904,38 +1801,27 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken0"
-	},
-/area/lost_supply_base/supply)
-"fV" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_burned1"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fW" = (
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken0"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fX" = (
 /obj/item/gun/projectile/shotgun/pump/voxlegis,
 /obj/landmark/corpse/infardi,
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken4"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "fY" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "fZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "ga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1961,7 +1847,7 @@
 	pixel_x = 24;
 	pixel_y = 12
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "gc" = (
 /obj/floor_decal/industrial/warning,
@@ -1969,7 +1855,7 @@
 	dir = 8;
 	target_pressure = 200
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "gd" = (
 /obj/floor_decal/industrial/warning{
@@ -1979,25 +1865,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "ge" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/floor_decal/industrial/warning/full,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "gf" = (
 /obj/structure/closet/warhammer/emcloset,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "gg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2007,25 +1893,25 @@
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "gi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "gj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "gk" = (
 /obj/machinery/door/airlock{
 	name = "Head"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "gl" = (
 /obj/structure/lattice,
@@ -2034,7 +1920,7 @@
 /area/lost_supply_base)
 "gm" = (
 /obj/machinery/light,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/lost_supply_base)
 "gn" = (
 /obj/structure/closet/crate/trashcart,
@@ -2053,18 +1939,18 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "go" = (
 /obj/item/stack/material/steel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base)
 "gq" = (
 /obj/structure/hygiene/toilet{
 	dir = 1
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "gr" = (
 /obj/structure/hygiene/shower{
@@ -2072,7 +1958,7 @@
 	},
 /obj/random/soap,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "gs" = (
 /obj/shuttle_landmark/nav_lost_supply_base/navantag,
@@ -2094,9 +1980,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled{
-	icon_state = "steel_broken0"
-	},
+/turf/simulated/floor/warhammer/metal/alt,
 /area/lost_supply_base/supply)
 "ik" = (
 /obj/structure/shuttle/engine/heater{
@@ -2105,11 +1989,11 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "mI" = (
 /obj/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "pr" = (
 /obj/structure/window/reinforced{
@@ -2117,11 +2001,11 @@
 	},
 /obj/item/stock_parts/circuitboard/broken,
 /obj/machinery/constructable_frame/machine_frame,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "sO" = (
 /obj/item/bikehorn/rubberducky,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "zC" = (
 /obj/paint/red,
@@ -2132,13 +2016,15 @@
 /obj/item/organ/internal/kidneys,
 /obj/item/organ/internal/kidneys,
 /obj/item/organ/internal/kidneys,
-/turf/simulated/floor,
+/obj/random/loot/randomcolonyitems,
+/obj/random/loot/lootcontraband,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "DF" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "EM" = (
 /obj/paint/silver,
@@ -2146,7 +2032,7 @@
 /area/space)
 "Rn" = (
 /obj/machinery/artifact,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "Wm" = (
 /obj/paint/red,
@@ -6898,7 +6784,7 @@ aa
 aa
 aA
 aA
-br
+bW
 ga
 aA
 aa
@@ -7397,7 +7283,7 @@ cN
 cO
 aG
 ds
-bW
+bj
 dX
 el
 el
@@ -7489,7 +7375,7 @@ aa
 aA
 aG
 bb
-bt
+bj
 bL
 aG
 aG
@@ -7696,7 +7582,7 @@ bc
 bu
 aG
 aG
-aG
+cJ
 aG
 cE
 aG
@@ -8014,7 +7900,7 @@ aG
 aG
 aG
 aG
-aG
+cJ
 fb
 aG
 aG
@@ -8107,7 +7993,7 @@ bT
 cd
 bq
 aG
-bW
+bj
 aG
 dj
 dj
@@ -8616,7 +8502,7 @@ aK
 aG
 cf
 cs
-cI
+bj
 cT
 cY
 dn
@@ -8820,17 +8706,17 @@ bi
 bi
 cg
 ct
-cJ
-cU
+dN
+dN
 da
 do
-cU
 dN
-cJ
 dN
-cJ
+dN
+dN
+dN
 eE
-eT
+fM
 fc
 fo
 dN
@@ -8919,7 +8805,7 @@ aP
 bj
 bj
 bj
-bW
+bj
 ch
 cu
 bj
@@ -8927,7 +8813,7 @@ cu
 bj
 dp
 bj
-dO
+bj
 bj
 bj
 bj
@@ -8936,7 +8822,7 @@ ch
 fd
 bj
 bj
-bt
+bj
 fN
 fS
 gh
@@ -9120,9 +9006,9 @@ aa
 aa
 aC
 aR
-aV
+bG
 bE
-aV
+bG
 bY
 cj
 cw
@@ -9137,9 +9023,9 @@ eq
 cK
 eF
 eV
-ff
+fU
 fq
-fs
+fW
 fE
 fP
 fU
@@ -9233,20 +9119,20 @@ cK
 dc
 cK
 dy
-cL
-cL
+cK
+cK
 dy
 cK
 eG
 cv
 fg
-fr
+fW
 fs
 fF
 fp
 fE
 gj
-fs
+fW
 fl
 aa
 aa
@@ -9325,7 +9211,7 @@ aa
 aC
 aT
 bl
-aV
+bG
 bP
 ca
 ck
@@ -9336,17 +9222,17 @@ dd
 cK
 dz
 dA
-cL
+cK
 er
-eA
+cK
 eH
 cv
 fh
-fs
-fr
+fW
+fW
 fh
 fp
-fV
+fW
 fp
 fp
 fl
@@ -9429,22 +9315,22 @@ aU
 bl
 bn
 bG
-bn
+bG
 ck
 cz
-cL
+cK
 cV
 de
 cK
 dA
-dP
+cK
 dA
 es
 cK
 ee
 cv
 fi
-fs
+fW
 fz
 fk
 fp
@@ -9527,7 +9413,7 @@ aa
 aa
 aa
 aC
-aV
+bG
 bm
 bG
 bQ
@@ -9542,12 +9428,12 @@ dB
 cK
 ef
 ef
-cK
+bt
 eI
 cv
 fj
-fr
-fs
+fW
+fW
 fG
 fp
 fX
@@ -9630,10 +9516,10 @@ aa
 aa
 aC
 aW
-bn
-bH
+bG
+bG
 bQ
-cb
+bG
 ck
 cB
 cK
@@ -9642,17 +9528,17 @@ df
 cK
 dC
 cK
-dP
+cK
 et
-ee
+cU
 eJ
 cv
-fk
+eA
 ft
 fA
-fk
+dP
 fp
-fs
+fW
 gk
 gr
 fl

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -20,7 +20,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "af" = (
 /obj/structure/cable/yellow{
@@ -32,7 +32,7 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/floor_decal/solarpanel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ag" = (
 /obj/structure/cable/yellow{
@@ -40,7 +40,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ah" = (
 /obj/structure/cable/yellow{
@@ -53,7 +53,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ai" = (
 /obj/structure/cable/yellow{
@@ -71,7 +71,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "aj" = (
 /obj/structure/cable/yellow{
@@ -79,7 +79,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ak" = (
 /obj/structure/cable/yellow{
@@ -97,7 +97,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "al" = (
 /obj/structure/cable/yellow{
@@ -115,7 +115,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "am" = (
 /obj/structure/cable/yellow{
@@ -128,7 +128,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "an" = (
 /obj/structure/cable/yellow,
@@ -137,14 +137,14 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/floor_decal/solarpanel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ao" = (
 /obj/item/stack/material/rods,
 /turf/space,
 /area/space)
 "ap" = (
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "aq" = (
 /obj/machinery/power/solar{
@@ -153,7 +153,7 @@
 	},
 /obj/structure/cable/yellow,
 /obj/floor_decal/solarpanel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ar" = (
 /turf/simulated/wall/r_wall,
@@ -168,7 +168,7 @@
 	pixel_x = -25;
 	pixel_y = -25
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "at" = (
 /obj/machinery/light/small,
@@ -184,7 +184,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aw" = (
 /turf/simulated/wall/r_wall,
@@ -203,30 +203,30 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "ay" = (
 /obj/structure/table/steel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "az" = (
 /obj/structure/table/steel,
 /obj/random/tool,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aA" = (
 /obj/structure/table/steel,
 /obj/random/junk,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aB" = (
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aC" = (
 /obj/structure/table/rack,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aD" = (
 /obj/machinery/door/airlock/external/bolted_open,
@@ -236,10 +236,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aE" = (
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "aF" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -247,11 +247,11 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "aG" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "aH" = (
 /obj/wingrille_spawn/reinforced_phoron/full,
@@ -260,7 +260,7 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "aI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -290,7 +290,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aN" = (
 /obj/structure/cable/yellow{
@@ -312,7 +312,7 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aO" = (
 /obj/structure/cable/yellow{
@@ -320,7 +320,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aP" = (
 /obj/structure/cable/yellow{
@@ -334,7 +334,7 @@
 	icon_state = "2-4"
 	},
 /obj/item/ore,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aQ" = (
 /obj/structure/cable/yellow{
@@ -347,7 +347,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aR" = (
 /obj/structure/cable/yellow{
@@ -355,17 +355,18 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aS" = (
 /obj/random/junk,
-/turf/simulated/floor,
+/mob/living/simple_animal/hostile/meat/abomination,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aT" = (
 /obj/structure/sign/warning/airlock{
 	pixel_y = 30
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -374,27 +375,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "aV" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "aW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "aX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "aY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "aZ" = (
 /obj/machinery/door/airlock/hatch,
@@ -403,21 +404,21 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "ba" = (
 /obj/machinery/mass_driver{
 	dir = 4;
 	id_tag = "enginecore"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bb" = (
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bc" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -427,12 +428,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "be" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bf" = (
 /obj/structure/cable/yellow{
@@ -440,7 +441,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bg" = (
 /turf/space,
@@ -453,7 +454,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/loot,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -467,28 +468,28 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bj" = (
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bk" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bl" = (
 /obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bm" = (
 /obj/machinery/atmospherics/unary/outlet_injector,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bn" = (
 /obj/machinery/power/smes/buildable/outpost_substation,
@@ -496,11 +497,11 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bo" = (
 /obj/item/ore,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bp" = (
 /obj/structure/lattice,
@@ -509,26 +510,26 @@
 "bq" = (
 /obj/structure/closet,
 /obj/random/junk,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "br" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bs" = (
 /obj/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bt" = (
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bu" = (
 /obj/wingrille_spawn/reinforced_phoron/full,
@@ -537,7 +538,7 @@
 	id_tag = "prototype_chamber_blast"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bv" = (
 /obj/wingrille_spawn/reinforced_phoron/full,
@@ -545,7 +546,7 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bw" = (
 /obj/shuttle_landmark/nav_magshield/nav2,
@@ -557,7 +558,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "by" = (
 /obj/structure/cable{
@@ -570,7 +571,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bz" = (
 /obj/structure/cable{
@@ -578,29 +579,29 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bA" = (
 /obj/structure/closet,
 /obj/item/toy/therapy_purple,
 /obj/random/hat,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bE" = (
 /obj/item/ore,
@@ -613,31 +614,31 @@
 "bG" = (
 /obj/structure/closet,
 /obj/item/device/flashlight/flare/glowstick/random,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bH" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bI" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -664,7 +665,7 @@
 /area/space)
 "bP" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bQ" = (
 /obj/structure/table/steel,
@@ -673,29 +674,29 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bR" = (
 /obj/structure/table/steel,
 /obj/random/drinkbottle,
 /obj/random/tool,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bS" = (
 /obj/structure/closet/crate/trashcart,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bT" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -703,7 +704,7 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -720,7 +721,7 @@
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bY" = (
 /obj/structure/bed/chair{
@@ -730,7 +731,7 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -740,19 +741,19 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "ca" = (
 /obj/structure/table/steel,
 /obj/item/device/geiger,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cb" = (
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cc" = (
 /obj/machinery/door/blast/regular{
@@ -778,13 +779,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -807,7 +808,8 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/mob/living/simple_animal/hostile/meat/strippedhuman,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cj" = (
 /obj/structure/cable/yellow{
@@ -818,7 +820,7 @@
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "ck" = (
 /obj/machinery/door/blast/regular{
@@ -843,7 +845,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -852,7 +854,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cn" = (
 /obj/machinery/atmospherics/binary/pump,
@@ -861,7 +863,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "co" = (
 /obj/structure/cable/yellow{
@@ -879,7 +881,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cq" = (
 /obj/structure/cable/yellow{
@@ -893,7 +895,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cr" = (
 /obj/structure/cable/yellow{
@@ -907,17 +909,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cs" = (
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "ct" = (
 /obj/structure/cable/yellow{
@@ -931,7 +933,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -941,20 +943,20 @@
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cx" = (
 /obj/machinery/atmospherics/binary/circulator{
@@ -974,7 +976,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cz" = (
 /obj/structure/cable{
@@ -982,24 +984,24 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cA" = (
 /obj/item/device/flashlight/flare/glowstick/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cD" = (
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -1021,7 +1023,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/ore,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cG" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -1032,7 +1034,7 @@
 	pixel_y = 1;
 	use_power = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cH" = (
 /obj/machinery/power/apc{
@@ -1044,12 +1046,12 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cI" = (
 /obj/structure/closet,
 /obj/random/gloves,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cJ" = (
 /obj/machinery/light/small{
@@ -1057,7 +1059,7 @@
 	icon_state = "bulb1"
 	},
 /obj/random/junk,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cK" = (
 /obj/structure/table/steel,
@@ -1066,21 +1068,21 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cL" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/radiation,
 /obj/item/device/flashlight,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cN" = (
 /obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cO" = (
 /obj/structure/girder/displaced,
@@ -1096,7 +1098,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cQ" = (
 /obj/structure/table/steel,
@@ -1112,7 +1114,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cR" = (
 /obj/structure/cable{
@@ -1131,10 +1133,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cS" = (
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -1146,7 +1148,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cT" = (
 /obj/structure/cable{
@@ -1160,7 +1162,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cU" = (
 /obj/structure/cable{
@@ -1173,7 +1175,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1187,7 +1189,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/smes_storage)
 "cW" = (
 /obj/machinery/door/airlock/hatch,
@@ -1202,7 +1204,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1216,7 +1218,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1231,7 +1233,7 @@
 	icon_state = "4-8"
 	},
 /mob/living/simple_animal/hostile/carp,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1245,7 +1247,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "da" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1260,23 +1262,23 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "db" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "dc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "dd" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/engine)
 "de" = (
 /turf/simulated/wall/r_wall,
@@ -1288,8 +1290,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock,
-/turf/simulated/floor,
+/obj/machinery/door/airlock/warhammer/engineering,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dg" = (
 /turf/space,
@@ -1302,55 +1304,55 @@
 	icon_state = "1-2"
 	},
 /obj/random/obstruction,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "di" = (
 /obj/item/ore,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dj" = (
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dk" = (
 /obj/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dl" = (
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dm" = (
 /obj/random/junk,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dn" = (
 /obj/item/storage/wallet/random,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "do" = (
 /obj/structure/largecrate,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dp" = (
 /obj/random/shoes,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dq" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dr" = (
 /obj/structure/iv_stand,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ds" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dt" = (
 /turf/simulated/wall,
@@ -1362,40 +1364,40 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dv" = (
 /obj/random/tool,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dw" = (
 /obj/random/tank,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dx" = (
 /obj/structure/table/steel,
 /obj/random/tool,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dy" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dz" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dA" = (
 /obj/structure/closet,
 /obj/random/toolbox,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dB" = (
 /obj/structure/closet,
 /obj/random/suit,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dC" = (
 /obj/structure/closet,
@@ -1403,25 +1405,26 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dD" = (
 /obj/structure/closet,
 /obj/structure/plushie/ian,
 /obj/random/drinkbottle,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dE" = (
 /obj/random/material,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dF" = (
 /obj/item/stack/material/rods,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dG" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dH" = (
 /obj/structure/lattice,
@@ -1429,26 +1432,26 @@
 /area/magshield/north)
 "dI" = (
 /obj/item/clothing/under/color/lightpurple,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dJ" = (
 /obj/random/firstaid,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dK" = (
 /obj/random/toolbox,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dL" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/structure/largecrate,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dM" = (
 /obj/random/obstruction,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dN" = (
 /obj/machinery/power/apc{
@@ -1461,52 +1464,52 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dO" = (
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dP" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dQ" = (
 /obj/machinery/field_generator,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dR" = (
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dS" = (
 /obj/floor_decal/industrial/warning,
 /obj/random/loot,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dT" = (
 /obj/floor_decal/industrial/warning,
 /obj/structure/largecrate,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dU" = (
 /obj/floor_decal/industrial/warning,
 /obj/random/junk,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dV" = (
 /obj/floor_decal/industrial/warning,
 /obj/item/flame/lighter/random,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dW" = (
 /obj/floor_decal/industrial/warning,
 /obj/random/tank,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dX" = (
 /obj/floor_decal/industrial/warning{
@@ -1514,7 +1517,7 @@
 	icon_state = "warning"
 	},
 /obj/random/toolbox,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dY" = (
 /obj/structure/cable{
@@ -1522,35 +1525,35 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "dZ" = (
 /obj/structure/table/steel,
 /obj/random/powercell,
 /obj/machinery/cell_charger,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ea" = (
 /obj/machinery/power/port_gen/pacman/mrs,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eb" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ec" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ed" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ee" = (
 /obj/structure/table/rack,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ef" = (
 /obj/structure/grille,
@@ -1562,7 +1565,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eh" = (
 /obj/structure/cable{
@@ -1570,7 +1573,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ei" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1581,7 +1584,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ej" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1592,7 +1595,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1606,7 +1609,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "el" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1618,7 +1621,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "em" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1627,13 +1630,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "en" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -1648,7 +1651,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1662,7 +1665,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ep" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1674,7 +1677,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1693,7 +1696,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "er" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1705,13 +1708,13 @@
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "es" = (
 /obj/structure/sign/warning/airlock{
 	pixel_x = 30
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "et" = (
 /obj/machinery/light/small{
@@ -1721,7 +1724,7 @@
 /area/space)
 "eu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ev" = (
 /obj/structure/sign/warning/airlock{
@@ -1733,7 +1736,7 @@
 /obj/structure/sign/warning/docking_area{
 	pixel_y = -30
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ex" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1745,7 +1748,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1757,7 +1760,7 @@
 /obj/structure/cable{
 	icon_state = "4-9"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "ez" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1770,7 +1773,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1783,7 +1786,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1798,7 +1801,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1818,7 +1821,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eD" = (
 /obj/machinery/door/airlock/external/bolted,
@@ -1830,7 +1833,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eE" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -1847,7 +1850,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eF" = (
 /obj/machinery/door/airlock/external/bolted,
@@ -1856,7 +1859,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eG" = (
 /obj/machinery/access_button{
@@ -1868,7 +1871,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eI" = (
 /obj/structure/magshield/maggen,
@@ -1876,7 +1879,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "eJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -1888,7 +1891,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1904,48 +1907,48 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/item/newspaper,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eO" = (
 /obj/machinery/light_construct/small,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eP" = (
 /obj/structure/table,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eQ" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eR" = (
 /obj/structure/table/steel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eS" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/lights,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eT" = (
 /obj/machinery/door/airlock/external/bolted_open,
@@ -1954,50 +1957,53 @@
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eU" = (
 /obj/machinery/light/small,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eV" = (
 /obj/structure/closet,
 /obj/random/material,
 /obj/random/material,
-/turf/simulated/floor,
+/obj/random/loot/randomsupply/tech,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eW" = (
 /obj/structure/closet,
 /obj/random/material,
-/turf/simulated/floor,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eX" = (
 /obj/structure/closet,
 /obj/random/tool,
-/turf/simulated/floor,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eY" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "eZ" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "fa" = (
 /obj/structure/janitorialcart,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "fb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "fc" = (
 /obj/machinery/light/small{
@@ -2017,7 +2023,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "fe" = (
 /turf/simulated/wall,
@@ -2027,22 +2033,23 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
-/turf/simulated/floor,
+/mob/living/simple_animal/hostile/meat/horrorsmall,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fh" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fi" = (
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2052,7 +2059,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fk" = (
 /turf/simulated/wall/r_wall,
@@ -2063,27 +2070,27 @@
 /area/magshield/north)
 "fm" = (
 /obj/item/mop,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "fn" = (
 /obj/machinery/door/airlock/external/bolted_open,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "fo" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fp" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fr" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -2093,14 +2100,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
 	level = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "ft" = (
 /obj/shuttle_landmark/nav_magshield/nav5,
@@ -2111,20 +2118,20 @@
 /area/magshield/west)
 "fv" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fw" = (
 /obj/machinery/access_button{
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "fx" = (
 /obj/machinery/atmospherics/unary/tank,
@@ -2134,35 +2141,34 @@
 /obj/machinery/light_construct{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fz" = (
 /obj/machinery/light_construct{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fA" = (
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/meatstation/wormscientist,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fB" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fC" = (
-/obj/machinery/light_construct{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/mob/living/simple_animal/hostile/meat/horrorsmall,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fD" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fE" = (
 /obj/structure/cable{
@@ -2173,27 +2179,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fF" = (
 /obj/machinery/light_construct{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fG" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fH" = (
 /obj/overmap/visitable/sector/magshield,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/north)
 "fI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fJ" = (
 /obj/structure/grille,
@@ -2203,7 +2209,7 @@
 /obj/structure/cable{
 	icon_state = "4-10"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fL" = (
 /obj/structure/table/steel,
@@ -2212,7 +2218,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fM" = (
 /obj/structure/cable{
@@ -2223,31 +2229,23 @@
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fN" = (
 /obj/structure/cable{
 	icon_state = "5-8"
 	},
-/turf/simulated/floor/tiled,
-/area/magshield/west)
-"fO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fP" = (
 /obj/item/newspaper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fQ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fR" = (
 /obj/machinery/atmospherics/omni/mixer{
@@ -2257,7 +2255,7 @@
 	tag_south = 1;
 	tag_south_con = 0.79
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2270,7 +2268,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fT" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -2278,19 +2276,19 @@
 	tag_south = 1;
 	tag_west = 3
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -2306,46 +2304,46 @@
 	id = "d_n2_in";
 	use_power = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "fY" = (
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "fZ" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "ga" = (
-/obj/machinery/computer/modular{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/magshield/west)
+/obj/structure/closet,
+/obj/random/clothing,
+/obj/random/loot/basicarmorbundle,
+/turf/simulated/floor/warhammer/metal/alt,
+/area/magshield/south)
 "gb" = (
 /obj/structure/table/steel,
 /obj/item/material/ashtray/plastic,
 /obj/random/smokes,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gc" = (
 /obj/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gd" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "ge" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gf" = (
 /obj/structure/cable{
@@ -2353,42 +2351,43 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gg" = (
 /obj/structure/table/steel,
 /obj/random/toy,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gh" = (
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gi" = (
 /obj/floor_decal/industrial/warning{
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
-/turf/simulated/floor,
+/mob/living/simple_animal/hostile/meat/horrorsmall,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gm" = (
 /obj/structure/cable{
@@ -2399,34 +2398,34 @@
 /obj/machinery/light_construct{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gn" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/drinks/coffee,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "go" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gp" = (
 /obj/structure/magshield/nav_light/red{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "gq" = (
 /obj/structure/magshield/nav_light{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "gr" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gs" = (
 /obj/structure/closet,
@@ -2434,6 +2433,7 @@
 /obj/random/cash,
 /obj/random/clothing,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/random/loot/randomsupply,
 /turf/simulated/floor/carpet/blue,
 /area/magshield/west)
 "gt" = (
@@ -2441,6 +2441,7 @@
 /obj/item/storage/wallet,
 /obj/random/clothing,
 /obj/random/smokes,
+/obj/random/loot/randomsupply,
 /turf/simulated/floor/carpet/blue,
 /area/magshield/west)
 "gu" = (
@@ -2460,18 +2461,18 @@
 /obj/machinery/light_construct{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gy" = (
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2480,7 +2481,7 @@
 "gB" = (
 /obj/floor_decal/industrial/warning,
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gC" = (
 /obj/floor_decal/industrial/warning{
@@ -2488,7 +2489,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2500,17 +2501,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gE" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2558,7 +2559,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2572,7 +2573,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2584,13 +2585,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gP" = (
 /turf/simulated/wall,
@@ -2602,10 +2603,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable,
-/turf/simulated/floor/tiled/white,
-/area/magshield/west)
-"gR" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gS" = (
 /obj/structure/cable{
@@ -2614,57 +2612,57 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "gU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gV" = (
 /obj/structure/bookcase/manuals/xenoarchaeology,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gW" = (
 /obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gX" = (
 /obj/structure/bookcase/manuals/medical,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gY" = (
 /obj/structure/table/woodentable,
 /obj/random/action_figure,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "gZ" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/drinks/coffee,
 /obj/random/smokes,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "ha" = (
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hb" = (
 /obj/structure/table/steel,
 /obj/random/glasses,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hc" = (
 /obj/shuttle_landmark/nav_magshield/nav1,
@@ -2672,13 +2670,13 @@
 /area/space)
 "hd" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "he" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2690,14 +2688,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hg" = (
 /obj/machinery/door/airlock/external/bolted_open,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hh" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -2706,7 +2704,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hi" = (
 /obj/structure/lattice,
@@ -2726,7 +2724,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "hl" = (
 /obj/structure/magshield/rad_sensor,
@@ -2734,7 +2732,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "hm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2743,64 +2741,65 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hn" = (
 /obj/structure/table/woodentable,
 /obj/item/material/sword/replica,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "ho" = (
-/obj/machinery/light_construct{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/magshield/west)
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/warhammer/plating,
+/area/magshield/north)
 "hp" = (
 /obj/structure/bed/chair/comfy/captain,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hq" = (
 /obj/item/paper/magshield/log,
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hr" = (
-/obj/random/junk,
-/turf/simulated/floor/tiled,
-/area/magshield/west)
-"hs" = (
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 10
+	},
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
+"hs" = (
+/mob/living/simple_animal/hostile/meatstation/meatmound,
+/turf/simulated/floor/warhammer/plating,
+/area/magshield/smes_storage)
 "ht" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hu" = (
 /turf/space,
 /area/magshield/east)
 "hv" = (
 /obj/item/ore/slag,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "hw" = (
 /obj/structure/table/woodentable,
 /obj/random/plushie/large,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hx" = (
 /obj/structure/table/steel,
 /obj/item/material/ashtray/bronze,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hy" = (
 /obj/structure/table/steel,
 /obj/random/smokes,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2808,13 +2807,13 @@
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hA" = (
 /obj/structure/table/rack,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hB" = (
 /obj/structure/safe,
@@ -2827,24 +2826,20 @@
 /obj/random/cash,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hC" = (
 /obj/structure/table/woodentable,
 /obj/item/toy/torchmodel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hD" = (
 /obj/item/book/manual/magshield_manual,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hE" = (
 /obj/structure/lattice,
 /turf/space,
-/area/magshield/west)
-"hF" = (
-/obj/item/ore,
-/turf/simulated/floor/tiled,
 /area/magshield/west)
 "hG" = (
 /obj/machinery/power/apc{
@@ -2858,7 +2853,7 @@
 	dir = 4;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hH" = (
 /obj/structure/cable{
@@ -2867,12 +2862,12 @@
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hJ" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -2883,22 +2878,23 @@
 "hK" = (
 /obj/structure/table/woodentable,
 /obj/item/book/manual/supermatter_engine,
+/obj/random/loot/raresidearmbundle,
 /turf/simulated/floor/carpet/blue,
 /area/magshield/west)
 "hL" = (
 /obj/item/ore,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hM" = (
 /turf/space,
 /area/magshield/west)
 "hN" = (
 /obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hO" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hP" = (
 /obj/structure/cable{
@@ -2906,14 +2902,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light_construct{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "hR" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -2953,18 +2949,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hV" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2973,8 +2969,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/magshield/west)
+/obj/machinery/light,
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/warhammer/metal/alt,
+/area/magshield/south)
 "hX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2983,7 +2981,7 @@
 	dir = 4
 	},
 /obj/item/paper/magshield/tornpage,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hY" = (
 /obj/structure/table/steel,
@@ -2994,7 +2992,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "hZ" = (
 /obj/structure/table/woodentable,
@@ -3021,7 +3019,7 @@
 /area/magshield/west)
 "ic" = (
 /obj/item/stack/material/rods,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "id" = (
 /obj/item/stack/material/rods,
@@ -3029,25 +3027,25 @@
 /area/magshield/west)
 "ie" = (
 /obj/machinery/seed_storage,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "if" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "ig" = (
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "ih" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "ii" = (
 /obj/item/material/minihoe,
@@ -3055,7 +3053,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "ij" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3064,7 +3062,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "ik" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3073,7 +3071,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "il" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3085,7 +3083,7 @@
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "im" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3094,7 +3092,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "in" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3103,13 +3101,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 "io" = (
 /obj/machinery/light_construct{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "ip" = (
 /turf/simulated/wall/r_wall,
@@ -3119,7 +3117,7 @@
 /area/magshield/south)
 "ir" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -3127,7 +3125,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "is" = (
 /obj/item/ore/slag,
@@ -3141,14 +3139,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "iu" = (
-/turf/simulated/floor/tiled/white,
-/area/magshield/south)
+/mob/living/simple_animal/hostile/meat/humansecurity,
+/turf/simulated/floor/warhammer/plating,
+/area/magshield/north)
 "iv" = (
 /obj/structure/curtain/open/shower,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iw" = (
 /obj/structure/hygiene/shower{
@@ -3157,7 +3156,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3167,29 +3166,25 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iy" = (
 /obj/structure/table,
 /obj/random/firstaid,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iz" = (
 /obj/machinery/light_construct{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/magshield/south)
-"iA" = (
-/obj/structure/bed,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iB" = (
 /obj/random/material,
 /turf/space,
 /area/space)
 "iC" = (
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/west)
 "iD" = (
 /obj/structure/table/steel,
@@ -3206,26 +3201,26 @@
 	pixel_x = -2;
 	pixel_y = -4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "iE" = (
 /obj/structure/iv_stand,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iF" = (
 /obj/random/medical/lite,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iG" = (
 /obj/machinery/light_construct,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "iH" = (
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iI" = (
 /obj/structure/hygiene/shower{
@@ -3235,15 +3230,16 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/obj/random/loot/lootcontraband,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iJ" = (
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iK" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -3251,18 +3247,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "iL" = (
 /obj/structure/hygiene/toilet,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iM" = (
 /obj/structure/hygiene/urinal{
 	pixel_y = 25
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/obj/decal/cleanable/blood/gibs/body,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3274,30 +3271,30 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iP" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iQ" = (
 /obj/machinery/vending/cola,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iR" = (
 /obj/machinery/vending/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iS" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iT" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/door/airlock/warhammer/engineering,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iU" = (
 /obj/structure/hygiene/toilet{
@@ -3306,7 +3303,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3319,41 +3316,43 @@
 /obj/machinery/light_construct{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iX" = (
 /obj/item/ore/slag,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iY" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "iZ" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/obj/random/loot/raregunslug,
+/obj/decal/cleanable/blood/gibs/limb,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ja" = (
-/mob/living/simple_animal/hostile/carp,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jd" = (
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "je" = (
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jf" = (
 /obj/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3367,7 +3366,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3376,7 +3375,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ji" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3385,20 +3384,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
 	level = 2
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jl" = (
 /turf/space,
@@ -3408,48 +3407,48 @@
 	name = "plastic table frame"
 	},
 /obj/random/smokes,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jn" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/random/firstaid,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jo" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jp" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jq" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jr" = (
 /obj/random/trash,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "js" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jt" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ju" = (
 /obj/structure/bed/chair{
@@ -3458,7 +3457,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jv" = (
 /obj/structure/table/standard{
@@ -3466,31 +3465,31 @@
 	},
 /obj/item/trash/plate,
 /obj/item/reagent_containers/food/snacks/flatbread,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jw" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jx" = (
 /obj/structure/table/marble,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jy" = (
 /obj/structure/table/marble,
 /obj/item/material/knife/kitchen/cleaver,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jz" = (
 /obj/structure/hygiene/sink{
 	pixel_y = 25
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jA" = (
 /obj/machinery/light/small{
@@ -3504,7 +3503,7 @@
 /area/magshield/south)
 "jC" = (
 /obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jD" = (
 /obj/structure/lattice,
@@ -3512,11 +3511,11 @@
 /area/magshield/south)
 "jE" = (
 /obj/structure/magshield/maggen,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "jF" = (
 /obj/machinery/door/airlock/external/bolted,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/south)
 "jG" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -3529,20 +3528,14 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/south)
 "jH" = (
 /obj/machinery/door/airlock/external/bolted,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/magshield/south)
-"jI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/south)
 "jJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3559,7 +3552,7 @@
 	dir = 4;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3571,7 +3564,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jL" = (
 /obj/structure/table/standard{
@@ -3579,7 +3572,7 @@
 	},
 /obj/random/plushie/large,
 /obj/random/smokes,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jM" = (
 /obj/structure/table/standard{
@@ -3588,62 +3581,67 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jN" = (
 /obj/structure/closet,
 /obj/random/glasses,
 /obj/random/hat,
 /obj/random/cash,
-/turf/simulated/floor/tiled,
+/obj/random/loot/raresidearmbundle,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jO" = (
 /obj/structure/closet,
 /obj/random/clothing,
 /obj/random/accessory,
 /obj/random/smokes,
-/turf/simulated/floor/tiled,
+/obj/random/loot/valuableloot,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jP" = (
 /obj/structure/closet,
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/obj/random/loot/tech2,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jQ" = (
 /obj/structure/closet,
 /obj/random/clothing,
-/turf/simulated/floor/tiled,
+/obj/random/loot/valuableloot,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jR" = (
 /obj/structure/closet,
 /obj/random/clothing,
 /obj/random/cash,
-/turf/simulated/floor/tiled,
+/obj/random/loot/rarearmorbundle,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jS" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jT" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/material/knife/table,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jU" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jV" = (
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jW" = (
 /obj/item/material/knife/hook,
@@ -3655,7 +3653,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jY" = (
 /obj/structure/hygiene/sink{
@@ -3663,7 +3661,7 @@
 	pixel_x = 11
 	},
 /obj/item/soap,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "jZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3680,7 +3678,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ka" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3691,7 +3689,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/south)
 "kb" = (
 /obj/structure/cable{
@@ -3699,14 +3697,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/south)
 "kc" = (
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/south)
 "kd" = (
 /obj/structure/roller_bed,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ke" = (
 /obj/structure/cable{
@@ -3714,49 +3712,51 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "kf" = (
 /obj/structure/sign/warning/airlock{
 	pixel_x = -30
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kh" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ki" = (
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kj" = (
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kl" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
-/area/magshield/south)
+/obj/structure/closet,
+/obj/random/toolbox,
+/obj/random/loot/randomsupply/tech,
+/turf/simulated/floor/warhammer/plating,
+/area/magshield/north)
 "km" = (
 /obj/machinery/vending/dinnerware,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kn" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ko" = (
 /turf/simulated/floor/tiled/freezer,
@@ -3771,20 +3771,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ks" = (
 /obj/structure/hygiene/sink{
 	dir = 4;
 	pixel_x = 11
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3797,19 +3797,16 @@
 /obj/machinery/light_construct{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ku" = (
 /obj/item/ore,
 /turf/space,
 /area/magshield/south)
 "kv" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled,
-/area/magshield/south)
+/mob/living/simple_animal/hostile/meatstation/meatworm,
+/turf/simulated/floor/warhammer/metal/alt,
+/area/magshield/west)
 "kw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -3817,17 +3814,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/magshield/south)
+/obj/random/junk,
+/turf/simulated/floor/warhammer/plating,
+/area/magshield/smes_storage)
 "ky" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -3835,18 +3827,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kz" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3856,7 +3848,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kB" = (
 /obj/item/flame/match,
@@ -3866,7 +3858,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kC" = (
 /obj/machinery/door/firedoor,
@@ -3876,7 +3868,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kD" = (
 /obj/item/material/kitchen/utensil/fork/plastic,
@@ -3886,21 +3878,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kG" = (
 /obj/random/trash,
@@ -3910,7 +3902,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/random/loot/rigloot,
+/obj/random/loot/heavymelee,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3919,17 +3913,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kI" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/snacks/chips,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kJ" = (
 /obj/structure/table/marble,
 /obj/item/material/knife/table,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kK" = (
 /obj/structure/kitchenspike,
@@ -3945,37 +3939,37 @@
 /turf/simulated/floor/tiled/freezer,
 /area/magshield/south)
 "kM" = (
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kN" = (
 /obj/structure/window/basic{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kO" = (
 /obj/structure/fitness/weightlifter,
 /obj/structure/window/basic{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kP" = (
 /obj/structure/window/basic{
 	dir = 1
 	},
 /obj/item/towel/random,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kQ" = (
 /obj/structure/window/basic{
 	dir = 1
 	},
 /obj/structure/fitness/punchingbag,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kR" = (
 /obj/structure/window/basic{
@@ -3984,19 +3978,19 @@
 /obj/structure/window/basic{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kS" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kT" = (
 /obj/structure/curtain/open/bed,
 /obj/item/material/knife/table,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4005,51 +3999,53 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kV" = (
 /obj/item/towel/random,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kW" = (
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kX" = (
 /obj/structure/closet,
 /obj/random/accessory,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kY" = (
 /obj/structure/closet,
 /obj/random/tool,
 /obj/random/smokes,
-/turf/simulated/floor/tiled,
+/obj/random/loot/basicarmorbundle,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "kZ" = (
 /obj/structure/closet,
 /obj/random/firstaid,
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/obj/random/loot/basicarmorbundle,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "la" = (
 /obj/structure/closet,
 /obj/random/loot,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lb" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/random/hat,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lc" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/deck/cards,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ld" = (
 /obj/structure/table/standard{
@@ -4057,15 +4053,15 @@
 	},
 /obj/item/material/kitchen/utensil/fork/plastic,
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "le" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/warhammer/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4074,7 +4070,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lg" = (
 /obj/item/stack/material/rods,
@@ -4082,62 +4078,62 @@
 /area/magshield/south)
 "lh" = (
 /obj/structure/fitness/weightlifter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "li" = (
 /obj/structure/fitness/punchingbag,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lj" = (
 /obj/structure/window/basic{
 	dir = 4
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lk" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ll" = (
 /obj/random/trash,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lm" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ln" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lo" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lp" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lq" = (
 /obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lr" = (
 /obj/machinery/light_construct{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "ls" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/south)
 "lt" = (
 /obj/shuttle_landmark/nav_magshield/nav4,
@@ -4152,7 +4148,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "lv" = (
 /obj/structure/cable/yellow{
@@ -4160,7 +4156,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "lw" = (
 /obj/structure/cable/yellow{
@@ -4172,7 +4168,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/floor_decal/solarpanel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "lx" = (
 /obj/structure/cable/yellow{
@@ -4190,7 +4186,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "ly" = (
 /obj/structure/cable/yellow,
@@ -4199,7 +4195,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/floor_decal/solarpanel,
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "lz" = (
 /obj/structure/cable/yellow{
@@ -4217,7 +4213,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/space)
 "lA" = (
 /obj/shuttle_landmark/nav_magshield/nav3,
@@ -4225,7 +4221,7 @@
 /area/space)
 "uL" = (
 /obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/magshield/west)
 "Eo" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -4233,7 +4229,7 @@
 	tag_south = 1;
 	tag_west = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/warhammer/plating,
 /area/magshield/east)
 
 (1,1,1) = {"
@@ -17669,9 +17665,9 @@ gv
 gH
 gP
 gV
-fA
-fA
-fA
+fB
+fB
+fB
 gv
 hS
 ia
@@ -17871,9 +17867,9 @@ gv
 gI
 gP
 gW
-fA
-fA
-fA
+fB
+fB
+fB
 hK
 hT
 ib
@@ -18073,12 +18069,12 @@ gv
 gJ
 gP
 gX
-fA
-fA
-fA
-fA
+fB
+fC
+fB
+fB
 hU
-fA
+fB
 fu
 fu
 aa
@@ -18278,9 +18274,9 @@ gY
 hn
 hw
 hC
-fA
+fB
 hU
-fA
+fB
 fu
 fu
 aa
@@ -18669,8 +18665,8 @@ eJ
 dH
 dj
 fu
-fA
-fA
+fB
+fB
 fY
 gf
 gm
@@ -18678,18 +18674,18 @@ gf
 gf
 gf
 gQ
-gR
-ho
-gR
-hD
-fA
-hW
-fA
-hF
+fB
 io
-fA
-fA
-hF
+fB
+hD
+fB
+hU
+fB
+hL
+io
+fB
+fB
+hL
 fu
 iL
 iY
@@ -18879,11 +18875,11 @@ fB
 fB
 fB
 fB
-gR
+fB
 gZ
 hp
 hx
-gR
+fB
 fB
 hX
 ic
@@ -19073,7 +19069,7 @@ ej
 dj
 di
 fu
-fC
+fF
 fL
 fZ
 gg
@@ -19081,11 +19077,11 @@ gn
 fZ
 go
 fB
-gR
+fB
 ha
 hq
 ha
-gR
+fB
 hL
 hY
 fZ
@@ -19098,9 +19094,9 @@ fu
 iM
 iZ
 iq
-jI
+jj
 kf
-kv
+iH
 ip
 ip
 ip
@@ -19277,32 +19273,32 @@ eO
 fu
 fB
 fM
-ga
-ga
-ga
-ga
-ga
+ha
+ha
+ha
+ha
+ha
 fB
 fB
-fA
-hr
-fA
+fB
+fD
+fB
 fB
 hM
 hM
 hE
-ga
-ga
-ga
-ga
+ha
+ha
+ha
+ha
 fB
 fu
 jz
 ja
 iq
-jI
-jd
-jd
+jj
+ja
+ja
 kN
 kV
 ip
@@ -19479,34 +19475,34 @@ dj
 fu
 fD
 fN
-fA
-fA
-fA
-fA
-fA
-fA
 fB
-fA
-fA
-fA
+fB
+fB
+fB
+fB
+fB
+fB
+fB
+kv
+fB
 hE
 hM
 hM
 hM
-hF
-fA
-fA
-fA
+hL
+fB
+fB
+fB
 fB
 fu
 iq
 iT
 iq
 jJ
-jd
-jd
+ja
+ja
 kO
-jd
+ja
 lh
 ip
 ip
@@ -19680,18 +19676,18 @@ dY
 dY
 fv
 fE
-fO
-fO
-fO
-fO
-fO
-fO
-fO
+gf
+gf
+gf
+gf
+gf
+gf
+gf
 gS
-fO
-fO
-fO
-fO
+gf
+gf
+gf
+gf
 hM
 hM
 hM
@@ -19708,8 +19704,8 @@ jK
 kg
 kw
 kP
-jd
-jd
+ja
+ja
 jf
 iS
 aa
@@ -19881,36 +19877,36 @@ eL
 dj
 dj
 fu
-fA
-fA
-fA
 fB
-fA
-fA
 fB
-fA
-fA
-fA
 fB
-fA
-hF
+fB
+fB
+fB
+fB
+fB
+fB
+fB
+fB
+fB
+hL
 hE
 hM
 id
 hM
 hE
+fB
 fA
-fA
-fA
+fB
 fu
 iP
-jd
-jd
-jd
-jd
-kx
+ja
+ja
+ja
+ja
+jh
 kQ
-jd
+ja
 li
 ip
 ip
@@ -20091,28 +20087,28 @@ go
 go
 fZ
 go
-fA
+fB
 hb
 fZ
 hy
-fA
+fB
 go
 fZ
 go
 hy
 fZ
 gn
-fA
+fB
 iG
 fu
 iQ
-jd
-jd
-jd
-jd
-kx
+ja
+ja
+ja
+ja
+jh
 kR
-jd
+ja
 lj
 ip
 ip
@@ -20286,25 +20282,25 @@ dj
 fm
 fu
 fG
-fA
-ga
-ga
-ga
-ga
-ga
-ga
-fA
-ga
-ga
-ga
+fB
+ha
+ha
+ha
+ha
+ha
+ha
+fB
+ha
+ha
+ha
 fF
-ga
-ga
-ga
-ga
-ga
-ga
-fA
+ha
+ha
+ha
+ha
+ha
+ha
+fB
 fG
 fu
 iR
@@ -20312,10 +20308,10 @@ je
 jm
 jL
 kh
-kx
-jd
-jd
-jd
+jh
+ja
+ja
+ja
 jf
 iS
 aa
@@ -20916,11 +20912,11 @@ aa
 ip
 ip
 jo
-jd
+ja
 ki
-kx
+jh
 ki
-jd
+ja
 lk
 ip
 ip
@@ -21522,11 +21518,11 @@ aa
 ip
 ip
 jo
-jd
+ja
 ki
-kx
+jh
 ki
-jd
+ja
 ll
 ip
 ip
@@ -21726,7 +21722,7 @@ ip
 jq
 jO
 iq
-kx
+jh
 iq
 kY
 jq
@@ -21928,7 +21924,7 @@ ip
 iq
 iq
 iq
-kx
+jh
 iq
 iq
 iq
@@ -22128,11 +22124,11 @@ aa
 ip
 ip
 jo
-jd
+ja
 ki
-kx
+jh
 ki
-jd
+ja
 lk
 ip
 ip
@@ -22332,9 +22328,9 @@ ip
 jq
 jP
 iq
-kA
+hW
 iq
-jQ
+ga
 jq
 ip
 ip
@@ -22534,7 +22530,7 @@ ip
 iq
 iq
 iq
-kx
+jh
 iq
 iq
 iq
@@ -22734,11 +22730,11 @@ aa
 ip
 ip
 jr
-jd
+ja
 ki
-kx
+jh
 ki
-jd
+ja
 lk
 ip
 ip
@@ -22896,7 +22892,7 @@ bQ
 bX
 aB
 aB
-aB
+hs
 aB
 cQ
 de
@@ -22938,7 +22934,7 @@ ip
 jp
 jQ
 iq
-kx
+jh
 iq
 kZ
 jq
@@ -23140,7 +23136,7 @@ ip
 iq
 iq
 iq
-kx
+jh
 iq
 iq
 iq
@@ -23340,11 +23336,11 @@ aa
 ip
 ip
 jo
-jd
+ja
 ki
-kx
+jh
 kT
-jd
+ja
 lk
 ip
 ip
@@ -23493,7 +23489,7 @@ aa
 au
 au
 aC
-aS
+kx
 bg
 bp
 bo
@@ -23699,11 +23695,11 @@ aT
 bh
 bg
 aB
-aS
+kx
 aB
 bo
 aB
-aS
+kx
 aB
 aB
 cT
@@ -23947,9 +23943,9 @@ ip
 ip
 js
 js
-jd
-kx
-jd
+ja
+jh
+ja
 js
 js
 ip
@@ -24106,7 +24102,7 @@ bA
 bG
 aB
 bj
-aS
+kx
 cr
 aB
 cJ
@@ -24149,9 +24145,9 @@ iS
 jf
 jt
 jS
-jd
+ja
 kD
-jd
+ja
 lb
 jt
 ip
@@ -24352,8 +24348,8 @@ jf
 jt
 jT
 kj
-kx
-jd
+jh
+ja
 lc
 lm
 ip
@@ -24555,7 +24551,7 @@ ju
 jw
 kk
 kE
-jd
+ja
 jw
 jw
 ip
@@ -24755,9 +24751,9 @@ ip
 ip
 js
 js
-kl
+iW
 kF
-jd
+ja
 js
 js
 ip
@@ -24923,7 +24919,7 @@ de
 de
 dw
 dj
-dj
+ho
 dM
 eo
 dj
@@ -24957,7 +24953,7 @@ iS
 jf
 jt
 jt
-jd
+ja
 kG
 jd
 ld
@@ -25159,9 +25155,9 @@ iS
 jf
 jv
 jU
-jd
-kx
-jd
+ja
+jh
+ja
 jU
 jt
 ip
@@ -25361,9 +25357,9 @@ ip
 ip
 jw
 jw
-jd
-kx
-jd
+ja
+jh
+ja
 jw
 jw
 ip
@@ -25561,9 +25557,9 @@ ac
 aa
 ip
 ip
-jd
-jd
-jd
+ja
+ja
+ja
 kH
 kg
 kw
@@ -25731,7 +25727,7 @@ de
 de
 dj
 dM
-dj
+iu
 dj
 eo
 dj
@@ -25768,7 +25764,7 @@ jV
 km
 iq
 iq
-kx
+jh
 kW
 ip
 ip
@@ -25966,11 +25962,11 @@ aa
 ip
 ip
 jy
-iu
-iu
-iu
+ja
+ja
+ja
 iT
-kx
+jh
 kW
 ip
 ip
@@ -26168,11 +26164,11 @@ aa
 ip
 ip
 jz
-iu
-iu
+ja
+ja
 jV
 iq
-kx
+jh
 kW
 ip
 ip
@@ -26369,12 +26365,12 @@ ac
 aa
 ip
 ip
-iu
-iu
-iu
+ja
+ja
+ja
 kI
 iq
-kx
+jh
 kW
 ip
 ip
@@ -26571,12 +26567,12 @@ ac
 aa
 ip
 ip
-iu
+ja
 jV
 kn
 kJ
 iq
-kx
+jh
 lo
 ip
 ip
@@ -26778,7 +26774,7 @@ iq
 iq
 iq
 iq
-kx
+jh
 iR
 ip
 ip
@@ -26980,7 +26976,7 @@ jW
 ko
 kK
 iq
-kx
+jh
 lp
 ip
 ip
@@ -27182,7 +27178,7 @@ jB
 kp
 kL
 iq
-kx
+jh
 lq
 ip
 ip
@@ -27575,13 +27571,13 @@ hd
 hd
 ih
 iq
-iu
-iu
+ja
+ja
 iH
-iu
-iu
-iu
-iu
+ja
+ja
+ja
+ja
 jX
 kq
 kM
@@ -27749,14 +27745,14 @@ bN
 bN
 de
 de
-dA
+kl
 dj
 dj
 dj
 dj
 eo
 dt
-fg
+hr
 fo
 fy
 fo
@@ -27769,12 +27765,12 @@ gC
 fi
 fe
 he
-hs
-hs
-hs
+fi
+fi
+fi
 hN
-hs
-hs
+fi
+fi
 ii
 iq
 iv
@@ -27783,13 +27779,13 @@ iv
 iq
 iT
 iq
-iu
-iu
+ja
+ja
 kr
 iq
-kx
-jd
-jd
+jh
+ja
+ja
 ip
 ip
 aa
@@ -27989,8 +27985,8 @@ jC
 jY
 ks
 iq
-kx
-jd
+jh
+ja
 ls
 jl
 aa
@@ -28191,7 +28187,7 @@ iq
 iq
 iq
 iq
-kx
+jh
 ip
 jl
 jl
@@ -28789,7 +28785,7 @@ in
 iq
 iy
 iE
-iu
+ja
 iF
 iW
 ji
@@ -28992,7 +28988,7 @@ iq
 iz
 iF
 iJ
-iu
+ja
 iX
 jj
 jD
@@ -29191,11 +29187,11 @@ gj
 fi
 fi
 iq
-iA
-iu
+jq
+ja
 iF
-iu
-iu
+ja
+ja
 jk
 jl
 kc

--- a/maps/away/meatstation/meatstation.dmm
+++ b/maps/away/meatstation/meatstation.dmm
@@ -501,10 +501,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
-"bo" = (
-/obj/item/book/manual/psionics,
-/turf/space,
-/area/space)
 "bp" = (
 /obj/machinery/recharger/wallcharger{
 	dir = 4;
@@ -707,11 +703,6 @@
 	},
 /turf/simulated/floor,
 /area/meatstation/engineering)
-"bP" = (
-/obj/random/maintenance/clean,
-/obj/random/single/meatstation/meatball,
-/turf/simulated/floor,
-/area/space)
 "bQ" = (
 /obj/structure/inflatable/wall,
 /obj/floor_decal/corner/black/border,
@@ -1034,7 +1025,6 @@
 /area/meatstation/engineering)
 "cy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/random/single/meatstation/low/wormscientist,
 /obj/machinery/light/small/red{
 	dir = 1
 	},
@@ -1621,13 +1611,6 @@
 "dO" = (
 /turf/simulated/floor,
 /area/meatstation/bathroom)
-"dP" = (
-/obj/random/single/meatstation/low/wormscientist,
-/obj/floor_decal/corner/black/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/meatstation/centerhallway)
 "dQ" = (
 /obj/item/stack/material/rods,
 /obj/random/junk,
@@ -2314,7 +2297,6 @@
 	icon_state = "1-2"
 	},
 /obj/random/trash,
-/obj/random/single/meatstation/low/wormscientist,
 /obj/decal/cleanable/blood/drip,
 /turf/simulated/floor/lino,
 /area/meatstation/mess)
@@ -3007,10 +2989,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/meatstation/hydroponics)
-"gN" = (
-/obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/space,
-/area/space)
 "gO" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -3282,13 +3260,6 @@
 /obj/item/material/shard,
 /turf/simulated/floor/tiled/monotile,
 /area/meatstation/hydroponics)
-"hw" = (
-/obj/random/single/meatstation/low/wormscientist,
-/obj/floor_decal/corner/black/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/meatstation/centerhallway)
 "hx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3713,10 +3684,6 @@
 /obj/item/material/knife/kitchen,
 /turf/space,
 /area/space)
-"iA" = (
-/obj/item/reagent_containers/food/snacks/sliceable/meatbread,
-/turf/space,
-/area/space)
 "iB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3770,10 +3737,6 @@
 /obj/item/material/knife/kitchen/cleaver,
 /turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
-"iI" = (
-/obj/item/reagent_containers/food/snacks/sliceable/pizza/meatpizza,
-/turf/space,
-/area/space)
 "iJ" = (
 /obj/machinery/cooker/grill,
 /obj/floor_decal/corner/lime/diagonal,
@@ -4642,10 +4605,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/meatstation/mess)
-"kR" = (
-/obj/structure/flora/pottedplant/smallcactus,
-/turf/space,
-/area/space)
 "kS" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/flora/pottedplantsmall/fern,
@@ -5023,10 +4982,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/meatstation/dorm)
-"lQ" = (
-/obj/item/book/manual/research_and_development,
-/turf/space,
-/area/space)
 "lR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5081,10 +5036,6 @@
 /obj/random/single/meatstation/low/wormguard,
 /turf/simulated/floor/reinforced,
 /area/meatstation/lab)
-"ma" = (
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/carpet/blue3,
-/area/meatstation/dorm)
 "mb" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/device/flashlight/lamp,
@@ -5424,16 +5375,8 @@
 /obj/structure/mine,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/swhallway)
-"mZ" = (
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled,
-/area/meatstation/dorm)
 "na" = (
 /obj/item/stack/material/wood/ebony/twentyfive,
-/turf/space,
-/area/space)
-"nb" = (
-/obj/item/stack/material/mhydrogen/ten,
 /turf/space,
 /area/space)
 "nc" = (
@@ -5856,10 +5799,6 @@
 /obj/item/stack/material/wood,
 /turf/simulated/floor/tiled/monotile,
 /area/meatstation/hydroponics)
-"oo" = (
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/white,
-/area/meatstation/lab)
 "op" = (
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/dark,
@@ -6028,10 +5967,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/meatstation/dorm)
-"oN" = (
-/obj/item/book/manual/robotics_cyborgs,
-/turf/space,
-/area/space)
 "oO" = (
 /obj/item/book/manual/medical_diagnostics_manual,
 /turf/space,
@@ -6064,7 +5999,6 @@
 /turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "oV" = (
-/obj/random/single/meatstation/low/wormscientist,
 /obj/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
@@ -6160,20 +6094,8 @@
 	},
 /turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
-"pi" = (
-/obj/item/extinguisher,
-/turf/space,
-/area/space)
-"pk" = (
-/obj/item/evidencebag,
-/turf/space,
-/area/space)
 "pl" = (
 /obj/item/flame/lighter/random,
-/turf/space,
-/area/space)
-"pm" = (
-/obj/item/flame/lighter/green,
 /turf/space,
 /area/space)
 "pn" = (
@@ -6187,10 +6109,6 @@
 /obj/random/closet,
 /turf/space,
 /area/space)
-"pp" = (
-/obj/random/firstaid,
-/turf/space,
-/area/space)
 "pq" = (
 /obj/floor_decal/corner/brown/border{
 	dir = 1
@@ -6199,10 +6117,6 @@
 /area/meatstation/cargo)
 "pr" = (
 /obj/random/tech_supply,
-/turf/space,
-/area/space)
-"ps" = (
-/obj/random/technology_scanner,
 /turf/space,
 /area/space)
 "pt" = (
@@ -6407,10 +6321,6 @@
 /obj/item/storage/box/canned_tomato,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
-"pV" = (
-/obj/item/storage/box/canned_beef,
-/turf/space,
-/area/space)
 "pW" = (
 /obj/item/storage/box/canned_spinach,
 /turf/simulated/floor,
@@ -6425,10 +6335,6 @@
 /obj/structure/disposaloutlet,
 /turf/simulated/floor/plating,
 /area/meatstation/storage)
-"pY" = (
-/obj/item/storage/box/canned_spinach,
-/turf/space,
-/area/space)
 "pZ" = (
 /obj/machinery/recharger/wallcharger{
 	dir = 4;
@@ -6449,10 +6355,6 @@
 /obj/item/storage/box/glowsticks,
 /turf/simulated/floor,
 /area/meatstation/cargo)
-"qc" = (
-/obj/item/storage/box/glowsticks,
-/turf/space,
-/area/space)
 "qd" = (
 /obj/item/storage/box/detergent,
 /turf/simulated/floor,
@@ -6524,10 +6426,6 @@
 /obj/item/tape_roll,
 /turf/simulated/floor/lino,
 /area/meatstation/mess)
-"qn" = (
-/obj/item/surgicaldrill,
-/turf/space,
-/area/space)
 "qo" = (
 /obj/item/towel/random,
 /turf/simulated/floor/tiled/dark,
@@ -7114,20 +7012,6 @@
 /obj/random/junk,
 /turf/simulated/floor/reinforced,
 /area/meatstation/lab)
-"rF" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/white,
-/area/meatstation/lab)
 "rG" = (
 /obj/item/paper,
 /obj/floor_decal/corner/red/border,
@@ -7154,21 +7038,6 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
-"rI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/white,
-/area/meatstation/lab)
 "rJ" = (
 /obj/floor_decal/corner/black/border{
 	dir = 6
@@ -7252,16 +7121,8 @@
 /obj/shuttle_landmark/nav_meatstation/nav1,
 /turf/space,
 /area/space)
-"rT" = (
-/obj/shuttle_landmark/nav_meatstation/nav5,
-/turf/space,
-/area/space)
 "rU" = (
 /obj/shuttle_landmark/nav_meatstation/nav2,
-/turf/space,
-/area/space)
-"rV" = (
-/obj/shuttle_landmark/nav_meatstation/nav4,
 /turf/space,
 /area/space)
 "rW" = (
@@ -7391,11 +7252,6 @@
 /obj/decal/cleanable/blood,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/reinforced,
-/area/meatstation/lab)
-"sq" = (
-/obj/decal/cleanable/blood,
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/white,
 /area/meatstation/lab)
 "sr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7542,11 +7398,6 @@
 /obj/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/medical)
-"sG" = (
-/obj/decal/cleanable/dirt,
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/reinforced,
-/area/meatstation/lab)
 "sH" = (
 /obj/random/trash,
 /obj/decal/cleanable/blood,
@@ -7617,10 +7468,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
-"sO" = (
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor,
-/area/meatstation/dorm)
 "sP" = (
 /obj/structure/closet/firecloset,
 /obj/floor_decal/corner/black/border{
@@ -7690,10 +7537,6 @@
 /obj/decal/cleanable/blood/drip,
 /turf/simulated/floor/tiled/white,
 /area/meatstation/bathroom)
-"sZ" = (
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/lino,
-/area/meatstation/mess)
 "ta" = (
 /obj/random/single/meatstation/meatworm,
 /turf/simulated/floor/tiled/white,
@@ -7900,24 +7743,8 @@
 	},
 /turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
-"tx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled,
-/area/meatstation/centerhallway)
 "ty" = (
 /obj/structure/bed/chair/office/comfy/black,
-/obj/random/single/meatstation/low/wormscientist,
 /turf/simulated/floor/carpet/red,
 /area/meatstation/cargooffice)
 "tz" = (
@@ -7932,24 +7759,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/random/single/meatstation/low/wormscientist,
 /obj/decal/cleanable/blood/drip,
 /obj/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/meatstation/lab)
-"tA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/white,
-/area/meatstation/centerhallway)
 "tB" = (
 /obj/structure/hygiene/shower{
 	dir = 1
@@ -7960,16 +7773,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/meatstation/centerhallway)
-"tC" = (
-/obj/decal/cleanable/blood/drip,
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/dark,
-/area/meatstation/cargo)
-"tD" = (
-/obj/random/junk,
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/meatstation/storage)
 "tE" = (
 /obj/item/remains/human,
 /turf/simulated/floor/tiled,
@@ -8111,7 +7914,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/random/single/meatstation/low/wormscientist,
 /obj/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/armory)
@@ -8173,10 +7975,6 @@
 /obj/floor_decal/corner/grey/border,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/armory)
-"ua" = (
-/obj/random/single/meatstation/low/biocell,
-/turf/space,
-/area/space)
 "ub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -8286,10 +8084,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
-"uo" = (
-/obj/item/clothing/accessory/badge/press,
-/turf/space,
-/area/space)
 "up" = (
 /obj/structure/table/rack,
 /obj/random/voidhelmet,
@@ -8328,10 +8122,6 @@
 /obj/random/single/meatstation/meatworm,
 /turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
-"uu" = (
-/obj/item/clothing/under/wetsuit,
-/turf/space,
-/area/space)
 "uv" = (
 /obj/machinery/recharger/wallcharger{
 	dir = 1;
@@ -8571,7 +8361,6 @@
 	dir = 1;
 	level = 2
 	},
-/obj/random/single/meatstation/low/wormscientist,
 /obj/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
 /area/meatstation/centerhallway)
@@ -8732,11 +8521,6 @@
 /obj/random/single/meatstation/meatworm,
 /obj/decal/cleanable/blood/drip,
 /turf/simulated/floor/reinforced,
-/area/meatstation/lab)
-"vm" = (
-/obj/random/single/meatstation/low/wormscientist,
-/obj/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/white,
 /area/meatstation/lab)
 "vn" = (
 /obj/machinery/light/small/red{
@@ -8958,15 +8742,7 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/meatstation/storage)
-"vN" = (
-/obj/random/single/meatstation/low/wormscientist,
-/obj/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/turf/simulated/floor/lino,
-/area/meatstation/mess)
 "vO" = (
-/obj/random/single/meatstation/low/wormscientist,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -9830,7 +9606,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/random/single/meatstation/low/wormscientist,
 /obj/floor_decal/corner/black/bordercorner{
 	dir = 1
 	},
@@ -9844,13 +9619,6 @@
 /area/meatstation/centerhallway)
 "yf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/floor_decal/corner/black/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/meatstation/centerhallway)
-"yg" = (
-/obj/random/single/meatstation/low/wormscientist,
 /obj/floor_decal/corner/black/border{
 	dir = 1
 	},
@@ -10599,21 +10367,6 @@
 	pixel_y = -24
 	},
 /obj/floor_decal/corner/red/border,
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/white,
-/area/meatstation/lab)
-"zU" = (
-/obj/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/white,
-/area/meatstation/lab)
-"zV" = (
-/obj/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/random/single/meatstation/low/wormscientist,
 /turf/simulated/floor/tiled/white,
 /area/meatstation/lab)
 "zW" = (
@@ -11640,7 +11393,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -13698,7 +13451,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -14092,7 +13845,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -14670,7 +14423,6 @@ aa
 aa
 aa
 aa
-po
 aa
 aa
 aa
@@ -14682,7 +14434,8 @@ aa
 aa
 aa
 aa
-jB
+aa
+aa
 aa
 aa
 aa
@@ -14870,7 +14623,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -15285,7 +15038,7 @@ aa
 aa
 aa
 aa
-pl
+aa
 aa
 aa
 aa
@@ -15455,7 +15208,6 @@ aa
 aa
 aa
 aa
-rT
 aa
 aa
 aa
@@ -15482,7 +15234,8 @@ aa
 aa
 aa
 aa
-nO
+aa
+aa
 aa
 aa
 aa
@@ -16106,7 +15859,6 @@ aa
 aa
 aa
 aa
-pm
 aa
 aa
 aa
@@ -16115,7 +15867,8 @@ aa
 aa
 aa
 aa
-nO
+aa
+aa
 aa
 aa
 aa
@@ -16341,7 +16094,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -16905,7 +16658,7 @@ aa
 aa
 aa
 aa
-po
+aa
 aa
 aa
 aa
@@ -17099,7 +16852,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -17722,7 +17475,6 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
@@ -17735,7 +17487,8 @@ aa
 aa
 aa
 aa
-jB
+aa
+aa
 aa
 aa
 aa
@@ -17902,7 +17655,6 @@ aa
 aa
 aa
 aa
-qn
 aa
 aa
 aa
@@ -17921,7 +17673,8 @@ aa
 aa
 aa
 aa
-nO
+aa
+aa
 aa
 aa
 aa
@@ -18108,7 +17861,7 @@ aa
 aa
 aa
 aa
-pk
+aa
 aa
 aa
 aa
@@ -18327,13 +18080,13 @@ aa
 aa
 aa
 aa
-ps
 aa
 aa
 aa
 aa
 aa
-nJ
+aa
+aa
 aa
 aa
 aa
@@ -18520,7 +18273,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -18725,7 +18478,6 @@ aa
 aa
 aa
 aa
-pr
 aa
 aa
 aa
@@ -18734,14 +18486,15 @@ aa
 aa
 aa
 aa
-mw
 aa
 aa
 aa
 aa
 aa
 aa
-nO
+aa
+aa
+aa
 aa
 aa
 aa
@@ -18910,7 +18663,7 @@ aa
 aa
 aa
 aa
-nO
+aa
 aa
 aa
 aa
@@ -19160,7 +18913,7 @@ aa
 aa
 aa
 aa
-rV
+aa
 aa
 aa
 aa
@@ -19529,17 +19282,17 @@ aa
 aa
 aa
 aa
-nO
 aa
 aa
 aa
 aa
 aa
 aa
-jB
 aa
 aa
-pp
+aa
+aa
+aa
 aa
 aa
 aa
@@ -19737,14 +19490,14 @@ aa
 aa
 aa
 aa
-pi
 aa
 aa
 aa
 aa
 aa
 aa
-jB
+aa
+aa
 aa
 aa
 aa
@@ -19941,7 +19694,7 @@ aa
 aa
 aa
 aa
-mw
+aa
 aa
 aa
 aa
@@ -20139,7 +19892,7 @@ aa
 aa
 aa
 aa
-ps
+aa
 aa
 aa
 aa
@@ -20328,7 +20081,6 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
@@ -20352,7 +20104,8 @@ aa
 aa
 aa
 aa
-lY
+aa
+aa
 aa
 aa
 aa
@@ -20519,7 +20272,6 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
@@ -20548,8 +20300,6 @@ aa
 aa
 aa
 aa
-qc
-jB
 aa
 aa
 aa
@@ -20559,7 +20309,10 @@ aa
 aa
 aa
 aa
-jB
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -20749,9 +20502,6 @@ aa
 aa
 aa
 aa
-pr
-aa
-po
 aa
 aa
 aa
@@ -20760,7 +20510,10 @@ aa
 aa
 aa
 aa
-nO
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -20946,7 +20699,7 @@ aa
 aa
 aa
 aa
-lY
+aa
 aa
 aa
 aa
@@ -21157,7 +20910,6 @@ aa
 aa
 aa
 aa
-qj
 aa
 aa
 aa
@@ -21170,7 +20922,8 @@ aa
 aa
 aa
 aa
-jB
+aa
+aa
 aa
 aa
 aa
@@ -21348,21 +21101,21 @@ aa
 aa
 aa
 aa
-uo
-aa
-pk
 aa
 aa
 aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
 aa
-jB
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -21547,7 +21300,6 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
@@ -21556,7 +21308,8 @@ aa
 aa
 aa
 aa
-jB
+aa
+aa
 aa
 aa
 aa
@@ -21740,7 +21493,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -21763,7 +21516,7 @@ aa
 aa
 aa
 aa
-nO
+aa
 aa
 aa
 aa
@@ -21927,6 +21680,36 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 jB
 aa
 aa
@@ -21939,36 +21722,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-jB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-qv
 aa
 aa
 aa
@@ -22164,9 +21917,9 @@ aa
 aa
 aa
 aa
-lY
 aa
-lk
+aa
+aa
 aa
 aa
 aa
@@ -22378,7 +22131,7 @@ aa
 aa
 aa
 aa
-lY
+aa
 aa
 aa
 aa
@@ -22574,7 +22327,7 @@ aa
 qx
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -22779,7 +22532,7 @@ aa
 aa
 aa
 aa
-uu
+aa
 aa
 aa
 aa
@@ -22982,7 +22735,7 @@ aa
 aa
 aa
 aa
-po
+aa
 aa
 aa
 aa
@@ -23398,7 +23151,7 @@ aa
 aa
 aa
 aa
-nO
+aa
 aa
 aa
 aa
@@ -24212,7 +23965,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -24399,7 +24152,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -25540,7 +25293,7 @@ aa
 aa
 aa
 aa
-lY
+aa
 aa
 aa
 aa
@@ -25996,7 +25749,7 @@ cK
 cK
 cc
 cK
-tC
+tP
 cK
 cK
 cK
@@ -26931,7 +26684,6 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
@@ -26946,7 +26698,8 @@ aa
 aa
 aa
 aa
-jB
+aa
+aa
 aa
 aa
 aa
@@ -27366,7 +27119,7 @@ aa
 aa
 aa
 aa
-nO
+aa
 aa
 aa
 aa
@@ -27562,7 +27315,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -27804,7 +27557,7 @@ dM
 tv
 tv
 dD
-dP
+tv
 tv
 eU
 tv
@@ -27813,7 +27566,7 @@ fB
 tv
 ch
 bh
-dP
+tv
 dD
 se
 sN
@@ -27823,7 +27576,7 @@ tW
 tv
 tv
 tv
-dP
+tv
 dM
 ux
 tv
@@ -28154,7 +27907,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -28979,10 +28732,10 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
-nO
+aa
+aa
 aa
 aa
 aa
@@ -29024,7 +28777,7 @@ wg
 zh
 ac
 db
-rI
+dm
 rB
 ac
 eT
@@ -29188,7 +28941,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -29384,7 +29137,6 @@ aa
 aa
 aa
 aa
-bt
 aa
 aa
 aa
@@ -29393,7 +29145,8 @@ aa
 aa
 aa
 aa
-lY
+aa
+aa
 aa
 aa
 aa
@@ -29591,7 +29344,7 @@ aa
 aa
 aa
 aa
-mw
+aa
 aa
 aa
 aa
@@ -29794,9 +29547,9 @@ aa
 aa
 aa
 aa
-jB
 aa
-nb
+aa
+aa
 aa
 aa
 aa
@@ -29970,7 +29723,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -30165,7 +29918,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -30394,13 +30147,13 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
 aa
 aa
-gN
+aa
+aa
 aa
 aa
 aa
@@ -30421,7 +30174,7 @@ be
 be
 be
 ah
-yg
+yb
 bh
 yr
 ah
@@ -30597,15 +30350,15 @@ aa
 aa
 aa
 aa
-lY
-jB
-aa
-hd
 aa
 aa
 aa
 aa
-jB
+aa
+aa
+aa
+aa
+aa
 aa
 he
 aa
@@ -30640,7 +30393,7 @@ wj
 hm
 fv
 uB
-rI
+dm
 bD
 wJ
 hm
@@ -30837,7 +30590,7 @@ hn
 lj
 gO
 kd
-rF
+kd
 kf
 wk
 fE
@@ -30984,7 +30737,7 @@ aa
 aa
 aa
 aa
-lY
+aa
 aa
 aa
 aa
@@ -31202,14 +30955,14 @@ aa
 aa
 aa
 aa
-bo
 aa
 aa
 aa
 aa
-aR
 aa
-bt
+aa
+aa
+aa
 aa
 aa
 jB
@@ -31245,7 +30998,7 @@ bD
 rG
 ac
 eA
-oo
+bD
 qr
 bD
 ku
@@ -31254,7 +31007,7 @@ wu
 lm
 hp
 mf
-vm
+ve
 wp
 ac
 aa
@@ -31367,7 +31120,6 @@ aa
 aa
 aa
 aa
-lY
 aa
 aa
 aa
@@ -31389,7 +31141,8 @@ aa
 aa
 aa
 aa
-jB
+aa
+aa
 aa
 aa
 aa
@@ -31609,11 +31362,11 @@ aa
 aa
 aa
 aa
-lY
 aa
 aa
 aa
-jB
+aa
+aa
 aa
 aa
 aa
@@ -31800,7 +31553,7 @@ aa
 aa
 ag
 fc
-bP
+oc
 aa
 ag
 ag
@@ -31809,12 +31562,12 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
 aa
-oN
+aa
+aa
 aa
 aa
 aa
@@ -31835,7 +31588,7 @@ bs
 ah
 ah
 ah
-yg
+yb
 bh
 yr
 ah
@@ -31853,10 +31606,10 @@ ac
 kt
 bD
 dm
-sq
+uB
 kw
 ac
-zV
+wu
 bD
 hq
 kv
@@ -32192,7 +31945,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -32591,7 +32344,6 @@ aa
 aa
 aa
 aa
-lY
 aa
 aa
 aa
@@ -32615,9 +32367,10 @@ aa
 aa
 aa
 aa
-ua
 aa
-jB
+aa
+aa
+aa
 aa
 aa
 aa
@@ -32659,7 +32412,7 @@ ko
 ac
 ac
 wy
-zU
+wo
 tz
 wA
 wD
@@ -32779,7 +32532,6 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
@@ -32813,10 +32565,11 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
-bt
+aa
+aa
+aa
 aa
 aa
 aa
@@ -33023,7 +32776,7 @@ aa
 aa
 aa
 aa
-aR
+aa
 aa
 aa
 aa
@@ -33250,7 +33003,7 @@ jB
 aa
 ah
 yb
-tx
+bh
 yr
 aW
 aa
@@ -33403,7 +33156,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -33476,7 +33229,7 @@ bC
 sl
 eI
 rP
-sG
+eI
 zj
 bx
 aa
@@ -33605,7 +33358,6 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
@@ -33622,14 +33374,15 @@ aa
 aa
 aa
 aa
-lY
 aa
 aa
 aa
 aa
 aa
 aa
-lQ
+aa
+aa
+aa
 aa
 aa
 au
@@ -33825,7 +33578,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -33839,7 +33592,7 @@ ax
 az
 au
 lK
-sO
+au
 az
 az
 dJ
@@ -33872,7 +33625,7 @@ bC
 zi
 ac
 wu
-rI
+dm
 rB
 ac
 sg
@@ -33994,7 +33747,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -34249,7 +34002,7 @@ cb
 fu
 kV
 lF
-mZ
+az
 az
 ia
 jE
@@ -34680,7 +34433,7 @@ aa
 aa
 bB
 ds
-tA
+cV
 zc
 bB
 aa
@@ -35237,7 +34990,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -35281,7 +35034,7 @@ we
 eL
 we
 gd
-hw
+we
 ym
 we
 we
@@ -36122,7 +35875,7 @@ ec
 gK
 ec
 tQ
-tD
+oi
 rq
 xu
 aP
@@ -36698,7 +36451,7 @@ cD
 mc
 qJ
 qJ
-sZ
+cD
 xD
 dy
 aa
@@ -37061,7 +36814,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -37271,7 +37024,7 @@ aa
 bs
 bs
 vy
-ma
+aE
 lW
 aE
 du
@@ -37703,7 +37456,7 @@ kM
 kM
 fw
 kM
-vN
+kM
 vP
 uS
 la
@@ -38471,7 +38224,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -39735,13 +39488,13 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
 aa
 aa
-nO
+aa
+aa
 aa
 aa
 aa
@@ -39934,11 +39687,11 @@ aa
 aa
 aa
 aa
-iY
 aa
 aa
 aa
-iA
+aa
+aa
 aa
 aa
 aa
@@ -40136,7 +39889,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -40337,7 +40090,6 @@ aa
 aa
 aa
 aa
-bt
 aa
 aa
 aa
@@ -40348,7 +40100,8 @@ aa
 aa
 aa
 aa
-iI
+aa
+aa
 bt
 aa
 aa
@@ -40545,10 +40298,10 @@ aa
 aa
 aa
 aa
-pV
 aa
 aa
-lY
+aa
+aa
 aa
 aa
 aa
@@ -40739,7 +40492,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -40949,7 +40702,7 @@ aa
 aa
 aa
 aa
-iz
+aa
 aa
 aa
 aa
@@ -41350,12 +41103,12 @@ aa
 aa
 aa
 aa
-qA
 aa
 aa
 aa
 aa
-pY
+aa
+aa
 aa
 aa
 aa
@@ -41749,7 +41502,7 @@ aa
 aa
 aa
 aa
-lY
+aa
 aa
 aa
 aa
@@ -42158,7 +41911,7 @@ aa
 aa
 aa
 aa
-jB
+aa
 aa
 aa
 aa
@@ -42348,7 +42101,6 @@ aa
 aa
 aa
 aa
-jB
 aa
 aa
 aa
@@ -42367,7 +42119,8 @@ aa
 aa
 aa
 aa
-kR
+aa
+aa
 aa
 aa
 aa
@@ -42570,7 +42323,7 @@ aa
 aa
 aa
 aa
-bt
+aa
 aa
 aa
 aa
@@ -43163,7 +42916,6 @@ aa
 aa
 aa
 aa
-bt
 aa
 aa
 aa
@@ -43171,7 +42923,8 @@ aa
 aa
 aa
 aa
-jB
+aa
+aa
 aa
 aa
 aa
@@ -43361,7 +43114,7 @@ aa
 aa
 aa
 aa
-bt
+aa
 aa
 aa
 aa
@@ -44185,7 +43938,7 @@ aa
 aa
 aa
 aa
-lY
+aa
 aa
 aa
 aa
@@ -44375,7 +44128,7 @@ aa
 aa
 aa
 aa
-lY
+aa
 aa
 aa
 aa

--- a/maps/torch/job/outfits/command_outfits.dm
+++ b/maps/torch/job/outfits/command_outfits.dm
@@ -2,7 +2,7 @@
 	name = OUTFIT_JOB_NAME("Torch Command Outfit")
 	hierarchy_type = /singleton/hierarchy/outfit/job/torch/crew/command
 	l_ear = /obj/item/device/radio/headset/headset_com
-	l_pocket = /obj/item/device/flashlight/maglight
+	l_pocket = /obj/item/device/flashlight/lantern
 
 /singleton/hierarchy/outfit/job/torch/crew/command/roguetrader
 	name = OUTFIT_JOB_NAME("Rogue Trader")
@@ -59,7 +59,7 @@
 	id_types = list(/obj/item/card/id/torch/silver/kroot)
 	pda_type = /obj/item/modular_computer/pda/heads
 	back = /obj/item/storage/backpack/satchel/explorer
-	l_pocket = /obj/item/device/flashlight/maglight
+	l_pocket = /obj/item/device/flashlight/lantern
 	backpack_contents = list(/obj/item/pen/fancy/quill = 1, /obj/item/material/twohanded/ravenor/knife/trench = 1, /obj/item/gun/projectile/pistol/slug/old = 1, /obj/item/ammo_magazine/speedloader/clip/sniper/xenos = 4)
 
 /singleton/hierarchy/outfit/job/torch/crew/command/biologis

--- a/maps/torch/job/outfits/security_outfits.dm
+++ b/maps/torch/job/outfits/security_outfits.dm
@@ -2,7 +2,7 @@
 	hierarchy_type = /singleton/hierarchy/outfit/job/torch/crew/security
 	l_ear = /obj/item/device/radio/headset/headset_sec
 	pda_slot = slot_l_store
-	l_pocket = /obj/item/device/flashlight/maglight
+	l_pocket = /obj/item/device/flashlight/lantern
 
 /singleton/hierarchy/outfit/job/torch/crew/security/deck_sergeant
 	name = OUTFIT_JOB_NAME("Enforcer Sergeant")

--- a/maps/torch/job/outfits/torch_outfits.dm
+++ b/maps/torch/job/outfits/torch_outfits.dm
@@ -8,7 +8,7 @@
 /singleton/hierarchy/outfit/job/torch/crew
 	name = OUTFIT_JOB_NAME("Dauntless Crew Outfit")
 	hierarchy_type = /singleton/hierarchy/outfit/job/torch/crew
-	l_pocket = /obj/item/device/flashlight/maglight
+	l_pocket = /obj/item/device/flashlight/lantern
 
 /singleton/hierarchy/outfit/job/torch/crew/fleet
 	name = OUTFIT_JOB_NAME("Dauntless Imperial Navy Outfit")

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -2358,6 +2358,16 @@
 /obj/paint/sfv_arbiter,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/power)
+"fw" = (
+/obj/paint/meatstation,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "petrov_shuttle_sensor";
+	pixel_x = -8;
+	pixel_y = -9
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/hallwaya)
 "fx" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -5167,6 +5177,17 @@
 /obj/machinery/oxygen_pump{
 	pixel_y = 32
 	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 4;
+	display_name = "Aft Dock (Petrov)";
+	frequency = 1380;
+	id_tag = "petrov_shuttle_dock_airlock";
+	pixel_x = -24;
+	tag_airpump = "petrov_shuttle_dock_pump";
+	tag_chamber_sensor = "petrov_shuttle_dock_sensor";
+	tag_exterior_door = "petrov_shuttle_dock_outer";
+	tag_interior_door = "petrov_shuttle_dock_inner"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "mw" = (
@@ -6604,11 +6625,6 @@
 	},
 /obj/floor_decal/techfloor{
 	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22;
-	pixel_y = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -12894,6 +12910,17 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	display_name = "Aft Dock (Petrov)";
+	frequency = 1380;
+	id_tag = "petrov_shuttle_airlock";
+	pixel_x = 24;
+	tag_airpump = "petrov_shuttle_dock_pump";
+	tag_chamber_sensor = "petrov_shuttle_dock_sensor";
+	tag_exterior_door = "petrov_shuttle_dock_outer";
+	tag_interior_door = "petrov_shuttle_dock_inner"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/hallwaya)
 "Jx" = (
@@ -14415,10 +14442,10 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/shuttle/petrov/isolation)
 "Pt" = (
+/obj/paint/meatstation,
 /obj/structure/sign/warning/airlock{
 	dir = 8
 	},
-/obj/paint/meatstation,
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/hallwaya)
 "Px" = (
@@ -15735,7 +15762,6 @@
 /turf/simulated/floor/warhammer/plating,
 /area/shuttle/petrov/hallwaya)
 "UU" = (
-/obj/structure/ladder/up,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
@@ -40731,7 +40757,7 @@ bP
 bP
 aa
 Al
-Al
+fw
 ML
 Tr
 Al
@@ -40936,7 +40962,7 @@ Al
 Va
 Gh
 Zw
-Al
+Pt
 aa
 xh
 FX
@@ -41138,7 +41164,7 @@ Al
 Jv
 yL
 Zc
-Al
+Pt
 Jk
 xh
 Wp
@@ -41337,7 +41363,7 @@ HJ
 Uy
 NO
 Al
-Pt
+Al
 Hf
 Bf
 Al

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -296,7 +296,7 @@
 	tag_exterior_door = "admin_shuttle_dock_outer";
 	tag_interior_door = "admin_shuttle_dock_inner"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "bm" = (
 /obj/machinery/door/firedoor,
@@ -361,12 +361,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/warhammer/ceramic/old,
 /area/crew_quarters/galley)
-"bx" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/warhammer/plating,
-/area/hallway/primary/fourthdeck/aft)
 "by" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1348,7 +1342,7 @@
 	dir = 8;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "eY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1360,7 +1354,7 @@
 	},
 /obj/floor_decal/industrial/warning/corner,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "fa" = (
 /obj/structure/bookcase,
@@ -1428,9 +1422,6 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod6/station)
 "fs" = (
@@ -1466,9 +1457,6 @@
 	icon_state = "warning"
 	},
 /obj/structure/table/steel,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/random/firstaid,
 /turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod7/station)
@@ -1567,7 +1555,7 @@
 	tag_door = "escape_pod_7_berth_hatch"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "fV" = (
 /obj/structure/bed/chair/warhammer/wood/fancy/comfy1{
@@ -1766,7 +1754,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "gM" = (
 /turf/simulated/floor/warhammer/metal/alt,
@@ -2745,6 +2733,7 @@
 	dir = 4
 	},
 /obj/structure/closet/warhammer/emcloset,
+/obj/random/loot/randomsupply,
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/fore)
 "mf" = (
@@ -2964,12 +2953,6 @@
 	},
 /turf/simulated/floor/warhammer/tunnelchess,
 /area/maintenance/fourthdeck/starboard)
-"mQ" = (
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
 "mR" = (
 /obj/floor_decal/industrial/warning{
 	dir = 5
@@ -3485,13 +3468,6 @@
 	map_airless = 1
 	},
 /area/maintenance/fourthdeck/aft)
-"pu" = (
-/obj/floor_decal/corner/green/three_quarters,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "px" = (
 /obj/floor_decal/industrial/warning{
 	dir = 1;
@@ -3740,14 +3716,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/eva)
-"qV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/simulated/floor/warhammer/plating,
-/area/hallway/primary/fourthdeck/fore)
 "ra" = (
 /obj/structure/table/steel,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4371,7 +4339,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
@@ -5120,6 +5087,7 @@
 /obj/structure/closet/warhammer/luxury,
 /obj/item/archaeological_find/tank,
 /obj/item/archaeological_find/robes,
+/obj/random/loot/armorinserts,
 /turf/simulated/floor/warhammer/ceramic/old,
 /area/crew_quarters/galley)
 "vH" = (
@@ -5556,7 +5524,7 @@
 	c_tag = "Fourth Deck Hallway - Aft Starboard";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "xH" = (
 /obj/structure/table/warhammer/polished_table,
@@ -5647,19 +5615,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
-"xT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -6014,7 +5969,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "zr" = (
 /obj/structure/cable/green{
@@ -6175,12 +6130,10 @@
 /turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod9/station)
 "Ab" = (
-/obj/structure/ladder,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "Ad" = (
@@ -6300,12 +6253,6 @@
 	},
 /turf/simulated/floor/warhammer/ceramic/old,
 /area/crew_quarters/galley)
-"AB" = (
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "AC" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -6661,6 +6608,7 @@
 	name = "Room Key #3";
 	access = list("ACCESS_TAVERN3")
 	},
+/obj/random/loot/basicarmorbundle,
 /turf/simulated/floor/warhammer/ceramic/old,
 /area/crew_quarters/galley)
 "Cy" = (
@@ -6831,7 +6779,9 @@
 /turf/space,
 /area/space)
 "Dr" = (
-/obj/machinery/computer/modular/preset/merchant,
+/obj/machinery/computer/modular/preset/merchant{
+	req_access = list("ACCESS_MECHANICUS")
+	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "Ds" = (
@@ -6880,7 +6830,7 @@
 	c_tag = "Fourth Deck - Aft Starboard Airlock";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "DN" = (
 /obj/structure/table/warhammer/big_wood_table{
@@ -7011,7 +6961,6 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
 "En" = (
-/obj/floor_decal/corner/green/mono,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -7020,7 +6969,7 @@
 	dir = 8;
 	pixel_x = 40
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "Ep" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7219,9 +7168,6 @@
 "Fk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
 	},
 /obj/machinery/light{
 	dir = 8
@@ -7489,9 +7435,6 @@
 /area/maintenance/fourthdeck/foreport)
 "Gh" = (
 /obj/floor_decal/industrial/warning,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod8/station)
 "Gi" = (
@@ -7535,9 +7478,6 @@
 /area/shuttle/escape_pod9/station)
 "Go" = (
 /obj/floor_decal/industrial/warning,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/simulated/floor/warhammer/splate,
 /area/shuttle/escape_pod9/station)
 "Gp" = (
@@ -8327,7 +8267,6 @@
 /turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/aft)
 "Jj" = (
-/obj/structure/ladder/up,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
@@ -8390,15 +8329,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "Jx" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/sign/warning/docking_area{
-	name = "\improper ESCAPE POD LAUNCH PATHWAY";
-	pixel_x = -32
+/obj/structure/sign/pelt/two{
+	pixel_y = -12
 	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/turf/simulated/floor/warhammer/darkwood,
+/area/crew_quarters/galleybackroom)
 "JA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -8566,6 +8504,7 @@
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
+/obj/random/loot/randomsupply/tech,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/port)
 "Kd" = (
@@ -8611,10 +8550,6 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 8
-	},
-/obj/structure/closet/warhammer/emcloset,
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
@@ -9087,9 +9022,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -9097,7 +9029,7 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "LV" = (
 /turf/simulated/wall/prepainted,
@@ -9188,7 +9120,10 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/crew_quarters/lounge)
 "Mv" = (
-/obj/machinery/atmospherics/valve/shutoff/supply{
+/obj/structure/torchwall{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/warhammer/darkwood,
@@ -9731,9 +9666,6 @@
 /obj/machinery/computer/modular/preset/civilian{
 	dir = 8;
 	icon_state = "console"
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
 	},
 /obj/item/clothing/suit/armor/grim/toggle/agent_jacket,
 /turf/simulated/floor/warhammer/coralg,
@@ -10305,13 +10237,6 @@
 /obj/machinery/light,
 /turf/simulated/open,
 /area/quartermaster/hangar/catwalks_port)
-"Qj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/warhammer/darkwood,
-/area/crew_quarters/galleybackroom)
 "Qn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -10609,9 +10534,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "Ro" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/structure/closet/crate/secure/biohazard,
 /turf/simulated/floor/warhammer/tunnelchess,
 /area/crew_quarters/laundry)
@@ -10644,9 +10566,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
 	},
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/fore)
@@ -10934,6 +10853,7 @@
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
+/obj/random/loot/randomsupply/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "Sq" = (
@@ -11696,13 +11616,6 @@
 /obj/item/pen,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
-"UJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/warhammer/darkwood,
-/area/crew_quarters/galleybackroom)
 "UL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -11767,7 +11680,7 @@
 	dir = 8;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "US" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{
@@ -11783,7 +11696,7 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/fourthdeck/aft)
 "UT" = (
 /obj/floor_decal/industrial/warning{
@@ -12004,12 +11917,6 @@
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
-"VD" = (
-/obj/machinery/atmospherics/valve/shutoff/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/warhammer/darkwood,
-/area/crew_quarters/galleybackroom)
 "VF" = (
 /obj/floor_decal/industrial/warning{
 	dir = 1;
@@ -12435,9 +12342,12 @@
 /turf/simulated/floor/warhammer/ceramic,
 /area/quartermaster/deckchief)
 "WX" = (
-/obj/floor_decal/corner/green/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/obj/floor_decal/spline/fancy/wood,
+/obj/structure/torchwall{
+	dir = 4
+	},
+/turf/simulated/floor/warhammer/darkwood,
+/area/crew_quarters/galleybackroom)
 "WY" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -12961,7 +12871,6 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/obj/structure/torchwall,
 /turf/simulated/floor/plating,
 /area/maintenance/waterstore)
 "YD" = (
@@ -13057,9 +12966,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/galleybackroom)
-"YR" = (
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "YS" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -13372,6 +13278,7 @@
 	name = "Room Key #4";
 	access = list("ACCESS_TAVERN4")
 	},
+/obj/random/loot/heavymelee,
 /turf/simulated/floor/warhammer/ceramic/old,
 /area/crew_quarters/galley)
 "ZE" = (
@@ -13443,12 +13350,6 @@
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/quartermaster/office)
-"ZP" = (
-/obj/machinery/oxygen_pump{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "ZQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -24117,7 +24018,7 @@ nl
 WH
 WH
 WH
-qV
+nt
 sq
 tU
 vn
@@ -24526,7 +24427,7 @@ dg
 dg
 dg
 dg
-xT
+nm
 Pz
 AH
 BK
@@ -28754,7 +28655,7 @@ KP
 Ts
 DN
 at
-OR
+WX
 sc
 aZ
 aZ
@@ -29157,7 +29058,7 @@ Xy
 Il
 bQ
 ZX
-jp
+Jx
 OR
 tx
 aZ
@@ -29560,8 +29461,8 @@ af
 Xy
 Il
 uY
-Qj
-UJ
+ZX
+jp
 OR
 tx
 aZ
@@ -29763,7 +29664,7 @@ Xy
 Il
 uY
 Mv
-VD
+jp
 OR
 Jc
 xc
@@ -36035,7 +35936,7 @@ rk
 rk
 rk
 rk
-bx
+CL
 MI
 WS
 vK
@@ -37634,23 +37535,23 @@ tG
 RR
 aJ
 bk
-Jx
-AB
-YR
-YR
-YR
+MW
+qc
+CL
+CL
+CL
 eX
 US
 LU
-YR
-YR
-ZP
+CL
+CL
+nv
 xF
-YR
-mQ
-YR
-pu
-WX
+CL
+qc
+CL
+Ym
+CL
 CL
 Ta
 uK

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -270,6 +270,7 @@
 "ba" = (
 /obj/structure/table/rack/dark,
 /obj/random/maintenance/solgov,
+/obj/random/loot/gunbundle,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "bb" = (
@@ -514,7 +515,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -522,6 +522,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/warhammer/command/ancient{
+	name = "Maintenance Access"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/thirddeck/aftstarboard)
@@ -1154,13 +1157,6 @@
 "dn" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftstarboard)
-"do" = (
-/obj/item/flame/candle{
-	pixel_x = -11;
-	pixel_y = 2
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "dr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -1298,8 +1294,8 @@
 /turf/simulated/floor/warhammer/metal,
 /area/crew_quarters/mess)
 "dM" = (
-/obj/machinery/suit_storage_unit/atmos/alt/sol,
 /obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/engineering/alt,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "dN" = (
@@ -2462,7 +2458,6 @@
 /obj/structure/table/rack/dark,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
-/obj/floor_decal/industrial/outline/yellow,
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -2627,10 +2622,12 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/warhammer/darkwood,
 /area/hydroponics)
 "hp" = (
-/obj/machinery/light/small,
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
@@ -3592,15 +3589,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
-"jO" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/bed/chair/warhammer/stoolw/wood{
-	color = null
-	},
-/turf/simulated/floor/warhammer/darkwood2,
-/area/crew_quarters/head/sauna)
 "jP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4107,7 +4095,6 @@
 /area/crew_quarters/mess)
 "lg" = (
 /obj/structure/closet/crate/internals/fuel,
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -4578,13 +4565,6 @@
 	},
 /turf/simulated/floor/warhammer/bar3,
 /area/crew_quarters/mess)
-"mB" = (
-/obj/structure/closet/coffin/wooden,
-/obj/structure/torchwall{
-	dir = 4
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "mF" = (
 /obj/structure/curtain/open{
 	color = "#5f82d8";
@@ -4752,6 +4732,9 @@
 /obj/item/device/boombox,
 /obj/item/device/cassette/sombre,
 /obj/item/device/cassette/western1,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/warhammer/darkwood,
 /area/hydroponics)
 "nq" = (
@@ -5053,12 +5036,10 @@
 /area/holocontrol)
 "on" = (
 /obj/structure/dispenser/oxygen,
-/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/engineering/hardstorage)
 "oo" = (
-/obj/machinery/suit_cycler/engineering/alt,
-/obj/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/dark,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/engineering/hardstorage)
 "op" = (
@@ -5250,10 +5231,6 @@
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/thirddeck/fore)
 "oX" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
 /obj/machinery/light/spot,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
@@ -5490,15 +5467,6 @@
 /obj/item/material/knife/folding/combat/switchblade,
 /turf/simulated/floor/warhammer/darkwood,
 /area/maintenance/thirddeck/starboard)
-"py" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/warhammer{
-	name = "Memorial Room"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/chapel/memorial)
 "pz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -5978,7 +5946,6 @@
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "rB" = (
@@ -5992,7 +5959,6 @@
 	dir = 4
 	},
 /obj/structure/table/rack/dark,
-/obj/floor_decal/industrial/outline/yellow,
 /obj/item/inflatable_dispenser,
 /obj/item/inflatable_dispenser,
 /obj/item/inflatable_dispenser,
@@ -6009,14 +5975,6 @@
 /obj/structure/grille,
 /turf/simulated/wall/r_wall/hull,
 /area/space)
-"rE" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/wall/prepainted,
-/area/chapel/memorial)
 "rG" = (
 /obj/structure/sign/warning/nosmoking_1{
 	dir = 4;
@@ -6030,10 +5988,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
 "rL" = (
-/obj/machinery/light/alien{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/floor/warhammer/tunnelchess,
 /area/crew_quarters/gym)
 "rM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6498,15 +6456,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/aft)
-"sH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "sI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -6792,12 +6741,6 @@
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d3port)
-"tL" = (
-/obj/machinery/light/alien{
-	dir = 1
-	},
-/turf/simulated/floor/warhammer/tunnelchess,
-/area/crew_quarters/gym)
 "tR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6906,11 +6849,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
-"uh" = (
-/obj/machinery/suit_storage_unit/engineering/alt/sol,
-/obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/hardstorage)
 "ui" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7142,10 +7080,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/disperser)
-"vi" = (
-/obj/structure/table/warhammer/rich_table,
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "vj" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 8;
@@ -7187,14 +7121,6 @@
 /obj/item/material/knife/kitchen/cleaver/bronze,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/crew_quarters/mess)
-"vo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/prepainted,
-/area/chapel/memorial)
 "vs" = (
 /obj/structure/closet/crate/warhammer/xenos/chest3,
 /obj/item/trash/warfare_can/flower,
@@ -7425,12 +7351,6 @@
 /obj/structure/barricade/sandbag,
 /turf/simulated/floor/warhammer/oldsmoothdirt,
 /area/crew_quarters/observation)
-"wp" = (
-/obj/structure/torchwall{
-	dir = 4
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "wq" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -7456,13 +7376,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
-"wr" = (
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/turf/simulated/wall/prepainted,
-/area/chapel/memorial)
 "wB" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -7501,12 +7414,6 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/crew_quarters/gym)
-"wK" = (
-/obj/structure/bed/chair/wood/wings/ebony{
-	dir = 4
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "wL" = (
 /obj/machinery/light{
 	dir = 1
@@ -7641,32 +7548,11 @@
 "xm" = (
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
-"xo" = (
-/obj/item/pyre/self_lit{
-	invisibility = 60;
-	name = "Invisible Light";
-	icon = 'icons/obj/candle.dmi';
-	icon_state = "candle1"
-	},
-/turf/simulated/wall/prepainted,
-/area/chapel/memorial)
-"xp" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "xr" = (
 /obj/structure/table/rack/dark,
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/forestarboard)
-"xu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "xv" = (
 /obj/floor_decal/techfloor{
 	dir = 4
@@ -7741,11 +7627,6 @@
 /obj/item/deck/tarot,
 /turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/mess)
-"xO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "xP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7802,7 +7683,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/ladder/up,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
@@ -7953,24 +7833,12 @@
 /turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "yp" = (
-/obj/structure/ladder,
-/obj/structure/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/thirddeck/center)
-"yq" = (
-/obj/structure/closet/coffin/wooden,
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
-"yr" = (
-/obj/structure/bed/chair/wood/wings/ebony{
-	dir = 8
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "yu" = (
 /obj/structure/barricade/sandbag,
 /turf/simulated/floor/warhammer/oldsmoothdirt,
@@ -8239,11 +8107,10 @@
 /turf/simulated/wall/r_wall/hull,
 /area/crew_quarters/cryolocker)
 "zJ" = (
-/obj/floor_decal/spline/plain/red,
-/obj/machinery/light/alien{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/warhammer/tunnelchess,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/crew_quarters/gym)
 "zO" = (
 /obj/structure/table/woodentable_reinforced/walnut,
@@ -8447,14 +8314,6 @@
 "AN" = (
 /turf/simulated/wall/prepainted,
 /area/storage/tools)
-"AP" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "AR" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -8471,14 +8330,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/aft)
-"AS" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/wall/prepainted,
-/area/chapel/memorial)
 "AX" = (
 /obj/machinery/gibber,
 /obj/structure/curtain/medical,
@@ -8928,12 +8779,6 @@
 /obj/structure/largecrate,
 /turf/simulated/floor/warhammer/plating,
 /area/maintenance/thirddeck/starboard)
-"CQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "CS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9462,8 +9307,8 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/crew_quarters/mess)
 "Em" = (
-/obj/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
+/obj/structure/sign/mechanicus,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/thirddeck/center)
 "Ep" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -9509,12 +9354,6 @@
 /obj/machinery/vending/coffee{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/brothel,
-/area/crew_quarters/sleep/cryo)
-"Ew" = (
-/obj/floor_decal/industrial/outline/yellow,
-/obj/random_multi/single_item/boombox,
-/obj/structure/closet/warhammer/secure_closet/personal,
 /turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
 "Ex" = (
@@ -9734,6 +9573,10 @@
 /area/maintenance/thirddeck/aftport)
 "Fn" = (
 /obj/machinery/vending/hydronutrients,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/warhammer/darkwood,
 /area/hydroponics)
 "Fo" = (
@@ -9791,47 +9634,6 @@
 "Fy" = (
 /turf/simulated/floor/warhammer/metal,
 /area/crew_quarters/mess)
-"Fz" = (
-/obj/item/flame/candle{
-	pixel_x = 10;
-	pixel_y = 14
-	},
-/obj/item/flame/candle{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/flame/candle{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/flame/candle{
-	pixel_y = 11
-	},
-/obj/item/flame/candle{
-	pixel_x = -9;
-	pixel_y = 13
-	},
-/obj/item/flame/candle{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/flame/candle{
-	pixel_x = -11;
-	pixel_y = 2
-	},
-/obj/item/flame/candle{
-	pixel_x = 8
-	},
-/obj/item/flame/candle/scented/incense{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/flame/candle/scented/incense{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "FA" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	controlled = 0;
@@ -9911,7 +9713,6 @@
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/emitter,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9927,7 +9728,6 @@
 	pixel_x = 6;
 	pixel_y = -24
 	},
-/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/engineering/hardstorage)
 "FU" = (
@@ -10248,6 +10048,7 @@
 "GL" = (
 /obj/structure/closet/cabinet,
 /obj/random/maintenance/solgov,
+/obj/random/loot/randomcolonyitems,
 /turf/simulated/floor/plating,
 /area/vacant/cabin)
 "GN" = (
@@ -10768,14 +10569,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/disperser)
-"Iv" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/prepainted,
-/area/chapel/memorial)
 "Iw" = (
 /obj/floor_decal/industrial/hatch/red,
 /obj/structure/ship_munition/disperser_charge/explosive,
@@ -10837,18 +10630,6 @@
 /obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/warhammer/surgerynew,
 /area/crew_quarters/head)
-"IJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/random_multi/single_item/punitelli,
-/turf/simulated/floor/warhammer/brothel,
-/area/crew_quarters/sleep/cryo)
 "IK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12527,26 +12308,6 @@
 /obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/port)
-"Nn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/aftport)
 "No" = (
 /obj/structure/bed/chair/armchair/green{
 	dir = 8
@@ -12759,14 +12520,6 @@
 	},
 /turf/space,
 /area/space)
-"Og" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/structure/closet/coffin/wooden,
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "Oi" = (
 /obj/structure/catwalk,
 /obj/machinery/field_generator,
@@ -12967,7 +12720,6 @@
 /area/thruster/d3port)
 "OT" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25
@@ -13093,6 +12845,9 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/crew_quarters/gym)
 "Pz" = (
@@ -13171,6 +12926,12 @@
 	},
 /turf/simulated/floor/warhammer/brothel,
 /area/crew_quarters/sleep/cryo)
+"PK" = (
+/obj/structure/table/rack/dark,
+/obj/random/maintenance/solgov,
+/obj/random/loot/randomcolonyitems,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/thirddeck/forestarboard)
 "PL" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 1;
@@ -13227,7 +12988,6 @@
 /obj/item/stack/material/titanium/ten,
 /obj/item/stack/material/titanium/ten,
 /obj/item/stack/material/titanium/ten,
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13370,26 +13130,6 @@
 /obj/structure/barricade/barbed,
 /turf/simulated/floor/warhammer/oldsmoothdirt,
 /area/crew_quarters/observation)
-"Qx" = (
-/obj/structure/table/warhammer/pagan{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = -9
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = -5;
-	pixel_x = -4
-	},
-/obj/item/flame/candle/scented/incense{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "Qy" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13435,78 +13175,14 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/thirddeck/center)
-"QE" = (
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = 2;
-	pixel_x = -9
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = 4;
-	pixel_x = -14
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = -8;
-	pixel_x = 14
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = -8;
-	pixel_x = 23
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = 3;
-	pixel_x = -2
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = -7;
-	pixel_x = -21
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = -6;
-	pixel_x = -9
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = -6;
-	pixel_x = 4
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = 2;
-	pixel_x = 14
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_x = 23
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = 2;
-	pixel_x = 4
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = 2;
-	pixel_x = -21
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "QG" = (
 /obj/machinery/botany/extractor,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/warhammer/darkwood,
 /area/hydroponics)
-"QH" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/wall/prepainted,
-/area/chapel/memorial)
 "QJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/warhammer/plating,
@@ -13712,16 +13388,6 @@
 	},
 /turf/simulated/floor/warhammer/surgerynew,
 /area/crew_quarters/head)
-"RG" = (
-/obj/item/flame/candle{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/flame/candle{
-	pixel_x = 8
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "RH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -13852,13 +13518,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/cryolocker)
-"Sm" = (
-/obj/item/storage/candle_box,
-/obj/item/storage/candle_box/incense,
-/obj/item/flame/lighter/random,
-/obj/structure/closet/crate/warhammer,
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "Sn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -14045,10 +13704,6 @@
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d3starboard)
-"SK" = (
-/obj/structure/table/warhammer/shrine,
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "SL" = (
 /obj/structure/table/rack/dark,
 /obj/item/tank/oxygen_emergency_double,
@@ -14058,7 +13713,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
@@ -14145,7 +13799,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/closet/crate/warhammer/xenos/chest3,
 /obj/item/card/id/key/grand{
 	name = "Grand Room Key";
 	access = list("ACCESS_TAVERN1")
@@ -14183,6 +13836,7 @@
 /obj/item/device/cassette/sombre,
 /obj/item/device/cassette/ambient3,
 /obj/item/device/cassette/western1,
+/obj/structure/closet/crate/warhammer/secure,
 /turf/simulated/floor/warhammer/ceramic/surgery2,
 /area/crew_quarters/galleybackroom)
 "Tm" = (
@@ -14335,6 +13989,7 @@
 /obj/structure/largecrate,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
+/obj/random/loot/randomcolonyitems,
 /turf/simulated/floor/warhammer/plating,
 /area/maintenance/thirddeck/port)
 "TV" = (
@@ -14420,10 +14075,6 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/crew_quarters/mess)
-"Un" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/prepainted,
-/area/chapel/memorial)
 "Uo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14519,47 +14170,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/forestarboard)
-"UA" = (
-/obj/item/flame/candle{
-	pixel_x = 10;
-	pixel_y = 14
-	},
-/obj/item/flame/candle{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/flame/candle{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/flame/candle{
-	pixel_y = 11
-	},
-/obj/item/flame/candle{
-	pixel_x = -9;
-	pixel_y = 13
-	},
-/obj/item/flame/candle{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/flame/candle{
-	pixel_x = -11;
-	pixel_y = 2
-	},
-/obj/item/flame/candle{
-	pixel_x = 8
-	},
-/obj/item/flame/candle/scented/incense{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/flame/candle/scented/incense{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "UD" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
@@ -14963,10 +14573,6 @@
 	},
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/thirddeck/center)
-"VH" = (
-/obj/machinery/light/alien,
-/turf/simulated/floor/warhammer/metal/alt,
-/area/crew_quarters/gym)
 "VK" = (
 /obj/machinery/vending/coffee{
 	dir = 1
@@ -15524,19 +15130,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d3port)
-"XB" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/closet/crate/warhammer/biohazard,
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "XC" = (
 /obj/floor_decal/techfloor{
 	dir = 6
@@ -15547,7 +15140,6 @@
 /obj/machinery/power/port_gen/pacman{
 	sheets = 25
 	},
-/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "XD" = (
@@ -15562,32 +15154,6 @@
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/engineering/hardstorage)
-"XF" = (
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
-"XJ" = (
-/obj/structure/statue/guardshrine{
-	pixel_x = 12;
-	pixel_y = 12
-	},
-/obj/structure/table/warhammer/pagan{
-	pixel_y = 2
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = -2;
-	pixel_x = 3
-	},
-/obj/decal/cleanable/remains{
-	layer = 4;
-	pixel_y = -9
-	},
-/obj/item/flame/candle/scented/incense{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/turf/simulated/floor/warhammer/brick,
-/area/chapel/memorial)
 "XK" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/service_break_room)
@@ -15741,9 +15307,6 @@
 	},
 /turf/simulated/floor/warhammer/oldsmoothdirt,
 /area/crew_quarters/observation)
-"Yn" = (
-/turf/simulated/wall/prepainted,
-/area/chapel/memorial)
 "Yo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27352,15 +26915,15 @@ bu
 ib
 bp
 jG
-xr
+PK
 lp
 bs
 bs
 nT
 gB
+rL
 fC
-fC
-zJ
+Ht
 Fs
 Py
 gB
@@ -28166,11 +27729,11 @@ mf
 gB
 gB
 gB
-tL
+fC
 fC
 Ht
 PG
-VH
+Fs
 IF
 QJ
 xQ
@@ -28772,8 +28335,8 @@ cK
 gB
 Fs
 Fs
+zJ
 Fs
-rL
 Fs
 gM
 Za
@@ -33024,7 +32587,7 @@ vW
 yd
 yW
 vW
-IJ
+vW
 vW
 vW
 Dd
@@ -33837,7 +33400,7 @@ vV
 vV
 Dg
 PJ
-Ew
+Lh
 Fd
 Nj
 Gf
@@ -35248,7 +34811,7 @@ gK
 TZ
 hL
 iF
-jO
+km
 km
 hL
 UZ
@@ -38464,23 +38027,23 @@ gP
 xv
 XC
 ds
-uh
-uh
+eI
+dM
 dM
 dM
 eI
 ji
 sv
 tW
-Yn
-Yn
-Og
-yq
-mB
-yq
-XB
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Ba
 CU
 Dn
@@ -38674,15 +38237,15 @@ qd
 ji
 sv
 ji
-Un
-QH
-XF
-xp
-XF
-XF
-AP
-AS
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Ba
 CU
 Gl
@@ -38876,15 +38439,15 @@ qc
 Oq
 sE
 ji
-Yn
-wp
-xu
-XF
-XF
-wK
-Yn
-Iv
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Ba
 CU
 Dn
@@ -39078,15 +38641,15 @@ om
 ji
 Zv
 uN
-py
-xO
-sH
-XF
-XF
-SK
-Yn
-Iv
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Ba
 CU
 ub
@@ -39280,15 +38843,15 @@ qd
 rr
 sG
 ji
-Yn
-XF
-CQ
-XF
-XF
-Yn
-Yn
-Iv
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Nq
 CU
 ub
@@ -39482,15 +39045,15 @@ qd
 Bg
 sU
 ua
-Yn
-wr
-vi
-XF
-XF
-SK
-Yn
-Iv
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Do
 DZ
 ub
@@ -39684,17 +39247,17 @@ qd
 ji
 Wh
 ji
-Yn
-Yn
-Sm
-RG
-XF
-yr
-Yn
-rE
-vo
-vo
-Nn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+CU
 ub
 Ox
 Fh
@@ -39886,16 +39449,16 @@ qd
 wB
 sJ
 ji
-Yn
-xo
-XJ
-Fz
-XF
-wK
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Lr
 ub
 ED
@@ -40088,16 +39651,16 @@ qd
 Wx
 sF
 ji
-Yn
-Yn
-QE
-UA
-XF
-SK
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 CU
 ub
 ED
@@ -40290,16 +39853,16 @@ qd
 rt
 kR
 ue
-Yn
-xo
-Qx
-Fz
-XF
-Yn
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 CU
 ub
 Ya
@@ -40492,16 +40055,16 @@ qd
 ji
 Xv
 ji
-Yn
-Yn
-Sm
-do
-XF
-Yn
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 CU
 Dn
 Dn
@@ -40694,16 +40257,16 @@ qd
 ru
 Xv
 ji
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 JX
 Kb
 Kb
@@ -40896,16 +40459,16 @@ qd
 ji
 Xv
 ji
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 FZ
 Bc
 Bc
@@ -41098,16 +40661,16 @@ qe
 lJ
 AR
 ZE
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 JT
 Bc
 Fm
@@ -41300,16 +40863,16 @@ qd
 rw
 Xv
 ji
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Bc
 Dq
 EE
@@ -41502,16 +41065,16 @@ qd
 ji
 sF
 uk
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Eb
 uV
 qM
@@ -41704,16 +41267,16 @@ wl
 ji
 sF
 ul
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 JT
 EE
 Fo
@@ -41907,15 +41470,15 @@ Vn
 op
 um
 vu
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Ed
 EG
 Fp
@@ -42110,14 +41673,14 @@ sU
 ZE
 YS
 oX
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
+Bc
 Ra
 Wr
 Ne

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1251,8 +1251,11 @@
 "cs" = (
 /obj/structure/table/rack/dark,
 /obj/floor_decal/industrial/outline/grey,
-/obj/item/stock_parts/circuitboard/arcade/battle,
-/obj/item/stock_parts/circuitboard/arcade/orion_trail,
+/obj/item/grenade/frag/high_yield/krak2,
+/obj/item/grenade/frag/high_yield/krak2,
+/obj/item/grenade/frag/high_yield/plasma,
+/obj/item/grenade/frag/high_yield/plasma,
+/obj/item/grenade/frag/high_yield/plasma,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "ct" = (
@@ -1984,6 +1987,7 @@
 "dY" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/engineering_senior,
+/obj/random/loot/lasbundle,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "ea" = (
@@ -4702,12 +4706,14 @@
 	},
 /area/engineering/storage)
 "kG" = (
-/obj/machinery/tele_pad,
+/obj/gibspawner/robot,
+/obj/gibspawner/human,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/teleporter/seconddeck)
 "kH" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/engineering_torch,
+/obj/random/loot/sidearmbundle,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "kJ" = (
@@ -5871,7 +5877,7 @@
 	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/engineering/atmos)
 "nW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6871,6 +6877,12 @@
 	},
 /turf/simulated/floor/warhammer/plating,
 /area/engineering/foyer)
+"qJ" = (
+/obj/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/engineering_senior,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engineering_bay)
 "qK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7978,10 +7990,6 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/engineering/engine_monitoring)
 "tD" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/structure/table/steel,
 /obj/random/maintenance/solgov,
 /obj/machinery/camera/network/engineering{
@@ -9112,7 +9120,7 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/engineering/atmos)
 "wY" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
@@ -9266,6 +9274,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/prototype/engine)
+"xx" = (
+/obj/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/engineering_senior,
+/obj/item/gun/energy/lasgun/laspistol/lucius,
+/obj/random/loot/randomsupply/engineering,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engineering_bay)
 "xy" = (
 /obj/machinery/light,
 /obj/structure/catwalk,
@@ -10029,7 +10044,6 @@
 /turf/simulated/floor/warhammer/plating,
 /area/teleporter/seconddeck)
 "Aa" = (
-/obj/structure/ladder/up,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
@@ -10762,6 +10776,7 @@
 /obj/random/bomb_supply,
 /obj/random/bomb_supply,
 /obj/random/maintenance/solgov,
+/obj/random/loot/randomsupply/engineering,
 /turf/simulated/floor/warhammer/plating,
 /area/vacant/cargo)
 "BW" = (
@@ -11164,6 +11179,7 @@
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
+/obj/random/loot/rigloot,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/vacant/cargo)
 "CY" = (
@@ -11911,7 +11927,7 @@
 	dir = 4
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/engineering/atmos)
 "EU" = (
 /turf/simulated/wall/ocp_wall,
@@ -13006,6 +13022,7 @@
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/engineering_torch,
+/obj/random/loot/gunbundle,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "Il" = (
@@ -13096,7 +13113,7 @@
 	dir = 8
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/engineering/atmos)
 "Iz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13882,7 +13899,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/warhammer/plating,
+/turf/simulated/floor/warhammer/metal/alt,
 /area/engineering/atmos)
 "Ls" = (
 /turf/simulated/floor/reinforced,
@@ -14371,10 +14388,7 @@
 	},
 /area/engineering/prototype/engine)
 "Nk" = (
-/obj/structure/sign/directions/infirmary{
-	dir = 1;
-	pixel_z = -6
-	},
+/obj/structure/sign/mechanicus,
 /turf/simulated/wall/ocp_wall,
 /area/hallway/primary/seconddeck/center)
 "Nl" = (
@@ -14795,6 +14809,7 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/secure_closet/engineering_senior,
+/obj/random/loot/randomsupply/engineering,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "Ou" = (
@@ -15855,6 +15870,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/engineering_senior,
+/obj/item/gun/energy/lasgun/laspistol/militarum,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "RX" = (
@@ -17308,6 +17324,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 21
 	},
+/obj/random/loot/randomcolonyitems,
 /turf/simulated/floor/warhammer/plating,
 /area/vacant/cargo)
 "WU" = (
@@ -17745,12 +17762,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
 "YA" = (
-/obj/structure/ladder,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/warhammer/plating,
 /area/engineering/foyer)
 "YG" = (
@@ -17797,6 +17812,10 @@
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/seconddeck/central)
+"YT" = (
+/obj/structure/sign/mechanicus,
+/turf/simulated/wall/ocp_wall,
+/area/engineering/bluespacebay)
 "YU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17867,6 +17886,7 @@
 /obj/item/sticky_pad/random,
 /obj/item/stamp/ce,
 /obj/item/pen,
+/obj/item/stamp/rd,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/seconddeck/central)
 "Ze" = (
@@ -30757,16 +30777,16 @@ iu
 hC
 pA
 kD
-kD
+Nk
 mi
 Nk
 kD
 VR
 nk
 gV
-gV
+YT
 gr
-gV
+YT
 gV
 dX
 aK
@@ -37219,7 +37239,7 @@ ax
 ax
 kS
 iN
-dY
+qJ
 wK
 ly
 nz
@@ -38027,7 +38047,7 @@ Wv
 QJ
 hj
 iN
-dY
+xx
 zc
 Fc
 rw
@@ -39244,7 +39264,7 @@ FL
 kU
 fW
 iN
-iw
+nr
 sS
 qO
 iw
@@ -40055,7 +40075,7 @@ iN
 iN
 qK
 mW
-iN
+ow
 ll
 sQ
 ur

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -572,13 +572,13 @@
 	pixel_y = 32
 	},
 /obj/machinery/reagentgrinder,
+/obj/structure/torchwall{
+	dir = 8
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/chemistry)
 "abo" = (
 /obj/machinery/optable,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/morgue/autopsy)
 "abp" = (
@@ -589,6 +589,9 @@
 /area/maintenance/firstdeck/aftstarboard)
 "abq" = (
 /obj/random_multi/single_item/skelestand,
+/obj/structure/torchwall{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue/autopsy)
 "abr" = (
@@ -596,9 +599,6 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/chemistry)
 "abs" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table/steel,
 /obj/item/reagent_containers/glass/beaker/insulated/large,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -1370,9 +1370,6 @@
 	dir = 4;
 	pixel_x = 11
 	},
-/obj/item/storage/mirror{
-	pixel_x = 32
-	},
 /turf/simulated/floor/warhammer/surgerynew,
 /area/medical/counselor)
 "acU" = (
@@ -1397,7 +1394,7 @@
 /area/medical/chemistry)
 "acV" = (
 /obj/structure/bed/chair/warhammer/cage,
-/turf/simulated/floor/warhammer,
+/turf/simulated/floor/warhammer/darkwood2,
 /area/chapel/memorial)
 "acW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -2656,7 +2653,7 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/warhammer{
-	req_access = list("ACCESS_MEDICAL");
+	req_access = list("ACCESS_DAUNTLESS");
 	name = "Medicae Clinic"
 	},
 /turf/simulated/floor/warhammer/coralg,
@@ -2672,7 +2669,8 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/sleeper)
 "afd" = (
-/obj/structure/roller_bed,
+/obj/structure/bed/warhammer/barrack,
+/obj/structure/bed/warhammer/barrack1,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/medical/sleeper)
 "aff" = (
@@ -2750,15 +2748,13 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue/autopsy)
 "afo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/medical1,
 /turf/simulated/wall/prepainted,
 /area/medical/foyer)
 "afp" = (
@@ -2870,11 +2866,12 @@
 /turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "afB" = (
-/obj/structure/roller_bed,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/bed/warhammer/barrack,
+/obj/structure/bed/warhammer/barrack1,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/medical/sleeper)
 "afC" = (
@@ -3136,8 +3133,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "ahd" = (
-/turf/simulated/wall/prepainted,
-/area/medical/counselor/therapy)
+/turf/simulated/wall/ocp_wall,
+/area/rnd/misc_lab)
 "ahr" = (
 /obj/item/clothing/head/helmet/space/void,
 /turf/space,
@@ -3147,6 +3144,10 @@
 	dir = 4
 	},
 /obj/item/material/knife/folding/combat/switchblade,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 11
+	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/wing)
 "ahx" = (
@@ -3185,6 +3186,7 @@
 /area/thruster/d1starboard)
 "ahC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/mob/living/simple_animal/hostile/meatstation/meatball,
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/safe_room/firstdeck)
 "ahD" = (
@@ -3216,6 +3218,7 @@
 	pixel_x = 21
 	},
 /obj/structure/catwalk,
+/obj/structure/barricade/sandbagwall,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
 "ahM" = (
@@ -3591,6 +3594,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/decal/cleanable/blood,
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/safe_room/firstdeck)
 "aiP" = (
@@ -3819,6 +3823,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/barricade/boards,
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/safe_room/firstdeck)
 "ajP" = (
@@ -3893,6 +3898,7 @@
 /obj/floor_decal/techfloor{
 	dir = 6
 	},
+/obj/decal/cleanable/blood,
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/safe_room/firstdeck)
 "ajT" = (
@@ -3914,6 +3920,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/barricade/boards,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/safe_room/firstdeck)
 "ajU" = (
@@ -3927,6 +3934,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/decal/cleanable/blood,
+/obj/structure/barricade/sandbag{
+	dir = 8
 	},
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/firstdeck/fore)
@@ -4579,12 +4590,15 @@
 /turf/simulated/floor/warhammer/brothel,
 /area/shuttle/escape_pod13/station)
 "ang" = (
-/obj/structure/table/steel_reinforced,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
 	},
 /obj/item/pen,
+/obj/structure/table/warhammer/big_wood_table{
+	icon_state = "wood_1tileendtable";
+	dir = 4
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/command/conference)
 "anm" = (
@@ -4942,6 +4956,7 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/medicalhallway)
 "aqQ" = (
+/obj/structure/sign/medposter2,
 /turf/simulated/wall/prepainted,
 /area/medical/foyer)
 "aqR" = (
@@ -4950,7 +4965,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/structure/torchwall{
+	dir = 1
+	},
 /turf/simulated/floor/warhammer/metal,
 /area/medical/foyer)
 "aqS" = (
@@ -4962,9 +4979,6 @@
 /turf/simulated/floor/warhammer/metal,
 /area/medical/foyer)
 "aqT" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medical Paperwork Office"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -4973,6 +4987,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/glass{
+	name = "Medicae Office";
+	req_access = list("ACCESS_MEDICAL_COMMAND")
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/medpaperworkoffice)
 "arb" = (
@@ -6521,11 +6539,11 @@
 /area/crew_quarters/head/deck1)
 "aAr" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/sleep/cryo/aux)
+/area/maintenance/firstdeck/centralport)
 "aAs" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
-/area/crew_quarters/sleep/cryo/aux)
+/area/hallway/primary/firstdeck/center)
 "aAx" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Emergency Storage"
@@ -6540,8 +6558,10 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/security/evidence)
 "aAK" = (
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/sleep/cryo/aux)
+/obj/decal/cleanable/blood,
+/obj/random/loot/lasbundle,
+/turf/simulated/floor/warhammer/plating,
+/area/crew_quarters/safe_room/firstdeck)
 "aAT" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/teleporter/firstdeck)
@@ -7063,35 +7083,9 @@
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/firstdeck/fore)
 "aFb" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/plating,
-/area/rnd/development)
+/obj/structure/sign/medposter,
+/turf/simulated/wall/prepainted,
+/area/medical/surgery2)
 "aFd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7185,6 +7179,8 @@
 /obj/machinery/keycard_auth/torch{
 	pixel_x = 26
 	},
+/obj/item/stamp/solgov,
+/obj/item/stamp/cos,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/bo)
 "aFS" = (
@@ -7287,9 +7283,12 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
 "aGE" = (
-/obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/plating,
-/area/rnd/development)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/sign/emergonly{
+	pixel_y = 26
+	},
+/turf/simulated/floor/warhammer/plating,
+/area/hallway/primary/firstdeck/center)
 "aGL" = (
 /obj/structure/catwalk,
 /obj/machinery/light{
@@ -7646,10 +7645,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "aIG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Locker Room"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7660,6 +7655,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/warhammer/engineering{
+	req_access = list("ACCESS_MECHANICUS_COMMAND");
+	name = "Gear Storage"
 	},
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/locker)
@@ -7734,6 +7733,7 @@
 /obj/structure/cable/green,
 /obj/item/crowbar/prybar,
 /obj/item/book/manual/law,
+/obj/item/material/twohanded/ravenor/powermaul,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/bo)
 "aJp" = (
@@ -8209,7 +8209,7 @@
 	req_access = list("ACCESS_BRIDGE")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "aMD" = (
 /obj/item/device/radio/intercom/department/security{
 	dir = 4;
@@ -8532,16 +8532,16 @@
 	},
 /area/thruster/d1port)
 "aOE" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
 /obj/floor_decal/techfloor,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "aOF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -8554,13 +8554,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "aOG" = (
 /obj/structure/table/rack/dark,
 /obj/machinery/light{
@@ -8577,7 +8572,7 @@
 /turf/simulated/floor/selfestructgrid{
 	name = "xenos plating"
 	},
-/area/security/secure_storage)
+/area/security/armoury)
 "aOI" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
@@ -8666,7 +8661,7 @@
 /obj/item/shield/riot,
 /obj/item/shield/riot,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "aPv" = (
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/wing)
@@ -9234,6 +9229,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = -20
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/wing)
@@ -9838,11 +9837,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/warhammer/command/ancient{
+	name = "Maintenance Hatch";
+	req_access = list("ACCESS_MECHANICUS")
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/firstdeck/centralport)
@@ -9869,11 +9871,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/warhammer/command/ancient{
+	name = "Maintenance Hatch";
+	req_access = list("ACCESS_MECHANICUS")
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/maintenance/firstdeck/aftport)
@@ -10241,11 +10246,9 @@
 /area/maintenance/firstdeck/foreport)
 "aUb" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	frequency = 1379;
+/obj/machinery/door/airlock/warhammer/command{
 	id_tag = "xeno_airlock_exterior";
-	locked = 1;
-	name = "Xenobiology External Airlock"
+	locked = 1
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/rnd/xenobiology/entry)
@@ -10259,11 +10262,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	frequency = 1379;
+/obj/machinery/door/airlock/warhammer/command{
 	id_tag = "xeno_airlock_exterior";
-	locked = 1;
-	name = "Xenobiology External Airlock"
+	locked = 1
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/rnd/xenobiology/entry)
@@ -10552,11 +10553,9 @@
 /area/rnd/xenobiology/cell_3)
 "aUF" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	frequency = 1379;
+/obj/machinery/door/airlock/warhammer/command{
 	id_tag = "xeno_airlock_interior";
-	locked = 1;
-	name = "Xenobiology Internal Airlock"
+	locked = 1
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/rnd/xenobiology)
@@ -10570,11 +10569,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	frequency = 1379;
+/obj/machinery/door/airlock/warhammer/command{
 	id_tag = "xeno_airlock_interior";
-	locked = 1;
-	name = "Xenobiology Internal Airlock"
+	locked = 1
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/rnd/xenobiology)
@@ -11202,9 +11199,6 @@
 "bhy" = (
 /obj/structure/iv_stand,
 /obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/device/radio/intercom/department/medbay{
 	pixel_y = 23
 	},
@@ -11271,9 +11265,9 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/equipstorage)
 "bmb" = (
-/obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/plating,
-/area/rnd/xenobiology/xenoflora)
+/obj/structure/closet/warhammer/secure_closet/personal/patient,
+/turf/simulated/floor/warhammer/coralg,
+/area/medical/staging)
 "bmO" = (
 /turf/simulated/floor/warhammer/coralg,
 /area/security/detectives_office)
@@ -11555,7 +11549,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "bGZ" = (
 /obj/floor_decal/sign/or1,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11608,6 +11602,19 @@
 /obj/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/reinforced,
 /area/shuttle/escape_pod13/station)
+"bKq" = (
+/obj/structure/closet/warhammer/emcloset,
+/obj/item/clothing/under/rank/clown,
+/obj/item/clothing/shoes/clown_shoes,
+/obj/item/clothing/mask/gas/clown_hat,
+/turf/simulated/floor/warhammer/plating,
+/area/maintenance/firstdeck/centralport)
+"bKW" = (
+/obj/structure/hivedecor/artillery{
+	dir = 1
+	},
+/turf/simulated/floor/warhammer/plating,
+/area/hallway/primary/firstdeck/fore)
 "bLb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -11744,7 +11751,7 @@
 /obj/machinery/photocopier/faxmachine{
 	department = "Dauntless - Research Paperwork Office"
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "bTb" = (
 /obj/item/device/radio/intercom{
@@ -12030,6 +12037,7 @@
 /area/maintenance/firstdeck/centralstarboard)
 "ckb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/decal/cleanable/blood,
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/safe_room/firstdeck)
 "ckL" = (
@@ -12241,7 +12249,7 @@
 /obj/item/hand_labeler,
 /obj/item/stack/package_wrap/cargo_wrap,
 /obj/item/device/destTagger,
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "cBU" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -12330,9 +12338,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue/autopsy)
 "cGQ" = (
-/obj/structure/sign/medposter2,
-/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
-/area/chapel/memorial)
+/obj/structure/sign/imperial,
+/turf/simulated/wall/prepainted,
+/area/command/conference)
 "cHb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -12450,17 +12458,11 @@
 /obj/floor_decal/floordetail/edgedrain{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/medical/surgery2)
 "cUb" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/research{
-	name = "Fabricator Laboratory"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12468,6 +12470,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/warhammer/engineering{
+	req_access = list("ACCESS_MECHANICUS_COMMAND");
+	name = "Factorum Laboratory"
 	},
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/development)
@@ -12616,9 +12622,7 @@
 /obj/structure/bed/chair/warhammer/padded/blue{
 	dir = 1
 	},
-/obj/structure/torchwall{
-	dir = 1
-	},
+/obj/machinery/light,
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/safe_room/medical)
 "deo" = (
@@ -12661,7 +12665,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "dgb" = (
 /obj/floor_decal/techfloor,
@@ -12886,11 +12890,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue/autopsy)
 "dIw" = (
-/obj/floor_decal/techfloor{
-	dir = 6
+/obj/structure/barricade/concrete{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "dIA" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -13274,13 +13278,13 @@
 /area/security/storage)
 "emb" = (
 /obj/structure/table/steel,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/item/paper_bin,
 /obj/item/sticky_pad/random,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = -5
+	},
+/obj/structure/torchwall{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue/autopsy)
@@ -13426,6 +13430,7 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/processing)
 "ezb" = (
+/obj/structure/janitorialcart,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/medical/sleeper)
 "eAb" = (
@@ -13454,14 +13459,6 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/warhammer/plating,
 /area/maintenance/firstdeck/centralport)
-"eGb" = (
-/obj/structure/table/steel,
-/obj/item/stack/material/uranium,
-/obj/item/stack/material/uranium,
-/obj/item/device/scanner/reagent,
-/obj/item/device/scanner/spectrometer/adv,
-/turf/simulated/floor/warhammer/ceramic/blackstone,
-/area/rnd/misc_lab)
 "eGl" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
@@ -13484,24 +13481,16 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "eHb" = (
 /obj/structure/table/warhammer/reinf_table,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/medical/sleeper)
 "eHp" = (
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/floor_decal/techfloor,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/obj/structure/barricade/concrete,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "eIb" = (
 /obj/item/flame/candle{
 	pixel_x = -11;
@@ -13606,7 +13595,7 @@
 /turf/simulated/floor/selfestructgrid{
 	name = "xenos plating"
 	},
-/area/security/secure_storage)
+/area/security/armoury)
 "eQK" = (
 /obj/floor_decal/techfloor{
 	dir = 9
@@ -13622,7 +13611,6 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/sleeper)
 "eRQ" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13634,11 +13622,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/warhammer/engineering{
-	req_access = list("ACCESS_MECHANICUS");
-	name = "Servitor Labs"
-	},
-/turf/simulated/floor/warhammer/metal/alt,
+/turf/simulated/wall/prepainted,
 /area/assembly/robotics/laboratory)
 "eRU" = (
 /turf/simulated/wall/r_wall/hull,
@@ -13699,6 +13683,9 @@
 	c_tag = "Medical - Foyer";
 	dir = 8
 	},
+/obj/structure/torchwall{
+	dir = 8
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/foyer)
 "eZQ" = (
@@ -13746,11 +13733,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Medical Storeroom"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/warhammer/glass{
+	name = "Mortis Investigation";
+	req_access = list("ACCESS_MEDICAL_COMMAND")
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/morgue/autopsy)
 "flB" = (
@@ -13783,7 +13771,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "fps" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -13796,8 +13784,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/structure/torchwall{
+	dir = 4
 	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/medpaperworkoffice)
@@ -13847,20 +13835,9 @@
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/rnd/xenobiology)
-"fBb" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/steel,
-/obj/item/device/integrated_circuit_printer,
-/turf/simulated/floor/warhammer/ceramic/blackstone,
-/area/rnd/misc_lab)
 "fCb" = (
 /obj/item/storage/firstaid/surgery,
 /obj/floor_decal/floordetail/edgedrain{
-	dir = 1
-	},
-/obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/table/steel_reinforced,
@@ -13920,9 +13897,6 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/medicalhallway)
 "fOu" = (
-/obj/machinery/door/airlock/medical{
-	name = "Locker Room"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -13931,6 +13905,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/glass{
+	name = "Medicae Storage";
+	req_access = list("ACCESS_MEDICAL_COMMAND")
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/equipstorage)
 "fQf" = (
@@ -14027,10 +14005,6 @@
 /turf/simulated/wall/r_wall/hull,
 /area/rnd/xenobiology/cell_1)
 "fYb" = (
-/obj/machinery/door/airlock/medical{
-	id_tag = "examdoor";
-	name = "Examination Room"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -14039,6 +14013,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/glass{
+	name = "Exam Room";
+	req_access = list("ACCESS_MEDICAL_COMMAND")
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/exam_room)
 "fYv" = (
@@ -14084,6 +14062,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/prepainted,
 /area/engineering/hardstorage/aux)
+"gbs" = (
+/obj/machinery/door/unpowered/jail_door,
+/turf/simulated/floor/warhammer/brick,
+/area/chapel/memorial)
 "gdl" = (
 /obj/structure/table/warhammer/shrine,
 /obj/item/storage/bible/bible,
@@ -14144,7 +14126,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "gij" = (
 /obj/floor_decal/techfloor{
@@ -14229,8 +14211,10 @@
 /obj/item/storage/firstaid/toxin,
 /obj/random/medical/lite,
 /obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/light,
 /obj/item/storage/firstaid/radiation,
+/obj/structure/torchwall{
+	dir = 1
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/equipstorage)
 "gvC" = (
@@ -14290,16 +14274,7 @@
 /turf/simulated/wall/warhammer,
 /area/medical/morgue/autopsy)
 "gzb" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "inf_recep_window";
-	name = "Infirmary Reception Window Lockdown";
-	opacity = 0
-	},
 /obj/item/storage/medical_lolli_jar,
-/obj/machinery/door/firedoor,
 /obj/structure/table/warhammer/big_wood_table{
 	icon_state = "wood_1tileendtable";
 	dir = 1
@@ -14338,9 +14313,9 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/medicalhallway)
 "gDD" = (
-/obj/structure/sign/medposte3,
-/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
-/area/chapel/memorial)
+/obj/structure/sign/medical1,
+/turf/simulated/wall/prepainted,
+/area/medical/medicalhallway)
 "gEb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -14405,7 +14380,7 @@
 	req_access = list("ACCESS_MEDICAL_COMMAND");
 	name = "Oubliette"
 	},
-/turf/simulated/floor/warhammer,
+/turf/simulated/floor/warhammer/darkwood2,
 /area/chapel/memorial)
 "gQb" = (
 /obj/structure/cable/green{
@@ -14643,6 +14618,7 @@
 /area/hallway/primary/firstdeck/center)
 "hhB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/mob/living/simple_animal/hostile/meatstation/wormscientist,
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/safe_room/firstdeck)
 "hib" = (
@@ -14767,38 +14743,20 @@
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d1starboard)
 "hrb" = (
-/obj/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "outercheckwindow";
-	name = "Outer Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/security/opscheck)
 "hsb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/opscheck)
 "htb" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "d1ladderwindow";
-	name = "Ladderwell Checkpoint Shutters";
-	opacity = 0
+/obj/structure/sign/solgov,
+/obj/structure/statue/verina{
+	pixel_y = 32;
+	pixel_x = -13
 	},
-/obj/wallframe_spawn/reinforced/no_grille,
-/obj/structure/sign/mechanicus,
-/turf/simulated/floor/plating,
-/area/rnd/entry)
+/turf/simulated/wall/prepainted,
+/area/security/processing)
 "htf" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -14846,7 +14804,6 @@
 /area/security/storage)
 "hvb" = (
 /obj/machinery/door/firedoor,
-/obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -14860,24 +14817,6 @@
 	},
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/entry)
-"hvY" = (
-/obj/structure/table/steel,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/storage/box/beakers,
-/obj/machinery/light/spot{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/turf/simulated/floor/warhammer/ceramic/blackstone,
-/area/rnd/misc_lab)
 "hwb" = (
 /obj/structure/sign/science_1{
 	dir = 1
@@ -14931,6 +14870,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/item/paper_bin{
+	icon = 'icons/map_project/fluff_items.dmi';
+	icon_state = "paperwork";
+	pixel_y = 4;
+	layer = 3
+	},
+/obj/structure/table/steel,
 /turf/simulated/floor/warhammer/coralg,
 /area/security/opscheck)
 "hBj" = (
@@ -15027,10 +14973,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/entry)
 "hGb" = (
@@ -15081,7 +15023,11 @@
 	},
 /obj/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
+"hMJ" = (
+/obj/structure/sign/mechanicus,
+/turf/simulated/wall/r_wall/hull,
+/area/rnd/xenobiology/cell_4)
 "hOZ" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -15104,8 +15050,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "hPt" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/table/warhammer/rusty_table,
+/obj/structure/torchwall{
 	dir = 1
 	},
 /turf/simulated/floor/warhammer/coralg,
@@ -15210,21 +15159,9 @@
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/firstdeck/center)
 "hZb" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/plating,
-/area/rnd/development)
+/obj/structure/sign/mechanicus,
+/turf/simulated/wall/r_wall/hull,
+/area/thruster/d1starboard)
 "iaq" = (
 /obj/structure/table/warhammer/pagan{
 	pixel_x = -4;
@@ -15368,9 +15305,6 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftport)
 "ipc" = (
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
 /obj/machinery/recharger,
 /obj/structure/table/glass,
 /obj/random/smokes,
@@ -15379,10 +15313,6 @@
 "ipq" = (
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
-"iqb" = (
-/obj/structure/bed/chair/comfy/lime,
-/turf/simulated/floor/warhammer/ceramic/blackstone,
-/area/rnd/misc_lab)
 "irb" = (
 /obj/structure/table/steel,
 /obj/item/disk/tech_disk,
@@ -15586,7 +15516,9 @@
 	},
 /obj/item/forensics/swab,
 /obj/item/forensics/sample_kit/powder,
-/obj/structure/table/glass/boron,
+/obj/structure/table/warhammer/big_wood_table{
+	icon_state = "wood_1tilethick"
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/security/detectives_office)
 "iGb" = (
@@ -15595,18 +15527,9 @@
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/medical/surgery)
 "iHb" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/cable/green,
-/obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/plating,
-/area/rnd/development)
+/obj/structure/sign/medical1,
+/turf/simulated/wall/prepainted,
+/area/medical/foyer)
 "iHX" = (
 /obj/floor_decal/sign/or2,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15661,13 +15584,16 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "iLB" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/machinery/door/airlock/warhammer/engineering{
+	req_access = list("ACCESS_MECHANICUS");
+	name = "Servitor Labs"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
@@ -15701,7 +15627,6 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15734,28 +15659,23 @@
 /area/maintenance/firstdeck/centralstarboard)
 "iQb" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "d1ladderwindow";
-	name = "Ladderwell Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/wallframe_spawn/reinforced/no_grille,
 /obj/structure/sign/mechanicus,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/rnd/entry)
 "iSb" = (
 /obj/structure/table/steel,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
 /obj/item/device/integrated_electronics/wirer,
 /obj/item/device/integrated_electronics/debugger{
 	pixel_x = -5
 	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/dropper,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "iTC" = (
@@ -15807,7 +15727,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/valve/shutoff/supply,
 /obj/floor_decal/industrial/shutoff,
 /obj/machinery/atmospherics/valve/shutoff/scrubbers,
@@ -15961,7 +15880,7 @@
 /obj/random/loot/gunbundle,
 /obj/random/loot/gunbundle,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "jhb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/warhammer,
@@ -15980,7 +15899,7 @@
 /turf/simulated/floor/selfestructgrid{
 	name = "xenos plating"
 	},
-/area/security/secure_storage)
+/area/security/armoury)
 "jhq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -16143,16 +16062,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "jtb" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance Access"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/metal,
+/turf/simulated/wall/prepainted,
 /area/rnd/locker)
 "jub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16282,6 +16197,10 @@
 "jAb" = (
 /obj/structure/table/steel,
 /obj/structure/window/reinforced,
+/obj/item/device/scanner/spectrometer/adv,
+/obj/item/device/scanner/reagent,
+/obj/item/stack/material/uranium,
+/obj/item/stack/material/uranium,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "jAM" = (
@@ -16333,13 +16252,6 @@
 	req_access = list("ACCESS_MEDICAL")
 	},
 /obj/machinery/button/blast_door{
-	id_tag = "inf_recep_window";
-	name = "Infirmary Reception Lockdown";
-	pixel_x = 7;
-	pixel_y = -24;
-	req_access = list("ACCESS_MEDICAL")
-	},
-/obj/machinery/button/blast_door{
 	id_tag = "infirm_stage";
 	name = "Infirmary Staging Lockdown";
 	pixel_x = -7;
@@ -16388,10 +16300,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/center)
 "jIb" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/bombcloset,
 /turf/simulated/floor/warhammer/coralg,
@@ -16541,13 +16449,20 @@
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/firstdeck/aft)
 "jZb" = (
-/obj/wallframe_spawn/reinforced/polarized/no_grille{
-	id = "misc_lab"
-	},
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
+/obj/structure/sign/medical1,
+/turf/simulated/wall/prepainted,
+/area/medical/staging)
 "kab" = (
-/obj/structure/table/steel,
+/obj/structure/statue/xenotube{
+	pixel_x = 2
+	},
+/obj/item/pyre/self_lit{
+	invisibility = 60;
+	name = "Invisible Light";
+	icon = 'icons/obj/candle.dmi';
+	icon_state = "candle1";
+	pixel_x = -3
+	},
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "kaS" = (
@@ -16560,18 +16475,13 @@
 /turf/simulated/floor/warhammer/surgerynew,
 /area/medical/counselor)
 "kbb" = (
-/obj/structure/table/steel,
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 26
+/obj/structure/sign/solgov,
+/obj/structure/statue/verina{
+	pixel_y = -17;
+	pixel_x = -13
 	},
-/obj/machinery/button/windowtint{
-	id = "misc_lab";
-	pixel_x = 4;
-	pixel_y = 26
-	},
-/turf/simulated/floor/warhammer/ceramic/blackstone,
-/area/rnd/misc_lab)
+/turf/simulated/wall/ocp_wall,
+/area/security/wing)
 "kbl" = (
 /turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/chapel/memorial)
@@ -16659,10 +16569,10 @@
 /area/security/detectives_office)
 "khb" = (
 /obj/structure/table/steel,
-/obj/structure/window/reinforced,
 /obj/item/device/integrated_electronics/analyzer{
 	pixel_x = 6
 	},
+/obj/machinery/reagent_temperature,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "kiR" = (
@@ -16746,8 +16656,9 @@
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/firstdeck/center)
 "kpb" = (
-/obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "kqb" = (
@@ -16836,7 +16747,10 @@
 	pixel_y = 4
 	},
 /obj/item/folder/red,
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/warhammer/big_wood_table{
+	icon_state = "wood_1tileendtable";
+	dir = 8
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/security/detectives_office)
 "kyb" = (
@@ -16888,7 +16802,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/warhammer/metal/south,
-/area/security/secure_storage)
+/area/security/armoury)
 "kDb" = (
 /obj/structure/bed/chair/warhammer{
 	dir = 8
@@ -16953,22 +16867,18 @@
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/firstdeck/aft)
 "kHb" = (
-/obj/structure/bed/padded,
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
+/obj/structure/bed/warhammer/barrack,
+/obj/structure/bed/warhammer/barrack1,
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
 "kIb" = (
-/obj/structure/closet/warhammer/secure_closet/personal/patient,
-/obj/machinery/body_scan_display{
-	pixel_y = 24
-	},
+/obj/structure/table/warhammer/rusty_table,
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
 "kJb" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/medical,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -16978,20 +16888,17 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/structure/bed/warhammer/barrack,
+/obj/structure/bed/warhammer/barrack1,
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
 "kKb" = (
-/turf/simulated/floor/warhammer,
+/turf/simulated/floor/warhammer/darkwood2,
 /area/chapel/memorial)
 "kLb" = (
-/obj/machinery/bodyscanner{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/warhammer/coralg,
-/area/medical/staging)
+/obj/structure/sign/medposte3,
+/turf/simulated/wall/prepainted,
+/area/medical/equipstorage)
 "kLY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/warhammer/plating,
@@ -17076,7 +16983,6 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
 "kSb" = (
-/obj/structure/curtain/open/privacy,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17088,7 +16994,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/ceramic/blackstone,
+/turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
 "kSi" = (
 /obj/structure/sign/warning/high_voltage{
@@ -17103,7 +17009,7 @@
 /obj/item/ammo_magazine/magnum/ap,
 /obj/item/ammo_magazine/magnum/ms,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "kTb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -17116,9 +17022,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/body_scanconsole{
-	dir = 1
-	},
+/obj/structure/curtain/open,
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
 "kTl" = (
@@ -17181,6 +17085,10 @@
 /obj/shuttle_landmark/lift/medical_top,
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/medical_lift)
+"kYZ" = (
+/obj/structure/torchwall,
+/turf/simulated/wall/prepainted,
+/area/medical/exam_room)
 "kZb" = (
 /obj/structure/closet/crate/warhammer,
 /obj/item/clothing/under/guard/uniform/sisterofbattle/repentia,
@@ -17194,6 +17102,8 @@
 	id = "postop_window";
 	pixel_y = -24
 	},
+/obj/structure/bed/warhammer/barrack,
+/obj/structure/bed/warhammer/barrack1,
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
 "laQ" = (
@@ -17212,18 +17122,18 @@
 /turf/simulated/floor/warhammer/brick,
 /area/chapel/memorial)
 "lbb" = (
-/obj/structure/curtain/open/privacy,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/warhammer/ceramic/blackstone,
+/obj/structure/closet/warhammer/secure_closet/personal/patient,
+/turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
 "lcb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/warhammer/coralg,
+/turf/simulated/wall/prepainted,
 /area/medical/staging)
 "lcq" = (
 /obj/machinery/recharge_station,
@@ -17330,11 +17240,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/floor_decal/industrial/outline/yellow,
-/obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/entry)
 "lkb" = (
@@ -17389,7 +17294,6 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/development)
 "lob" = (
-/obj/machinery/computer/modular/preset/security,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -17398,6 +17302,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/computer/modular/preset/security{
+	dir = 8;
+	icon_state = "console"
 	},
 /turf/simulated/floor/warhammer/coralg,
 /area/security/opscheck)
@@ -17506,24 +17414,13 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/security/opscheck)
 "lxb" = (
-/obj/structure/table/steel,
-/obj/item/paper_bin,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/item/device/taperecorder,
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 8
-	},
 /turf/simulated/floor/warhammer/coralg,
 /area/security/opscheck)
 "lxs" = (
-/obj/structure/bed/chair/comfy/lime{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "lxE" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -17648,13 +17545,19 @@
 "lCN" = (
 /obj/item/device/tape/random,
 /obj/item/device/tape/random,
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/warhammer/reinf_table,
 /turf/simulated/floor/warhammer/coralg,
 /area/security/evidence)
 "lEb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/equipstorage)
+"lHj" = (
+/obj/structure/torchwall{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue/autopsy)
 "lHO" = (
 /turf/simulated/wall/prepainted,
 /area/medical/sleeper)
@@ -17662,7 +17565,10 @@
 /obj/item/reagent_containers/spray/luminol,
 /obj/item/reagent_containers/spray/sterilizine,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/table/glass/boron,
+/obj/structure/table/warhammer/big_wood_table{
+	icon_state = "wood_1tileendtable";
+	dir = 1
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/security/detectives_office)
 "lJj" = (
@@ -17879,9 +17785,25 @@
 "mgb" = (
 /obj/item/material/ashtray/bronze,
 /obj/random/smokes,
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/warhammer/big_wood_table{
+	icon_state = "wood_1tilethick";
+	dir = 4
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/security/detectives_office)
+"mgI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/structure/barricade/sandbagwall,
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/fore)
 "mhb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17977,11 +17899,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/bed/chair/comfy/blue,
 /obj/random_multi/single_item/runtime,
+/obj/structure/torchwall{
+	dir = 8
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/medpaperworkoffice)
 "mlX" = (
@@ -17990,7 +17912,7 @@
 	dir = 4;
 	pixel_x = -21
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "mmb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18013,9 +17935,9 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/research)
 "mpq" = (
-/obj/floor_decal/industrial/warning,
-/turf/simulated/floor/warhammer/plating,
-/area/hallway/primary/firstdeck/center)
+/obj/structure/sign/mechanicus,
+/turf/simulated/wall/r_wall/hull,
+/area/thruster/d1port)
 "mpy" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftstarboard)
@@ -18065,7 +17987,10 @@
 	},
 /obj/item/device/camera,
 /obj/item/device/taperecorder,
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/warhammer/big_wood_table{
+	icon_state = "wood_1tileendtable";
+	dir = 4
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/security/detectives_office)
 "mua" = (
@@ -18176,11 +18101,12 @@
 "mCe" = (
 /obj/item/storage/box/fingerprints,
 /obj/item/storage/box/swabs,
-/obj/structure/table/glass/boron,
+/obj/structure/table/warhammer/big_wood_table{
+	icon_state = "wood_1tileendtable"
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/security/detectives_office)
 "mCk" = (
-/obj/structure/table/steel,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -18726,6 +18652,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/table/steel,
+/obj/item/device/taperecorder,
+/obj/item/folder/red,
 /turf/simulated/floor/warhammer/coralg,
 /area/security/opscheck)
 "nAp" = (
@@ -18853,8 +18782,6 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/obj/structure/ladder,
-/obj/structure/catwalk,
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/entry)
 "nLb" = (
@@ -18921,9 +18848,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/bed/chair/comfy/red{
-	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19055,6 +18979,8 @@
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
+/obj/item/clothing/under/sexyclown,
+/obj/item/clothing/mask/gas/sexyclown,
 /turf/simulated/floor/warhammer/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "nZR" = (
@@ -19169,15 +19095,6 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/research)
 "ofb" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "inf_recep_window";
-	name = "Infirmary Reception Window Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
 /obj/item/modular_computer/telescreen/preset/medical{
 	pixel_y = 32
 	},
@@ -19197,12 +19114,17 @@
 /obj/item/pen/red,
 /obj/item/pen,
 /obj/item/device/camera,
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "ojb" = (
 /obj/structure/table/steel,
-/obj/random_multi/single_item/memo_research,
-/turf/simulated/floor/warhammer/ceramic/old,
+/obj/item/paper_bin{
+	icon = 'icons/map_project/fluff_items.dmi';
+	icon_state = "paperwork";
+	pixel_y = 4;
+	layer = 3
+	},
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "okp" = (
 /obj/structure/closet/bombclosetsecurity,
@@ -19213,9 +19135,6 @@
 /turf/simulated/floor/warhammer/plating,
 /area/security/locker)
 "omb" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -19436,8 +19355,11 @@
 /obj/item/ammo_magazine/autogun/militarum/ms,
 /obj/item/ammo_magazine/heavy,
 /obj/item/ammo_magazine/heavy/ap,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "oAx" = (
 /obj/structure/sign/warning/pods/south{
 	dir = 1
@@ -19526,6 +19448,9 @@
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 1;
 	pixel_y = -28
+	},
+/obj/structure/torchwall{
+	dir = 1
 	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
@@ -19680,6 +19605,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/research)
+"oTA" = (
+/obj/structure/torchwall{
+	dir = 1
+	},
+/turf/simulated/floor/warhammer/coralg,
+/area/medical/exam_room)
 "oUb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19705,6 +19636,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
+"oVC" = (
+/obj/machinery/door/airlock/warhammer/command/ancient{
+	req_access = list("ACCESS_DAUNTLESS");
+	name = "Hazardous Containment"
+	},
+/obj/machinery/door/blast/gates/grates{
+	identifier = "researchlock"
+	},
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "oWb" = (
 /obj/machinery/light_switch{
 	pixel_x = 6;
@@ -19735,17 +19676,13 @@
 /obj/item/ammo_magazine/bolt_rifle_magazine,
 /obj/item/ammo_magazine/bolt_rifle_magazine,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "oXx" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/barricade/concrete{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "pab" = (
 /obj/machinery/light_switch{
 	pixel_x = 20;
@@ -19823,8 +19760,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research{
-	name = "Miscellaneous Laboratory"
+/obj/machinery/door/airlock/warhammer/engineering{
+	req_access = list("ACCESS_MECHANICUS_COMMAND");
+	name = "Hazardous Research"
 	},
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/misc_lab)
@@ -19851,16 +19789,12 @@
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "pib" = (
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/ceramic/blackstone,
+/turf/simulated/wall/ocp_wall,
 /area/rnd/misc_lab)
 "pjb" = (
 /obj/structure/cable/green{
@@ -19868,12 +19802,16 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/door/blast/gates/grates{
+	identifier = "researchlock2";
+	begins_closed = 0
+	},
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "pjR" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 10
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/wing)
@@ -19920,8 +19858,8 @@
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/firstdeck/aft)
 "pnb" = (
-/obj/machinery/chem_master,
-/obj/floor_decal/industrial/outline/yellow,
+/obj/structure/table/steel,
+/obj/item/melee/baton/cattleprod,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "poS" = (
@@ -20005,10 +19943,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass/research{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/engineering{
+	req_access = list("ACCESS_MECHANICUS_COMMAND");
 	name = "Xenoflora Laboratory"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/xenobiology/xenoflora)
 "pxb" = (
@@ -20128,10 +20067,7 @@
 /area/thruster/d1port)
 "pBb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/wallframe_spawn/reinforced/polarized/no_grille{
-	id = "misc_lab"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/rnd/misc_lab)
 "pBL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -20142,6 +20078,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/imperial,
 /turf/simulated/wall/prepainted,
 /area/command/conference)
 "pCb" = (
@@ -20156,10 +20093,8 @@
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "pDb" = (
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
+/obj/item/reagent_containers/food/snacks/donut/chaos,
+/obj/random/randomchaos,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "pEb" = (
@@ -20167,6 +20102,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
@@ -20193,8 +20131,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/bed/chair/comfy/lime{
-	dir = 4
+/obj/machinery/button/blast_door{
+	id_tag = "researchlock2";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access = list("ACCESS_MECHANICUS")
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "researchlock2";
+	name = "Lockdown";
+	pixel_y = 33;
+	req_access = list("ACCESS_MECHANICUS")
 	},
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
@@ -20208,8 +20155,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/chemical_dispenser/full,
-/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "pHb" = (
@@ -20223,6 +20168,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/research)
+"pHE" = (
+/obj/machinery/door/airlock/warhammer/engineering{
+	req_access = list("ACCESS_MECHANICUS_COMMAND");
+	name = "Security Office"
+	},
+/turf/simulated/floor/warhammer/coralg,
+/area/security/opscheck)
 "pIb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -20285,7 +20237,6 @@
 /area/rnd/xenobiology/xenoflora)
 "pKb" = (
 /obj/machinery/atmospherics/portables_connector,
-/obj/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "pLb" = (
@@ -20315,7 +20266,7 @@
 /area/rnd/xenobiology/xenoflora)
 "pOL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "pPa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20385,6 +20336,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/bed/chair/warhammer/cage,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/processing)
 "pVv" = (
@@ -20592,7 +20544,6 @@
 /area/rnd/misc_lab)
 "qju" = (
 /obj/floor_decal/floordetail/edgedrain,
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -20603,6 +20554,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/torchwall{
+	dir = 1
 	},
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/medical/surgery2)
@@ -20644,7 +20598,6 @@
 /area/rnd/misc_lab)
 "qnA" = (
 /obj/floor_decal/floordetail/edgedrain,
-/obj/machinery/light,
 /obj/structure/closet/crate/warhammer/freezer,
 /obj/item/device/mmi,
 /obj/item/reagent_containers/ivbag/nanoblood,
@@ -20652,14 +20605,15 @@
 /obj/item/reagent_containers/ivbag/blood/human/oneg,
 /obj/item/reagent_containers/ivbag/blood/tau/oneg,
 /obj/item/reagent_containers/ivbag/blood/unathi/oneg,
+/obj/structure/torchwall{
+	dir = 1
+	},
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/medical/surgery)
 "qqb" = (
-/obj/wallframe_spawn/reinforced/polarized/full{
-	id = "sci_office"
-	},
-/turf/simulated/floor/plating,
-/area/rnd/office)
+/obj/structure/sign/mechanicus,
+/turf/simulated/wall/r_wall/hull,
+/area/rnd/xenobiology/cell_1)
 "qrb" = (
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/research)
@@ -20691,12 +20645,16 @@
 /area/chapel/memorial)
 "qsO" = (
 /obj/structure/table/steel,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/obj/item/paper_bin{
+	icon = 'icons/map_project/fluff_items.dmi';
+	icon_state = "paperwork";
+	pixel_y = 4;
+	layer = 3
+	},
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "qsV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20794,13 +20752,7 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
 "qAb" = (
-/obj/machinery/door/window/westright{
-	dir = 1;
-	name = "Xenoflora Environment"
-	},
-/obj/machinery/door/window/southright{
-	name = "Xenoflora Environment"
-	},
+/obj/machinery/door/airlock/warhammer/engineering,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
 "qBb" = (
@@ -20833,10 +20785,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "qDb" = (
-/obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/generic{
-	dir = 8
-	},
+/obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "qDJ" = (
@@ -20877,10 +20826,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/research{
-	name = "Research Paperwork Office"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/engineering{
+	req_access = list("ACCESS_MECHANICUS");
+	name = "Munitorum Office"
+	},
 /turf/simulated/floor/warhammer/metal,
 /area/rnd/office)
 "qFb" = (
@@ -21027,10 +20977,7 @@
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "qQd" = (
-/obj/structure/bed/chair/comfy/lime{
-	dir = 1
-	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "qRb" = (
 /obj/machinery/atmospherics/valve{
@@ -21101,13 +21048,11 @@
 /area/maintenance/firstdeck/foreport)
 "qWb" = (
 /obj/structure/table/steel,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
 /obj/machinery/light/spot{
 	dir = 4
 	},
+/obj/item/clothing/mask/gas/krieg,
+/obj/item/clothing/mask/gas/krieg,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "qWF" = (
@@ -21237,8 +21182,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/warhammer/ceramic/blackstone,
+/turf/simulated/wall/prepainted,
 /area/rnd/xenobiology/xenoflora)
 "reb" = (
 /obj/machinery/biogenerator,
@@ -21277,11 +21221,12 @@
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/xenobiology/xenoflora)
 "rge" = (
-/obj/structure/sign/imperial,
-/turf/simulated/floor/warhammer/fancyfloor/carpet{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/area/chapel/memorial)
+/obj/structure/barricade/sandbagwall,
+/turf/simulated/floor/warhammer/plating,
+/area/hallway/primary/firstdeck/fore)
 "rhb" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/floor_decal/industrial/warning{
@@ -21352,24 +21297,16 @@
 	dir = 1;
 	icon_state = "freezer"
 	},
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "rmb" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 1
 	},
-/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "rnb" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/floor_decal/industrial/outline/yellow,
-/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "rnp" = (
@@ -21383,6 +21320,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
+/obj/machinery/chem_master,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "rpb" = (
@@ -21421,7 +21359,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "rsb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -21436,7 +21374,6 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/security/detectives_office)
 "rsu" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -21444,11 +21381,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	secured_wires = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/wall/prepainted,
 /area/security/opscheck)
 "rtb" = (
 /obj/structure/table/steel,
@@ -21490,9 +21423,9 @@
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "ruz" = (
-/obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/warhammer/ceramic/blackstone,
-/area/rnd/xenobiology/xenoflora)
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/warhammer/plating,
+/area/crew_quarters/safe_room/firstdeck)
 "ruS" = (
 /obj/structure/sign/chemistry,
 /turf/simulated/wall/prepainted,
@@ -21787,7 +21720,7 @@
 	},
 /obj/structure/closet/secure_closet/guncabinet/sidearm,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "rLb" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/wallframe_spawn/reinforced_phoron,
@@ -21961,7 +21894,7 @@
 "rYN" = (
 /obj/machinery/papershredder,
 /obj/machinery/light,
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "rZb" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -22084,9 +22017,6 @@
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/safe_room/medical)
 "scr" = (
-/obj/machinery/door/airlock/medical{
-	name = "Equipment Storage"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -22099,6 +22029,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/glass{
+	name = "Medicae Foyer";
+	req_access = list("ACCESS_MEDICAL_COMMAND")
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/equipstorage)
 "scC" = (
@@ -22108,14 +22042,14 @@
 /turf/simulated/floor/warhammer/surgerynew,
 /area/medical/counselor)
 "scD" = (
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/warhammer/big_wood_table{
+	icon_state = "wood_1tileendtable";
+	dir = 8
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/command/conference)
 "sdb" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Access"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -22123,16 +22057,21 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/warhammer/command/ancient{
+	name = "Maintenance Hatch";
+	req_access = list("ACCESS_MECHANICUS_COMMAND")
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/rnd/research)
 "sde" = (
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "seb" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Xenoflora Lab Maintenance"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/command/ancient{
+	name = "Maintenance Hatch";
+	req_access = list("ACCESS_MECHANICUS_COMMAND")
+	},
 /turf/simulated/floor/warhammer/newsteel/dark,
 /area/rnd/xenobiology/xenoflora)
 "sfb" = (
@@ -22262,9 +22201,6 @@
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/xenobiology/xenoflora)
 "smb" = (
-/obj/machinery/door/airlock/glass/research{
-	name = "Xenoflora Laboratory"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -22283,6 +22219,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/engineering,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/xenobiology/xenoflora)
 "smp" = (
@@ -22541,7 +22478,6 @@
 "sBg" = (
 /obj/structure/table/warhammer/reinf_table,
 /obj/random/loot/lasbundle,
-/obj/random/loot/lasbundle,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/armoury)
 "sCb" = (
@@ -22616,6 +22552,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
+"sFY" = (
+/obj/structure/sign/medposte3,
+/turf/simulated/wall/prepainted,
+/area/medical/surgery)
 "sGs" = (
 /obj/structure/sign/warning/nosmoking_1{
 	dir = 4;
@@ -22628,6 +22568,8 @@
 	dir = 1;
 	pixel_y = -28
 	},
+/obj/structure/bed/warhammer/barrack,
+/obj/structure/bed/warhammer/barrack1,
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/staging)
 "sHb" = (
@@ -22660,6 +22602,15 @@
 /obj/structure/closet/crate/warhammer/biohazard,
 /turf/simulated/floor/warhammer/brick,
 /area/chapel/memorial)
+"sJO" = (
+/obj/structure/barricade/concrete{
+	dir = 1
+	},
+/obj/structure/barricade/concrete{
+	dir = 8
+	},
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "sLb" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
@@ -22720,8 +22671,11 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/rnd/xenobiology)
 "sOd" = (
-/obj/structure/table/steel_reinforced,
 /obj/item/storage/slide_projector,
+/obj/structure/table/warhammer/big_wood_table{
+	icon_state = "wood_1tilethick";
+	dir = 4
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/command/conference)
 "sOo" = (
@@ -23080,11 +23034,12 @@
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
 "tgT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/barricade/concrete{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/obj/structure/barricade/concrete,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "thb" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/structure/cable/green{
@@ -23142,8 +23097,11 @@
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/firstdeck/aft)
 "tiQ" = (
-/turf/simulated/wall/ocp_wall,
-/area/security/secure_storage)
+/obj/structure/barricade/concrete{
+	dir = 8
+	},
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "tkb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23407,9 +23365,9 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/foreport)
 "tCm" = (
-/obj/structure/sign/medposter,
-/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
-/area/chapel/memorial)
+/obj/structure/sign/imperial,
+/turf/simulated/wall/r_wall/hull,
+/area/engineering/fuelbay/aux)
 "tCu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23481,7 +23439,7 @@
 	pixel_x = 22;
 	pixel_y = -6
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "tGe" = (
 /obj/structure/cable/green{
@@ -23543,7 +23501,7 @@
 /obj/item/device/paicard,
 /obj/item/device/taperecorder,
 /obj/item/device/tape,
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "tRX" = (
 /obj/structure/railing/mapped{
@@ -23720,6 +23678,13 @@
 	},
 /turf/simulated/floor/warhammer/plating,
 /area/hallway/primary/firstdeck/aft)
+"uhe" = (
+/obj/structure/table/steel,
+/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "uhl" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -23797,6 +23762,8 @@
 "urA" = (
 /obj/structure/table/warhammer/reinf_table,
 /obj/item/melee/whip,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
 /turf/simulated/floor/warhammer/brick,
 /area/chapel/memorial)
 "usN" = (
@@ -23947,6 +23914,9 @@
 	pixel_x = -23;
 	pixel_y = -10
 	},
+/obj/structure/torchwall{
+	dir = 4
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/medicalhallway)
 "uLB" = (
@@ -23968,6 +23938,12 @@
 	},
 /turf/simulated/floor/warhammer/plating,
 /area/security/wing)
+"uMM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "uOQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24138,8 +24114,11 @@
 /turf/simulated/floor/warhammer/plating,
 /area/thruster/d1starboard)
 "vfK" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/glass{
+	name = "Medicae Foyer";
+	req_access = list("ACCESS_MEDICAL_COMMAND")
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/equipstorage)
 "vgr" = (
@@ -24260,9 +24239,6 @@
 /obj/structure/hygiene/sink{
 	dir = 4;
 	pixel_x = 11
-	},
-/obj/item/storage/mirror{
-	pixel_x = 32
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -24392,8 +24368,8 @@
 	name = "Chemistry Cleaner"
 	},
 /obj/item/storage/box/autoinjectors,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/torchwall{
+	dir = 8
 	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/chemistry)
@@ -24406,13 +24382,13 @@
 /turf/simulated/wall/ocp_wall,
 /area/security/evidence)
 "vPW" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/floor_decal/techfloor,
 /obj/floor_decal/techfloor{
 	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/armoury)
@@ -24485,10 +24461,10 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/equipstorage)
 "vZK" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/torchwall{
 	dir = 4
 	},
 /turf/simulated/floor/warhammer/coralg,
@@ -24497,13 +24473,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "wcw" = (
 /turf/simulated/floor/warhammer/fancyfloor/carpet{
 	dir = 9
@@ -24517,6 +24488,14 @@
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/bo)
+"weT" = (
+/obj/structure/barricade/sandbagwall,
+/turf/simulated/floor/warhammer/plating,
+/area/hallway/primary/firstdeck/fore)
+"wfo" = (
+/obj/structure/curtain/open,
+/turf/simulated/floor/warhammer/coralg,
+/area/medical/staging)
 "whm" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -24525,6 +24504,10 @@
 /obj/item/device/radio/intercom/department/security{
 	dir = 8;
 	pixel_x = 21
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 9
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/wing)
@@ -24568,9 +24551,6 @@
 /obj/item/storage/box/rxglasses,
 /obj/item/clothing/accessory/stethoscope,
 /obj/item/device/flashlight/pen,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/warhammer/coralg,
 /area/medical/equipstorage)
 "wlP" = (
@@ -24662,11 +24642,9 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/security/brig)
 "wBc" = (
-/obj/structure/sign/medical1,
-/turf/simulated/floor/warhammer/fancyfloor/carpet{
-	dir = 4
-	},
-/area/chapel/memorial)
+/obj/structure/sign/mechanicus,
+/turf/simulated/wall/prepainted,
+/area/rnd/entry)
 "wDm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/warhammer/butcher_table,
@@ -24684,6 +24662,15 @@
 "wEw" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/thruster/d1port)
+"wGd" = (
+/obj/structure/barricade/concrete{
+	dir = 1
+	},
+/obj/structure/barricade/concrete{
+	dir = 4
+	},
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "wHE" = (
 /obj/structure/table/rack/dark,
 /obj/item/storage/box/lights/mixed,
@@ -24721,6 +24708,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue/autopsy)
+"wUL" = (
+/obj/structure/barricade/concrete{
+	dir = 4
+	},
+/obj/structure/barricade/concrete,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
+/area/rnd/misc_lab)
 "wXc" = (
 /obj/item/device/radio/intercom/entertainment{
 	dir = 4;
@@ -24882,10 +24876,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "xzK" = (
-/obj/structure/bed/chair/warhammer/padded/red,
 /obj/machinery/camera/network/security{
 	c_tag = "Security  - Lobby"
 	},
@@ -24922,7 +24915,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "xCn" = (
 /obj/machinery/hologram/holopad,
@@ -24957,15 +24950,10 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/centralstarboard)
 "xFx" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/green,
 /obj/structure/table/rack/dark,
 /obj/random/loot/swordmelee,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/security/secure_storage)
+/area/security/armoury)
 "xFL" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/robotics_lift)
@@ -25016,7 +25004,7 @@
 /area/medical/exam_room)
 "xMP" = (
 /obj/structure/table/steel,
-/obj/machinery/reagent_temperature,
+/obj/item/device/integrated_circuit_printer,
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/misc_lab)
 "xPU" = (
@@ -25073,7 +25061,7 @@
 /area/medical/sleeper)
 "xVt" = (
 /obj/machinery/computer/modular/preset/civilian,
-/turf/simulated/floor/warhammer/ceramic/old,
+/turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/rnd/office)
 "xYM" = (
 /turf/simulated/wall/prepainted,
@@ -32532,15 +32520,15 @@ aCv
 aBb
 aBb
 aBb
-aBb
-aBb
-aBb
-aBb
-aBb
-aBb
-aBb
-aBb
-aBb
+oMb
+oMb
+oMb
+oMb
+oMb
+oMb
+oMb
+oMb
+oMb
 tAS
 aaa
 aaa
@@ -32734,7 +32722,7 @@ aCv
 bNL
 brN
 aLv
-tiQ
+oMb
 oXv
 aOE
 kSs
@@ -32742,7 +32730,7 @@ xRu
 sBg
 vPW
 rEK
-aBb
+oMb
 tAS
 aaa
 aaa
@@ -32936,7 +32924,7 @@ elT
 cZi
 cZi
 ujx
-tiQ
+oMb
 ozG
 hLf
 aPu
@@ -32944,7 +32932,7 @@ xRu
 uie
 umz
 pxv
-aBb
+oMb
 tAS
 aaa
 aaa
@@ -33138,15 +33126,15 @@ wvZ
 enM
 enM
 sHN
-tiQ
+oMb
 aMC
-eHp
+hLf
 xFx
 xRu
 aKv
 dPr
 aWQ
-aBb
+oMb
 tAS
 aaa
 aaa
@@ -33340,7 +33328,7 @@ gGO
 daN
 aKw
 aLw
-tiQ
+oMb
 jft
 wbE
 rKP
@@ -33348,7 +33336,7 @@ xRu
 hWR
 lcI
 bii
-aBb
+oMb
 tAS
 aaa
 aaa
@@ -33545,12 +33533,12 @@ uPo
 kCN
 bGh
 aOF
-oXx
+aEw
 qyX
 aEw
 qWF
 maU
-aBb
+oMb
 tAS
 aaa
 aaa
@@ -33744,15 +33732,15 @@ aLz
 uRO
 enM
 usN
-tiQ
+oMb
 iLA
-tgT
-dIw
+vFa
+etI
 xRu
 eqZ
 vFa
 etI
-aBb
+oMb
 tAS
 aaa
 aaa
@@ -33946,7 +33934,7 @@ lRa
 uRO
 aKy
 huf
-tiQ
+oMb
 ePu
 aOG
 jhf
@@ -33954,7 +33942,7 @@ oMb
 pud
 rby
 buX
-aBb
+oMb
 tAS
 aaa
 aaa
@@ -34148,15 +34136,15 @@ aMT
 hbP
 nli
 nli
-oby
-oby
-oby
-oby
-oby
-oby
-oby
-aBb
-aBb
+oMb
+oMb
+oMb
+oMb
+oMb
+oMb
+oMb
+oMb
+oMb
 tAS
 aaa
 aaa
@@ -34352,7 +34340,7 @@ aKA
 aLA
 aMD
 oby
-aPv
+pjR
 aPv
 tKE
 vrM
@@ -34724,7 +34712,7 @@ hBr
 hBr
 adM
 csb
-csb
+ruz
 csb
 adM
 aiO
@@ -34926,7 +34914,7 @@ hBr
 hBr
 adM
 csb
-csb
+aAK
 csb
 adM
 aiP
@@ -35363,7 +35351,7 @@ bpb
 aij
 lcL
 aNG
-pjR
+dkV
 aOI
 aRo
 aSo
@@ -35746,11 +35734,11 @@ vMw
 vMw
 vMw
 vMw
-eim
-vJO
+kbb
+uJd
 oIb
 avI
-pAb
+htb
 axO
 xRh
 xRh
@@ -35938,13 +35926,13 @@ adU
 aeI
 afI
 aqd
-sCM
+rge
 aqd
 ajU
 akV
-aqd
+weT
 aOJ
-aqd
+bKW
 aqd
 aqd
 aqd
@@ -36144,7 +36132,7 @@ ahI
 aiU
 ajV
 akW
-akW
+mgI
 ast
 qKH
 apf
@@ -36955,7 +36943,7 @@ hIl
 alZ
 ang
 aob
-njj
+cGQ
 aqd
 mib
 aDL
@@ -41207,20 +41195,20 @@ uSl
 axe
 ayh
 hdb
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aAr
-aAK
+aJS
 aIB
 jjh
 jjh
@@ -41409,20 +41397,20 @@ uSl
 dRf
 ayg
 hdb
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aPO
 jjh
 aRB
@@ -41611,20 +41599,20 @@ kUb
 awc
 mvl
 azm
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aPL
 aQI
 aRC
@@ -41813,20 +41801,20 @@ mrX
 lfb
 ayi
 adx
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aPM
 jjh
 aRB
@@ -42015,20 +42003,20 @@ uSl
 axi
 ayg
 hdb
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aPN
 oAx
 jjh
@@ -42217,20 +42205,20 @@ oJb
 lgb
 bHp
 hdb
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aPO
 jjh
 aRD
@@ -42420,19 +42408,19 @@ hdb
 ayj
 azp
 aAs
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aPP
 aQJ
 aRE
@@ -42621,20 +42609,20 @@ oJb
 hdb
 ayg
 hdb
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aPQ
 jjh
 aRD
@@ -42823,20 +42811,20 @@ ldb
 hdb
 lib
 hdb
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aIB
 oAx
 jjh
@@ -43025,20 +43013,20 @@ oJb
 lMD
 ayi
 ghI
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aPO
 jjh
 aRF
@@ -43227,20 +43215,20 @@ oJb
 abf
 ayg
 azq
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aPR
 aQK
 aRG
@@ -43429,20 +43417,20 @@ oJb
 koX
 ayg
 hdb
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aPQ
 jjh
 aRF
@@ -43631,20 +43619,20 @@ leb
 axa
 aym
 axa
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
-aAK
+auN
+auN
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
+aJS
 aIB
 jjh
 jjh
@@ -44017,12 +44005,12 @@ abP
 aef
 cjb
 rhO
-vzy
+aFb
 cTb
 fxe
 fxe
 qju
-kCb
+sFY
 fCb
 gib
 jxb
@@ -44230,7 +44218,7 @@ gjb
 kcb
 xvt
 kCb
-leb
+bmb
 kSb
 lbb
 leb
@@ -44251,7 +44239,7 @@ cQo
 lfM
 aOj
 aJS
-aBO
+bKq
 cQo
 aRJ
 aSD
@@ -44432,11 +44420,11 @@ kCb
 ePb
 kCb
 kCb
-kLb
+leb
 kTb
 lcb
 leb
-lMD
+aGE
 ayi
 azn
 auN
@@ -44464,11 +44452,11 @@ aaa
 aaa
 aaa
 aaa
-aVa
+qqb
 bCb
 bCb
 bCb
-aVa
+qqb
 aaa
 aaa
 aaa
@@ -44637,8 +44625,8 @@ lHO
 oCf
 pjV
 jul
-leb
-xSf
+jZb
+hdb
 ayg
 hdb
 aAx
@@ -45243,8 +45231,8 @@ leb
 leb
 leb
 leb
-leb
-xSf
+jZb
+hdb
 ayp
 hdb
 awX
@@ -45446,7 +45434,7 @@ ipq
 aGx
 ipq
 leb
-hdb
+xSf
 gxX
 aec
 rsu
@@ -45458,7 +45446,7 @@ awX
 rap
 qFb
 ptb
-qqb
+mav
 ojb
 qQd
 xCf
@@ -45660,7 +45648,7 @@ awX
 jSb
 qFb
 pub
-qqb
+mav
 xVt
 pOL
 rrI
@@ -45829,7 +45817,7 @@ aaI
 afq
 aaQ
 aaU
-afq
+tCm
 rhO
 cjb
 poS
@@ -45845,7 +45833,7 @@ fKb
 oGU
 glb
 glb
-ipq
+wfo
 ipq
 ipq
 oLK
@@ -45858,13 +45846,13 @@ hCb
 lob
 nQb
 lxb
-awX
+pHE
 jMb
 jXb
 pkb
 mav
-qqb
-qqb
+mav
+mav
 qEb
 mav
 mav
@@ -46262,7 +46250,7 @@ bOZ
 lyb
 lyb
 nSb
-aBP
+wBc
 jPb
 jzb
 pmb
@@ -46435,7 +46423,7 @@ aaM
 afq
 aaT
 aaX
-afq
+tCm
 afX
 cjb
 poS
@@ -46458,7 +46446,7 @@ ovb
 leb
 dMe
 xmO
-mpq
+hdb
 hqb
 ljb
 hVb
@@ -46657,7 +46645,7 @@ uKs
 orb
 orb
 orb
-acz
+gDD
 hdb
 hhb
 iVb
@@ -46669,7 +46657,7 @@ obb
 iPb
 jeb
 lBb
-qtb
+aSK
 qHb
 qab
 qzb
@@ -46863,15 +46851,15 @@ vIn
 ssg
 bEQ
 hdb
-htb
+wBc
 hGb
 nKb
 nKb
 ocb
-aBP
+wBc
 pab
 qFb
-qtb
+aSK
 qHb
 qbb
 qtb
@@ -47073,7 +47061,7 @@ odb
 mUm
 jRb
 qFb
-qtb
+aSK
 qHb
 qcb
 qzb
@@ -47263,19 +47251,19 @@ dXM
 tgg
 gDb
 gDb
-acz
+gDD
 hdb
 igp
 azm
 hwb
 aCf
-hZb
-aFb
-iHb
+aCf
+aCf
+aCf
 aCf
 qrb
 mTb
-qtb
+aSK
 qHb
 qdb
 qAb
@@ -47478,12 +47466,12 @@ aCf
 dlf
 mTb
 aSK
-qtb
-qtb
+aSK
+aSK
 aSK
 rdb
-ruz
-ruz
+aSK
+aSK
 smb
 swb
 aSK
@@ -47676,7 +47664,7 @@ hKb
 ibb
 isb
 jkb
-aGE
+aCf
 qrb
 oeb
 pvb
@@ -47898,11 +47886,11 @@ bDK
 bDK
 aaa
 aaa
-gww
+hMJ
 bDb
 bDb
 bDb
-gww
+hMJ
 aaa
 aaa
 aaa
@@ -48070,7 +48058,7 @@ aqP
 nBb
 iMW
 twz
-twz
+oTA
 nCb
 hdb
 ayw
@@ -48080,7 +48068,7 @@ lmb
 lqb
 ltb
 iLb
-aGE
+aCf
 qrb
 oQb
 aSK
@@ -48250,9 +48238,9 @@ owb
 kdx
 wcw
 doe
-rge
-rge
-rge
+doe
+doe
+doe
 doe
 doe
 gEb
@@ -48269,7 +48257,7 @@ adn
 aeB
 afm
 qLr
-nCb
+kYZ
 omb
 twz
 avo
@@ -48452,22 +48440,22 @@ jxa
 gdl
 qXS
 kbl
-cGQ
-gDD
-tCm
+kbl
+kbl
+kbl
 kbl
 kbl
 jlB
 gyV
 alo
-erb
+lHj
 cEb
 fmb
 jCM
 jCM
 jCM
 jCM
-aqQ
+iHb
 aeC
 afo
 aqQ
@@ -48487,7 +48475,7 @@ abk
 abk
 jUb
 oUb
-bmb
+aSK
 pOb
 pYb
 qLb
@@ -48654,9 +48642,9 @@ owb
 kdx
 tTx
 pzx
-wBc
-wBc
-wBc
+pzx
+pzx
+pzx
 pzx
 pzx
 sbY
@@ -48689,7 +48677,7 @@ abk
 abk
 rap
 mTb
-bmb
+aSK
 pQb
 pYb
 qLb
@@ -48891,7 +48879,7 @@ abk
 abk
 qrb
 mTb
-bmb
+aSK
 pRb
 qib
 qMb
@@ -49258,7 +49246,7 @@ pIN
 cob
 cob
 cob
-kdx
+gbs
 cob
 cob
 cob
@@ -49295,7 +49283,7 @@ eqh
 abk
 jRb
 pdb
-jZb
+aHi
 pKb
 qjb
 qCb
@@ -49682,7 +49670,7 @@ jCM
 uiY
 scr
 uiY
-uiY
+kLb
 ipc
 eoj
 gFb
@@ -49697,7 +49685,7 @@ acT
 abk
 kaS
 abk
-jZb
+aHi
 pfb
 aHi
 pKb
@@ -49893,7 +49881,7 @@ xYM
 tiz
 hnN
 cgu
-ahd
+aHi
 ahd
 ahd
 ahd
@@ -50095,13 +50083,13 @@ xYM
 kGX
 hnN
 tiz
+aHi
+sJO
+tiQ
+tiQ
+tgT
 ahd
-ahd
-ahd
-ahd
-ahd
-ahd
-kbb
+oXb
 phb
 pPb
 qlb
@@ -50297,16 +50285,16 @@ pWW
 pmz
 hnN
 tiz
+aHi
+oXx
+oXb
+oXb
+eHp
 ahd
 ahd
-ahd
-ahd
-ahd
-ahd
-hvY
 pib
-pDb
-fBb
+oXb
+oXb
 iSb
 qnb
 rvb
@@ -50499,18 +50487,18 @@ pWW
 vHB
 ayB
 azN
-ahd
-ahd
-ahd
-ahd
-ahd
-ahd
+aHi
+oXx
+pDb
+oXb
+oXb
+oVC
 kpb
 pjb
 pEb
-iqb
-jAb
 oXb
+uhe
+xMP
 oXb
 rnb
 aHi
@@ -50701,14 +50689,14 @@ pWW
 tiz
 hnN
 tiz
-ahd
-ahd
-ahd
-ahd
-ahd
-ahd
-eGb
+aHi
+oXx
 oXb
+oXb
+eHp
+ahd
+ahd
+ahd
 pFb
 oXb
 khb
@@ -50903,16 +50891,16 @@ pWW
 pmz
 jAM
 tiz
-ahd
-ahd
-ahd
-ahd
-ahd
+aHi
+wGd
+dIw
+dIw
+wUL
 ahd
 aHi
 pnb
 pGb
-xMP
+uMM
 jAb
 qDb
 qWb
@@ -51080,9 +51068,9 @@ acV
 kKb
 cob
 abN
-abN
+hZb
 aci
-abN
+hZb
 mpy
 mpy
 mpy
@@ -51105,7 +51093,7 @@ pWW
 tiz
 jAM
 tiz
-ahd
+aHi
 ahd
 ahd
 ahd
@@ -51124,9 +51112,9 @@ aNy
 bDK
 bDK
 bDK
-xPU
+mpq
 aUf
-xPU
+mpq
 xPU
 aaa
 aaa

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -69,6 +69,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/table/rack/dark,
+/obj/random/loot/rarearmorbundle,
 /turf/simulated/floor/warhammer/coralg,
 /area/bridge/storage)
 "ak" = (
@@ -88,6 +89,14 @@
 	icon_state = "bedr";
 	pixel_y = 20;
 	pixel_x = -7
+	},
+/obj/item/bedsheet/brown{
+	pixel_y = 15;
+	pixel_x = -3
+	},
+/obj/item/bedsheet/brown{
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
@@ -309,7 +318,7 @@
 /area/crew_quarters/heads/cobed)
 "aK" = (
 /obj/structure/sign/rpainting2,
-/turf/simulated/wall/r_wall/hull,
+/turf/simulated/wall/ocp_wall,
 /area/bridge/storage)
 "aM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -417,18 +426,21 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/bridge/aft)
 "aZ" = (
-/obj/floor_decal/spline/fancy/wood{
-	icon = 'icons/map_project/roguefloor.dmi';
-	icon_state = "borderfall";
-	layer = 2.8;
-	color = "grey"
-	},
 /obj/structure/hivedecor/statue2{
 	layer = 2.9;
 	pixel_x = -20
 	},
+/obj/structure/railing/mapped{
+	icon_state = "borderfall";
+	icon = 'icons/map_project/roguefloor.dmi';
+	color = "grey";
+	layer = 2
+	},
+/obj/item/pyre/self_lit/church{
+	pixel_x = -22
+	},
 /obj/structure/sign/banner_count/flag{
-	layer = 4.1
+	layer = 3.1
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
@@ -548,10 +560,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/warhammer/command{
-	req_access = list("ACCESS_BRIDGE");
-	name = "Rogue Trader's Chamber"
+/obj/floor_decal/spline/fancy/wood{
+	dir = 1
 	},
+/obj/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/warhammer/coralg,
 /area/crew_quarters/heads/office/co)
 "bx" = (
@@ -833,7 +845,7 @@
 /obj/structure/hivedecor/statue4{
 	pixel_x = -14
 	},
-/turf/simulated/floor/warhammer/fancyfloor/ancient_cobble_old,
+/turf/simulated/floor/warhammer/coralg,
 /area/crew_quarters/heads/office/co)
 "cu" = (
 /obj/structure/cable/green{
@@ -841,16 +853,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
-/area/bridge)
-"cv" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/hivedecor/statue7,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
 "cw" = (
@@ -1233,6 +1235,8 @@
 /obj/item/gun/projectile/revolver/imperial/captain{
 	pixel_y = -3
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/crew_quarters/heads/cobed)
 "da" = (
@@ -1443,6 +1447,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/steel_reinforced,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
 "dS" = (
@@ -1476,11 +1484,13 @@
 /area/maintenance/auxsolarbridge)
 "dW" = (
 /obj/structure/sign/banner_count/flag{
-	layer = 4.1;
+	layer = 2;
 	icon = 'icons/obj/structures/stairs.dmi';
 	icon_state = "above";
 	dir = 1;
-	color = "#4c535b"
+	color = "#4c535b";
+	health_max = 1500;
+	name = "Stairway"
 	},
 /turf/simulated/floor/warhammer/fancyfloor/carpet/blue{
 	dir = 4
@@ -1663,10 +1673,9 @@
 /obj/structure/bed/chair/warhammer/padded/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/crew_quarters/heads/cobed)
 "eC" = (
@@ -1707,10 +1716,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
 	},
 /obj/structure/table/steel_reinforced,
 /obj/machinery/computer/ship/helm{
@@ -2268,6 +2273,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge/hallway/port)
+"fU" = (
+/obj/structure/torchwall{
+	dir = 4
+	},
+/turf/simulated/floor/warhammer/darkwood,
+/area/crew_quarters/heads/cobed)
 "fV" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/device/radio/intercom{
@@ -2328,6 +2339,10 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/computer/modular/preset/cardslot/command{
+	dir = 4;
+	icon_state = "console"
 	},
 /turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
@@ -2490,16 +2505,15 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftstarboard)
 "gJ" = (
-/obj/floor_decal/spline/fancy/wood{
-	icon = 'icons/map_project/roguefloor.dmi';
-	icon_state = "borderfall";
-	dir = 8;
-	layer = 3;
-	color = "grey";
-	health_max = 1000
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/warhammer/metal/alt,
-/area/bridge)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
+/area/crew_quarters/heads/cobed)
 "gL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2550,22 +2564,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/prepainted,
+/turf/simulated/wall/ocp_wall,
 /area/maintenance/bridge/foreport)
 "gR" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/bridge/fore)
 "gT" = (
@@ -2613,7 +2623,8 @@
 /area/aquila/medical)
 "hb" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Cockpit"
+	name = "Cockpit";
+	req_access = list("ACCESS_RESTRICTED_COMMAND")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2648,14 +2659,12 @@
 /turf/simulated/floor/warhammer/coralg,
 /area/crew_quarters/heads/office/co)
 "hn" = (
-/obj/floor_decal/spline/fancy/wood{
-	icon = 'icons/map_project/roguefloor.dmi';
-	icon_state = "borderfall";
+/obj/structure/railing/mapped{
 	dir = 4;
-	layer = 3;
+	icon_state = "borderfall";
+	icon = 'icons/map_project/roguefloor.dmi';
 	color = "grey";
-	density = 1;
-	health_max = 1000
+	health_max = 1500
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
@@ -2809,12 +2818,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/spline/fancy/wood{
-	icon = 'icons/map_project/roguefloor.dmi';
-	icon_state = "borderfall";
-	layer = 2.8;
-	color = "grey"
-	},
 /obj/structure/table/warhammer/big_wood_table{
 	dir = 8;
 	pixel_x = 7;
@@ -2830,7 +2833,16 @@
 	pixel_x = -12
 	},
 /obj/structure/sign/banner_count/flag{
-	layer = 2.9
+	layer = 3.1
+	},
+/obj/structure/railing/mapped{
+	icon_state = "borderfall";
+	icon = 'icons/map_project/roguefloor.dmi';
+	color = "grey";
+	layer = 2
+	},
+/obj/item/pyre/self_lit/church{
+	pixel_x = 19
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
@@ -2863,6 +2875,7 @@
 	icon = 'icons/map_project/furniture_and_decor.dmi';
 	icon_state = "smelter1"
 	},
+/obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/warhammer/fancyfloor/carpet{
 	dir = 1
 	},
@@ -2992,6 +3005,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/aquila/air)
+"iF" = (
+/turf/simulated/wall/ocp_wall,
+/area/crew_quarters/heads/office/sgr)
 "iI" = (
 /turf/simulated/wall/r_wall/hull,
 /area/space)
@@ -3509,7 +3525,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/r_wall/hull,
+/turf/simulated/wall/ocp_wall,
 /area/bridge)
 "lA" = (
 /obj/structure/sign/warning/high_voltage{
@@ -3736,7 +3752,8 @@
 /area/aquila/airlock)
 "lZ" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Passenger Seating"
+	name = "Passenger Seating";
+	req_access = list("ACCESS_RESTRICTED_COMMAND")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3838,6 +3855,7 @@
 /area/bridge)
 "mI" = (
 /obj/structure/table/rack/dark,
+/obj/random/loot/basicarmorbundle,
 /turf/simulated/floor/warhammer/coralg,
 /area/bridge/storage)
 "mJ" = (
@@ -4110,9 +4128,6 @@
 	},
 /area/bridge)
 "nv" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/simulated/floor/warhammer/fancyfloor/carpet,
 /area/crew_quarters/heads/cobed)
 "nE" = (
@@ -4180,6 +4195,10 @@
 	icon_state = "paperwork";
 	pixel_y = 4;
 	layer = 3
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
@@ -4285,8 +4304,12 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/bridge/aftport)
 "on" = (
-/turf/simulated/wall/prepainted,
-/area/aux_eva)
+/obj/floor_decal/spline/fancy/wood/corner,
+/obj/floor_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/turf/simulated/floor/warhammer/coralg,
+/area/crew_quarters/heads/office/co)
 "ox" = (
 /turf/simulated/wall/ocp_wall,
 /area/bridge)
@@ -4298,9 +4321,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
 "oE" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
+/obj/structure/torchwall{
+	dir = 8
 	},
 /turf/simulated/floor/warhammer/fancyfloor/carpet{
 	dir = 4
@@ -4310,7 +4332,7 @@
 /obj/structure/hivedecor/statue3{
 	pixel_x = -14
 	},
-/turf/simulated/floor/warhammer/fancyfloor/ancient_cobble_old,
+/turf/simulated/floor/warhammer/coralg,
 /area/crew_quarters/heads/office/co)
 "oK" = (
 /obj/wallframe_spawn/reinforced,
@@ -4332,18 +4354,21 @@
 	icon_state = "1-2"
 	},
 /obj/structure/sign/banner_count/flag{
-	layer = 4.1;
+	layer = 2;
 	icon = 'icons/obj/structures/stairs.dmi';
 	icon_state = "above";
 	dir = 1;
-	color = "#4c535b"
+	color = "#4c535b";
+	health_max = 1500;
+	name = "Stairway"
 	},
 /turf/simulated/floor/warhammer/fancyfloor/carpet/blue{
 	dir = 8
 	},
 /area/bridge)
 "oP" = (
-/obj/structure/closet/crate/warhammer/secure,
+/obj/structure/closet/crate/warhammer,
+/obj/random/loot/valuableloot,
 /obj/random/loot/raresidearmbundle,
 /turf/simulated/floor/warhammer/coralg,
 /area/bridge/storage)
@@ -4441,7 +4466,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/hatch{
-	name = "Engineering"
+	name = "Engineering";
+	req_access = list("ACCESS_RESTRICTED_COMMAND")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4490,7 +4516,9 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/aquila/airlock)
 "ph" = (
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	req_access = list("ACCESS_RESTRICTED_COMMAND")
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4627,24 +4655,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/floor_decal/spline/fancy/wood{
-	icon = 'icons/map_project/roguefloor.dmi';
-	icon_state = "borderfall";
+/obj/structure/railing/mapped{
 	dir = 4;
-	layer = 3;
+	icon_state = "borderfall";
+	icon = 'icons/map_project/roguefloor.dmi';
 	color = "grey";
-	health_max = 1000
+	health_max = 1500
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
 "pJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/crate/warhammer/secure,
-/obj/random/loot/raregunsenergy,
+/obj/structure/table/rack/dark,
+/obj/random/loot/rarearmorbundle,
 /turf/simulated/floor/warhammer/coralg,
 /area/bridge/storage)
 "pL" = (
@@ -4759,6 +4781,7 @@
 /obj/structure/closet/crate/warhammer/xenos/chest3,
 /obj/random/loot/tech2,
 /obj/random/loot/lootartifacts,
+/obj/random/loot/lootcontraband,
 /turf/simulated/floor/warhammer/coralg,
 /area/bridge/storage)
 "qg" = (
@@ -4933,10 +4956,6 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
 	},
 /obj/machinery/shieldwallgen/online,
 /obj/structure/cable/green{
@@ -5268,11 +5287,6 @@
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/crew_quarters/heads/office/xo)
 "rK" = (
-/obj/machinery/door/airlock/sol{
-	id_tag = "captaindoor";
-	name = "Commanding Officer";
-	secured_wires = 1
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -5293,6 +5307,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/command{
+	req_access = list("ACCESS_BRIDGE");
+	name = "Seneschal's Office"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
 "rQ" = (
@@ -5471,7 +5489,7 @@
 	pixel_x = -2;
 	pixel_y = 39
 	},
-/turf/simulated/floor/warhammer/fancyfloor/ancient_cobble_old,
+/turf/simulated/floor/warhammer/coralg,
 /area/crew_quarters/heads/office/co)
 "sS" = (
 /obj/machinery/door/firedoor,
@@ -5704,7 +5722,7 @@
 	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
-/obj/structure/closet/crate/warhammer/freezer/rations,
+/obj/structure/closet/secure_closet/crew,
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/storage)
 "tN" = (
@@ -5718,7 +5736,7 @@
 	dir = 6
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/guncabinet/sidearm,
+/obj/structure/closet/secure_closet/crew,
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/storage)
 "tR" = (
@@ -5729,6 +5747,9 @@
 /obj/structure/sign/portrait_large2,
 /turf/simulated/wall/prepainted,
 /area/bridge/meeting_room)
+"tV" = (
+/turf/simulated/wall/ocp_wall,
+/area/bridge/disciplinary_board_room)
 "tW" = (
 /obj/floor_decal/techfloor{
 	dir = 8
@@ -5737,22 +5758,17 @@
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/safe_room/bridge)
 "tZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/bed/warhammer,
-/turf/simulated/floor/warhammer/plating,
-/area/crew_quarters/safe_room/bridge)
-"ua" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/warhammer/fancyfloor/carpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/torchwall,
+/turf/simulated/wall/ocp_wall,
 /area/crew_quarters/heads/cobed)
+"ua" = (
+/obj/structure/closet/crate/warhammer,
+/obj/random/loot/valuableloot,
+/obj/random/loot/tech1,
+/turf/simulated/floor/warhammer/coralg,
+/area/bridge/storage)
 "ub" = (
 /obj/structure/bed/chair/warhammer/padded/blue{
 	dir = 4
@@ -6535,6 +6551,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/structure/closet/crate/warhammer/freezer/rations,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/bridge)
 "wA" = (
@@ -6547,6 +6564,9 @@
 "wH" = (
 /obj/machinery/light/small,
 /obj/structure/table/woodentable_reinforced/walnut/maple,
+/obj/item/stamp/sea,
+/obj/item/stamp/sea,
+/obj/item/stamp/sea,
 /turf/simulated/floor/warhammer/brick,
 /area/bridge/disciplinary_board_room)
 "wI" = (
@@ -7138,6 +7158,7 @@
 "yL" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/firecloset,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/bridge)
 "yM" = (
@@ -7146,10 +7167,6 @@
 /turf/simulated/wall/r_wall/hull,
 /area/crew_quarters/heads/cobed)
 "yR" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	secured_wires = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 2;
@@ -7163,6 +7180,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/warhammer{
+	name = "Security Checkpoint";
+	req_access = list("ACCESS_RESTRICTED_COMMAND")
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bridgecheck)
 "yS" = (
@@ -7500,7 +7521,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/r_wall/hull,
+/turf/simulated/wall/ocp_wall,
 /area/bridge/storage)
 "AI" = (
 /obj/structure/disposalpipe/segment,
@@ -7574,6 +7595,9 @@
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/aquila/airlock)
+"Bl" = (
+/turf/simulated/wall/ocp_wall,
+/area/maintenance/bridge/foreport)
 "Bo" = (
 /obj/machinery/door/blast/gates/middle{
 	id_tag = "roguegates";
@@ -7581,6 +7605,19 @@
 	},
 /turf/simulated/floor/warhammer/fancyfloor/carpet/blue,
 /area/crew_quarters/heads/office/co)
+"Bu" = (
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "borderfall";
+	icon = 'icons/map_project/roguefloor.dmi';
+	color = "grey";
+	health_max = 1500
+	},
+/obj/item/pyre/self_lit/church{
+	pixel_x = -9
+	},
+/turf/simulated/floor/warhammer/metal/alt,
+/area/bridge)
 "Bw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7624,7 +7661,7 @@
 	dir = 4
 	},
 /obj/structure/lattice,
-/turf/simulated/wall/prepainted,
+/turf/simulated/wall/ocp_wall,
 /area/maintenance/bridge/foreport)
 "BO" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
@@ -7702,6 +7739,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/torchwall{
+	dir = 4
 	},
 /turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
@@ -7821,14 +7861,21 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
 "CN" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftport)
 "CO" = (
-/turf/simulated/wall/r_wall/hull,
-/area/aux_eva)
+/obj/structure/closet/crate/warhammer,
+/obj/random/loot/valuableloot,
+/obj/random/loot/raregunsenergy,
+/turf/simulated/floor/warhammer/coralg,
+/area/bridge/storage)
 "CU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8330,6 +8377,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/bridge/fore)
 "Gx" = (
@@ -8337,6 +8386,7 @@
 	icon_state = "wood_1tileendtable";
 	dir = 8
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
 "Gy" = (
@@ -8375,11 +8425,13 @@
 	},
 /area/crew_quarters/heads/cobed)
 "GB" = (
-/obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 8;
-	icon_state = "console"
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/paper_bin{
+	icon = 'icons/map_project/fluff_items.dmi';
+	icon_state = "paperwork";
+	pixel_y = 4;
+	layer = 3
 	},
-/obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/crew_quarters/heads/cobed)
 "GD" = (
@@ -8418,6 +8470,16 @@
 	},
 /turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
+"GP" = (
+/obj/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/bed/warhammer,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/warhammer/plating,
+/area/crew_quarters/safe_room/bridge)
 "GU" = (
 /obj/structure/displaycase,
 /obj/machinery/light,
@@ -8559,16 +8621,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/floor_decal/spline/fancy/wood{
-	icon = 'icons/map_project/roguefloor.dmi';
-	icon_state = "borderfall";
-	layer = 2.9;
-	color = "grey"
-	},
 /obj/structure/table/warhammer/big_wood_table{
 	dir = 4;
 	pixel_x = -4;
 	pixel_y = -17
+	},
+/obj/structure/railing/mapped{
+	icon_state = "borderfall";
+	icon = 'icons/map_project/roguefloor.dmi';
+	color = "grey";
+	layer = 2
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
@@ -8629,6 +8691,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
 "HX" = (
@@ -8752,10 +8815,6 @@
 /turf/simulated/floor/warhammer/plating,
 /area/crew_quarters/safe_room/bridge)
 "Iv" = (
-/obj/machinery/door/airlock/sol{
-	name = "CO's Quarters";
-	secured_wires = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8765,6 +8824,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/warhammer/command{
+	req_access = list("ACCESS_BRIDGE");
+	name = "Seneschal's Quarters"
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
 "Ix" = (
@@ -8889,8 +8952,25 @@
 /turf/simulated/wall/titanium,
 /area/aquila/power)
 "IM" = (
-/turf/simulated/floor/warhammer/coralg,
+/obj/machinery/door/airlock/warhammer/command{
+	req_access = list("ACCESS_BRIDGE");
+	name = "Rogue Trader's Chamber"
+	},
+/turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
+"IO" = (
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "borderfall";
+	icon = 'icons/map_project/roguefloor.dmi';
+	color = "grey";
+	health_max = 1500
+	},
+/obj/item/pyre/self_lit/church{
+	pixel_x = 10
+	},
+/turf/simulated/floor/warhammer/metal/alt,
+/area/bridge)
 "IT" = (
 /obj/machinery/photocopier,
 /obj/structure/table/woodentable_reinforced/walnut,
@@ -8980,6 +9060,10 @@
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/aquila/storage)
+"JL" = (
+/obj/structure/torchwall,
+/turf/simulated/wall/ocp_wall,
+/area/crew_quarters/heads/cobed)
 "JT" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9092,7 +9176,7 @@
 	id_tag = "aquila_shuttle_inner";
 	locked = 1;
 	name = "Aquila External Access";
-	req_access = list("ACCESS_DAUNTLESS")
+	req_access = list("ACCESS_RESTRICTED_COMMAND")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
@@ -9178,10 +9262,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "Lb" = (
-/obj/structure/closet/crate/warhammer/secure,
-/obj/random/loot/rarearmorbundle,
-/turf/simulated/floor/warhammer/coralg,
-/area/bridge/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall/ocp_wall,
+/area/crew_quarters/heads/cobed)
 "Le" = (
 /obj/structure/sign/warning/high_voltage,
 /turf/simulated/wall/ocp_wall,
@@ -9269,11 +9353,13 @@
 /area/maintenance/bridge/foreport)
 "Lw" = (
 /obj/structure/sign/banner_count/flag{
-	layer = 4.1;
+	layer = 2;
 	icon = 'icons/obj/structures/stairs.dmi';
 	icon_state = "above";
 	dir = 1;
-	color = "#4c535b"
+	color = "#4c535b";
+	health_max = 1500;
+	name = "Stairway"
 	},
 /turf/simulated/floor/warhammer/fancyfloor/carpet/blue/middle,
 /area/bridge)
@@ -9312,9 +9398,6 @@
 /area/aquila/medical)
 "LR" = (
 /obj/structure/table/woodentable/walnut,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
 /obj/item/stamp/denied{
 	pixel_x = 4;
 	pixel_y = -2
@@ -9329,8 +9412,6 @@
 	pixel_x = -1;
 	pixel_y = 3
 	},
-/obj/item/reagent_containers/food/drinks/glass2/coffeecup/corp,
-/obj/item/storage/box/large/union_cards,
 /turf/simulated/floor/warhammer/fancyfloor/carpet{
 	dir = 1
 	},
@@ -9399,6 +9480,13 @@
 /area/crew_quarters/heads/office/co)
 "MA" = (
 /obj/fluid_mapped,
+/mob/living/simple_animal/hostile/carp/pike{
+	health = 350;
+	name = "royal canine";
+	color = "gold";
+	dodgey = 12;
+	blocky = 14
+	},
 /turf/simulated/floor/plating,
 /area/bridge/storage)
 "MD" = (
@@ -9573,11 +9661,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "Nw" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/warhammer/fancyfloor/carpet{
 	dir = 8
@@ -9606,7 +9694,7 @@
 	pixel_x = 11;
 	pixel_y = 33
 	},
-/turf/simulated/floor/warhammer/fancyfloor/ancient_cobble_old,
+/turf/simulated/floor/warhammer/coralg,
 /area/crew_quarters/heads/office/co)
 "NL" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -9752,14 +9840,23 @@
 /turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/crew_quarters/heads/cobed)
 "Ox" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
 "Oy" = (
 /obj/structure/table/woodentable_reinforced/walnut,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/item/toy/torchmodel,
 /turf/simulated/floor/warhammer/fancyfloor/carpet{
 	dir = 8
@@ -9773,6 +9870,8 @@
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/maintenance/bridge/aftport)
 "OM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/warhammer/fancyfloor/carpet{
 	dir = 1
 	},
@@ -9965,13 +10064,9 @@
 /turf/simulated/floor/warhammer/metal/alt,
 /area/aquila/power)
 "PW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
 "Qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10034,12 +10129,11 @@
 /turf/simulated/floor/warhammer/darkwood,
 /area/bridge/meeting_room)
 "Qp" = (
-/obj/machinery/door/airlock/sol{
-	id_tag = "captaindoorfore";
-	name = "Commanding Officer";
-	secured_wires = 1
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/warhammer/command{
+	req_access = list("ACCESS_BRIDGE");
+	name = "Seneschal's Office"
+	},
 /turf/simulated/floor/warhammer/coralg,
 /area/bridge)
 "Qq" = (
@@ -10104,11 +10198,6 @@
 /turf/simulated/floor/warhammer/ceramic/blackstone,
 /area/crew_quarters/heads/office/sgr)
 "QW" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/bookcase,
 /turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
@@ -10135,9 +10224,7 @@
 /area/aquila/storage)
 "Rd" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
 "Re" = (
@@ -10363,7 +10450,7 @@
 	id_tag = "aquila_shuttle_dock_airlock";
 	pixel_x = 24;
 	pixel_y = 24;
-	req_access = list("ACCESS_BRIDGE");
+	req_access = list("ACCESS_RESTRICTED_COMMAND");
 	tag_airpump = "aquila_shuttle_dock_pump";
 	tag_chamber_sensor = "aquila_shuttle_dock_sensor";
 	tag_exterior_door = "aquila_shuttle_dock_outer";
@@ -10390,17 +10477,9 @@
 /turf/simulated/floor/plating,
 /area/aquila/air)
 "SA" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
-	},
 /obj/paint/meatstation,
-/turf/simulated/floor/plating,
+/obj/paint/meatstation,
+/turf/simulated/wall/titanium,
 /area/aquila/cockpit)
 "SB" = (
 /obj/item/device/tape/random,
@@ -10558,12 +10637,6 @@
 /obj/machinery/hologram/holopad/longrange,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
-"Tn" = (
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 4
-	},
-/turf/simulated/floor/warhammer/plating,
-/area/crew_quarters/safe_room/bridge)
 "To" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -10603,7 +10676,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/light,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
 "TK" = (
@@ -10872,9 +10944,6 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/closet/crate/warhammer/secure,
-/obj/random/loot/tech1,
-/obj/random/loot/lootcontraband,
 /turf/simulated/floor/warhammer/coralg,
 /area/bridge/storage)
 "VC" = (
@@ -10888,7 +10957,7 @@
 /area/solar/bridge)
 "VW" = (
 /obj/structure/bed/padded,
-/obj/item/bedsheet/captain,
+/obj/item/bedsheet/brown,
 /turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/office/xo)
 "VY" = (
@@ -11040,6 +11109,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/light/small,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/bridge)
 "Xe" = (
@@ -11132,6 +11202,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/warhammer/metal/alt,
 /area/hallway/primary/bridge/fore)
+"XO" = (
+/obj/structure/torchwall{
+	dir = 1
+	},
+/turf/simulated/wall/r_wall/hull,
+/area/crew_quarters/heads/cobed)
 "XQ" = (
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -11347,15 +11423,19 @@
 	},
 /turf/simulated/floor/warhammer/darkwood,
 /area/bridge/meeting_room)
+"Zf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/warhammer/metal/alt,
+/area/bridge)
 "Zg" = (
-/obj/floor_decal/spline/fancy/wood{
-	icon = 'icons/map_project/roguefloor.dmi';
-	icon_state = "borderfall";
+/obj/structure/railing/mapped{
 	dir = 8;
-	layer = 3;
+	icon_state = "borderfall";
+	icon = 'icons/map_project/roguefloor.dmi';
 	color = "grey";
-	density = 1;
-	health_max = 1000
+	health_max = 1500
 	},
 /turf/simulated/floor/warhammer/metal/alt,
 /area/bridge)
@@ -11396,12 +11476,8 @@
 /turf/simulated/floor/warhammer/darkwood,
 /area/crew_quarters/heads/cobed)
 "ZJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/warhammer/fancyfloor/carpet/middle,
 /area/crew_quarters/heads/cobed)
 "ZM" = (
@@ -18575,16 +18651,16 @@ aa
 OE
 at
 at
-at
-at
-at
-at
-at
-at
-Ie
-Ie
+qO
+qO
+qO
+qO
+qO
+qO
+ox
+ox
 ly
-Ie
+ox
 aa
 aa
 Ie
@@ -18776,9 +18852,9 @@ aa
 OE
 at
 at
-at
-at
-yc
+qO
+qO
+ua
 yc
 af
 eq
@@ -18978,10 +19054,10 @@ OE
 at
 at
 at
-at
+qO
 mJ
 yc
-yc
+oP
 eq
 eq
 eq
@@ -19180,7 +19256,7 @@ OE
 at
 at
 at
-at
+qO
 qf
 OS
 eq
@@ -19382,21 +19458,21 @@ OE
 at
 at
 at
-at
-Lb
-oP
+qO
+eq
+eq
 eq
 eq
 mI
-at
-Ie
+qO
+ox
 CJ
 jz
 jz
 bf
 cu
 jz
-jz
+Zf
 jz
 cu
 jz
@@ -19584,9 +19660,9 @@ OE
 at
 at
 at
-at
+qO
 VB
-pJ
+db
 db
 db
 aj
@@ -19605,7 +19681,7 @@ hn
 hn
 hn
 hn
-hn
+IO
 cu
 jz
 XR
@@ -19786,13 +19862,13 @@ OE
 at
 at
 at
-at
+qO
 EJ
 zq
-yc
+CO
 eq
-mI
-at
+pJ
+qO
 GX
 cT
 Tl
@@ -19988,13 +20064,13 @@ OE
 at
 at
 at
-at
-at
+qO
+qO
 yc
 Ao
 eq
 LJ
-at
+qO
 GY
 Hc
 MV
@@ -20189,14 +20265,14 @@ aa
 OE
 at
 at
-at
-at
-at
-at
-at
+qO
+qO
+qO
+qO
+qO
 aK
-at
-at
+qO
+qO
 GZ
 Rs
 Kv
@@ -20408,12 +20484,12 @@ jz
 jz
 Gr
 cA
-gJ
 Zg
 Zg
 Zg
 Zg
 Zg
+Bu
 jz
 ex
 eV
@@ -20810,7 +20886,7 @@ yg
 Dx
 bS
 jz
-cv
+Gy
 cC
 jz
 jz
@@ -21229,8 +21305,8 @@ fC
 fS
 sy
 tm
-tZ
 uG
+GP
 uH
 vQ
 wx
@@ -21635,7 +21711,7 @@ rR
 Ik
 to
 ub
-Tn
+uH
 Pf
 vS
 wz
@@ -22421,7 +22497,7 @@ zV
 He
 He
 He
-RK
+on
 Wy
 Dx
 Gy
@@ -23018,7 +23094,7 @@ bR
 GM
 da
 dG
-dG
+fU
 aE
 cq
 ai
@@ -23045,16 +23121,16 @@ pz
 hq
 rf
 rY
-sL
-sL
-sL
-sL
-sL
-sL
-sL
-sL
-sL
-sL
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
 gP
 NW
 tg
@@ -23247,7 +23323,7 @@ iS
 hq
 rf
 Pe
-sL
+iF
 uO
 ui
 uN
@@ -23619,7 +23695,7 @@ aa
 aa
 OE
 bR
-bR
+XO
 eo
 dG
 dG
@@ -23633,7 +23709,7 @@ ik
 Ix
 GB
 ns
-ZJ
+kS
 qR
 Ti
 BY
@@ -23651,7 +23727,7 @@ fF
 Um
 xZ
 zF
-sL
+iF
 DZ
 uO
 uO
@@ -23827,17 +23903,17 @@ dG
 dG
 dG
 Gx
-aE
-cq
-dG
-dG
+Ox
+Lb
+PW
+PW
 OM
-Ix
-kS
+gJ
+ZJ
 cZ
 ZJ
-cq
-cq
+tZ
+Lb
 Gs
 gR
 fB
@@ -23853,16 +23929,16 @@ mE
 mE
 uK
 ga
-sL
-sL
-sL
-sL
-TX
-TX
-TX
-TX
-xc
-xc
+iF
+iF
+iF
+iF
+tV
+tV
+tV
+tV
+Bl
+Bl
 BG
 Fz
 tg
@@ -24028,16 +24104,16 @@ al
 dG
 dG
 dG
-cq
+JL
 aF
 aP
 bg
-cq
+JL
 LR
 Ix
 kS
-Ox
-PW
+kS
+kS
 nv
 cq
 xW
@@ -24240,7 +24316,7 @@ Oh
 kS
 Ov
 kS
-ua
+nv
 cq
 Lf
 gM
@@ -27079,15 +27155,15 @@ DN
 kP
 aV
 mZ
-on
-on
-on
-on
-on
-on
-on
-on
-on
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 uX
 Pc
 wn
@@ -27281,15 +27357,15 @@ DN
 kQ
 aU
 na
-on
-on
-on
-on
-on
-on
-on
-on
-on
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 uX
 vI
 wo
@@ -27483,15 +27559,15 @@ jY
 kR
 aW
 kM
-on
-on
-on
-on
-on
-on
-on
-on
-on
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
 dV
 vJ
 wp
@@ -27685,15 +27761,15 @@ jZ
 kN
 lN
 nc
-on
-on
-on
-on
-on
-on
-on
-on
-CO
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+DN
 dV
 dV
 wq
@@ -27887,15 +27963,15 @@ DN
 kT
 lO
 nd
-on
-on
-on
-on
-on
-on
-on
-on
-CO
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+DN
 dV
 dV
 Tc
@@ -28089,15 +28165,15 @@ DN
 kU
 Sg
 ne
-on
-on
-on
-on
-on
-on
-on
-on
-CO
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+fI
+DN
 dV
 dV
 ws
@@ -28291,15 +28367,15 @@ DN
 DN
 Tg
 DN
-CO
-CO
-CO
-CO
-CO
-CO
-CO
-CO
-CO
+DN
+DN
+DN
+DN
+DN
+DN
+DN
+DN
+DN
 dV
 ad
 wt
@@ -29895,8 +29971,8 @@ aI
 cP
 gY
 ec
-SA
-SA
+ec
+ec
 ec
 go
 ec

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -238,7 +238,7 @@
 	icon_state = "hallA"
 
 /area/crew_quarters/safe_room/firstdeck
-	name = "\improper First Deck Safe Room"
+	name = "\improper Officer Bunkroom"
 
 /area/crew_quarters/safe_room/medical
 	name = "\improper Medical Safe Room"
@@ -282,7 +282,7 @@
 	name = "\improper Officer's Bunkroom"
 
 /area/bridge/storage
-	name = "\improper Bridge Storage"
+	name = "\improper Rogue Sanctum"
 	req_access = list(access_bridge)
 
 // Shuttles
@@ -605,7 +605,7 @@
 	holomap_color = HOLOMAP_AREACOLOR_COMMAND
 
 /area/command/conference
-	name = "Briefing Room"
+	name = "Meeting Room"
 	icon_state = "briefing_room"
 	sound_env = MEDIUM_SOFTFLOOR
 
@@ -654,21 +654,21 @@
 
 /area/crew_quarters/heads/cobed
 	icon_state = "heads_cap"
-	name = "\improper Command - CO's Quarters"
+	name = "\improper Rogue Quarters"
 	sound_env = MEDIUM_SOFTFLOOR
 	req_access = list(access_roguetrader)
 	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/heads/office/co
 	icon_state = "heads_cap"
-	name = "\improper Command - CO's Office"
+	name = "\improper Rogue Hall"
 	sound_env = MEDIUM_SOFTFLOOR
 	req_access = list(access_roguetrader)
 	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/heads/office/xo
 	icon_state = "heads_hop"
-	name = "\improper Command - XO's Office"
+	name = "\improper Seneschal's Office"
 	req_access = list(access_dauntless)
 	lighting_tone = AREA_LIGHTING_WARM
 
@@ -705,7 +705,7 @@
 
 /area/crew_quarters/heads/office/sgr
 	icon_state = "heads_sr"
-	name = "\improper Command - ImperiumR's Office"
+	name = "\improper Navigator's Sanctum"
 	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/heads/office/sea
@@ -1060,45 +1060,45 @@
 // Security
 
 /area/security/bo
-	name = "\improper Security - Brig Chief"
+	name = "\improper Dauntless - Security Office"
 	icon_state = "Warden"
 	req_access = list(access_restricted_command)
 
 /area/security/storage
-	name = "\improper Security - Equipment Storage"
+	name = "\improper Dauntless - Equipment Storage"
 	icon_state = "security"
 	req_access = list(access_restricted)
 
 /area/security/secure_storage
-	name = "\improper Security - Secure Storage"
+	name = "\improper Dauntless - Secure Storage"
 	icon_state = "security"
 	req_access = list(access_restricted_command)
 
 /area/security/armoury
-	name = "\improper Security - Armory"
+	name = "\improper Dauntless - Armory"
 	icon_state = "Warden"
 	req_access = list(access_restricted_command)
 
 /area/security/detectives_office
-	name = "\improper Security - Investigations Office"
+	name = "\improper Dauntless - Mortis Investigator's Office"
 	icon_state = "detective"
 	sound_env = MEDIUM_SOFTFLOOR
 	lighting_tone = AREA_LIGHTING_COOL
 
 /area/security/locker
-	name = "\improper Security - Locker Room"
+	name = "\improper Dauntless - Enforcer Barracks"
 	icon_state = "security"
 
 /area/security/evidence
-	name = "\improper Security - Evidence Storage"
+	name = "\improper Dauntless - Evidence Storage"
 	icon_state = "security"
 
 /area/security/processing
-	name = "\improper Security - Processing"
+	name = "\improper Dauntless - Processing"
 	icon_state = "security"
 
 /area/security/questioning
-	name = "\improper Security - Interview Room"
+	name = "\improper Dauntless - Interrogation"
 	icon_state = "security"
 
 /area/security/wing
@@ -1301,13 +1301,13 @@
 	name = "\improper Bridge Starboard Access Hallway"
 
 /area/bridge/meeting_room
-	name = "\improper Command Meeting Room"
+	name = "\improper Feast Hall"
 	icon_state = "bridge_meeting"
 	ambience = list()
 	sound_env = MEDIUM_SOFTFLOOR
 
 /area/bridge/disciplinary_board_room
-	name = "\improper Disciplinary Board Room"
+	name = "\improper Administratum Office"
 	sound_env = SMALL_ENCLOSED
 
 /area/bridge/disciplinary_board_room/deliberation


### PR DESCRIPTION
Engineering/alt storage units now produce mechanicus hazard suits instead of engineering hardsuits.

Added the random chaos daemon spawner, updated colonial item and engineering item spawners to include some grenades.

Fixed frag grenades having no icons. Edited det-times on grenades to be less and also reduced penalty for being clumsy on them as well.

Fixed random power cell spawner not having laspacks. Reduced med-spawner's amount of medicine.

Edited emergency closet icon to be unique.

Fixed ceramic/surgery tiles being blank.

Fixed SDTF reference to be Tau Empire now.

Fixed mechanicus hazard suit having no toggled hood.

Grenade launcher's can now fire frag grenades.

Touched up railgun code.

Redid wizard cash bag as not infinite since money is vastly more important, they now get 2000 scrip instead of infinite.

Added admin config fix per Oprime's request.

Massive edits to away-site maps, many still need much more work and there are many many more passes to be made on away-sites. This current pass deals with turfs, loot spawn and mob placement. Future passes will include restructuring, recoding and more thorough changes to their design.

Also included fixes to the Dauntless such as the rogue trader's throne, bridge airlocks and access requirements.

