### PR TITLE
Adds Ricochet and Armor Penetration for mechs

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -486,6 +486,35 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	return target
 
+// Simple proc to recursively get a turf away from a target. More accurate than get edge turf but could be more accurate if using map coordinates or vectors.
+/proc/get_turf_away_from_target_simple(atom/center, atom/target, distance)
+	if(!center || !target)
+		return FALSE
+	var/opposite_dir = turn(get_dir(center,target), 180)
+	var/looping_distance = distance
+	var/atom/current_turf = center
+	while(looping_distance)
+		current_turf = get_step(current_turf,opposite_dir)
+		opposite_dir = turn(get_dir(current_turf, target) , 180) // Get the new opposite relative to our new location
+		looping_distance--
+	return current_turf
+
+// More complex proc that uses basic trigonometry to get a turf away from target . Accurate
+// it gets the difference between the center and target x and y axis. If they are - or + is handled without hardcode
+// The ratios are divided by their total (x + y ) and then multiplied by distance x / (x+y) * distance
+// this value is added ontop of the center coordinates , giving us our "away" turf.
+/proc/get_turf_away_from_target_complex(atom/center, atom/target, distance)
+	var/list/distance_reports = list(center.x - target.x, center.y - target.y)
+	var/distance_total = abs(distance_reports[1]) + abs(distance_reports[2])
+	if(distance_reports[1])
+		distance_reports[1] = round(distance_reports[1] / distance_total * distance)
+	if(distance_reports[2])
+		distance_reports[2] = round(distance_reports[2] / distance_total * distance)
+	distance_reports[1] = center.x + distance_reports[1]
+	distance_reports[2] = center.y + distance_reports[2]
+	return locate(distance_reports[1], distance_reports[2], center.z)
+
+
 // returns turf relative to A in given direction at set range
 // result is bounded to map size
 // note range is non-pythagorean

--- a/code/modules/mechs/components/armour.dm
+++ b/code/modules/mechs/components/armour.dm
@@ -14,6 +14,7 @@
 		rad = ARMOR_RAD_THIRTY
 		)
 	origin_tech = list(TECH_MATERIAL = 1)
+	var/ricochet_chance = 5
 
 /obj/item/robot_parts/robot_component/armour/exosuit/radproof
 	name = "radiation-proof armour plating"
@@ -61,6 +62,7 @@
 		bio = ARMOR_BIO_SHIELDED
 		)
 	origin_tech = list(TECH_MATERIAL = 3)
+	ricochet_chance = 10
 
 /obj/item/robot_parts/robot_component/armour/exosuit/Initialize()
 	. = ..()

--- a/code/modules/mechs/components/armour.dm
+++ b/code/modules/mechs/components/armour.dm
@@ -15,6 +15,7 @@
 		)
 	origin_tech = list(TECH_MATERIAL = 1)
 	var/ricochet_chance = 5
+	var/armor_piercing_resistance = 30
 
 /obj/item/robot_parts/robot_component/armour/exosuit/radproof
 	name = "radiation-proof armour plating"

--- a/code/modules/mechs/mech_damage.dm
+++ b/code/modules/mechs/mech_damage.dm
@@ -86,16 +86,17 @@
 	switch(def_zone)
 		if(BP_HEAD , BP_CHEST, BP_MOUTH, BP_EYES)
 			if(LAZYLEN(pilots))
-				if(projectile.armor_penetration >= mech_armor.armor_piercing_resistance && prob((100 - (15-mech_armor.ricochet_chance)) && (hatch_closed)))
+				if(projectile.armor_penetration >= mech_armor.armor_piercing_resistance && prob((75+mech_armor) && (hatch_closed)))
 					return PROJECTILE_FORCE_MISS
 				visible_message(SPAN_WARNING("[projectile] penetrates through the cabin compartment of the [src]!"))
 				var/mob/living/pilot = pick(pilots)
 				return pilot.bullet_act(projectile, def_zone, used_weapon)
-		if(projectile.armor_penetration >= mech_armor.armor_piercing_resistance && prob(35-mech_armor.ricochet_chance))
-			var/obj/item/mech_component/target = zoneToComponent(def_zone)
-			target.take_component_damage(projectile.damage)
-			visible_message(SPAN_WARNING("[projectile] penetrates straight through the compartment of the [src]!"))
-			return PROJECTILE_FORCE_MISS //it hit straight through armor, bypassing it.
+
+	if(projectile.armor_penetration >= mech_armor.armor_piercing_resistance && prob(35-mech_armor.ricochet_chance))
+		var/obj/item/mech_component/target = zoneToComponent(def_zone)
+		target.take_component_damage(projectile.damage)
+		visible_message(SPAN_WARNING("[projectile] penetrates straight through the compartment of the [src]!"))
+		return PROJECTILE_FORCE_MISS //it hit straight through armor, bypassing it.
 	..()
 
 /mob/living/exosuit/get_armors_by_zone(def_zone, damage_type, damage_flags)

--- a/code/modules/mechs/mech_damage.dm
+++ b/code/modules/mechs/mech_damage.dm
@@ -66,14 +66,37 @@
 		return pilot.hitby(AM, TT)
 	. = ..()
 
-/mob/living/exosuit/bullet_act(obj/item/projectile/P, def_zone, used_weapon)
+/mob/living/exosuit/bullet_act(obj/item/projectile/projectile, def_zone, used_weapon)
 	if (status_flags & GODMODE)
 		return PROJECTILE_FORCE_MISS
+
+	var/obj/item/robot_parts/robot_component/armour/exosuit/mech_armor = body?.m_armour
+	if(prob(mech_armor.ricochet_chance))
+		playsound(src, pick(projectile.ricochet_sounds), 100, 1)
+		visible_message(SPAN_WARNING("[projectile] ricochets harmlessly off the [src]!"))
+		if(projectile.starting)
+			var/turf/sourceloc = get_turf_away_from_target_simple(src, projectile.starting, 6)
+			var/new_x = sourceloc.x + ( rand(2, 5) * (prob(50) ? -1 : 1 ))
+			var/new_y = sourceloc.y + ( rand(2, 5) * (prob(50) ? -1 : 1 ))
+			sourceloc = locate(new_x , new_y, sourceloc.z)
+			sourceloc.color = "#a92312"
+			projectile.redirect(new_x, new_y, get_turf(src), src)
+		return PROJECTILE_CONTINUE
+
 	switch(def_zone)
 		if(BP_HEAD , BP_CHEST, BP_MOUTH, BP_EYES)
-			if(LAZYLEN(pilots) && (!hatch_closed || !prob(body.pilot_coverage)))
+			if(LAZYLEN(pilots))
+				if(projectile.armor_penetration >= 30 && prob(5+mech_armor.ricochet_chance) && (hatch_closed))
+					return PROJECTILE_FORCE_MISS
+				visible_message(SPAN_WARNING("[projectile] penetrates through the cabin compartment of the [src]!"))
 				var/mob/living/pilot = pick(pilots)
-				return pilot.bullet_act(P, def_zone, used_weapon)
+				return pilot.bullet_act(projectile, def_zone, used_weapon)
+		else
+			if(projectile.armor_penetration >= 30 && prob(35-mech_armor.ricochet_chance))
+				var/obj/item/mech_component/target = zoneToComponent(def_zone)
+				target.take_component_damage(projectile.damage)
+				visible_message(SPAN_WARNING("[projectile] penetrates straight through the compartment of the [src]!"))
+				return PROJECTILE_FORCE_MISS //it hit straight through armor, bypassing it.
 	..()
 
 /mob/living/exosuit/get_armors_by_zone(def_zone, damage_type, damage_flags)

--- a/code/modules/mechs/mech_damage.dm
+++ b/code/modules/mechs/mech_damage.dm
@@ -86,17 +86,16 @@
 	switch(def_zone)
 		if(BP_HEAD , BP_CHEST, BP_MOUTH, BP_EYES)
 			if(LAZYLEN(pilots))
-				if(projectile.armor_penetration >= 30 && prob(5+mech_armor.ricochet_chance) && (hatch_closed))
+				if(projectile.armor_penetration >= mech_armor.armor_piercing_resistance && prob((100 - (15-mech_armor.ricochet_chance)) && (hatch_closed)))
 					return PROJECTILE_FORCE_MISS
 				visible_message(SPAN_WARNING("[projectile] penetrates through the cabin compartment of the [src]!"))
 				var/mob/living/pilot = pick(pilots)
 				return pilot.bullet_act(projectile, def_zone, used_weapon)
-		else
-			if(projectile.armor_penetration >= 30 && prob(35-mech_armor.ricochet_chance))
-				var/obj/item/mech_component/target = zoneToComponent(def_zone)
-				target.take_component_damage(projectile.damage)
-				visible_message(SPAN_WARNING("[projectile] penetrates straight through the compartment of the [src]!"))
-				return PROJECTILE_FORCE_MISS //it hit straight through armor, bypassing it.
+		if(projectile.armor_penetration >= mech_armor.armor_piercing_resistance && prob(35-mech_armor.ricochet_chance))
+			var/obj/item/mech_component/target = zoneToComponent(def_zone)
+			target.take_component_damage(projectile.damage)
+			visible_message(SPAN_WARNING("[projectile] penetrates straight through the compartment of the [src]!"))
+			return PROJECTILE_FORCE_MISS //it hit straight through armor, bypassing it.
 	..()
 
 /mob/living/exosuit/get_armors_by_zone(def_zone, damage_type, damage_flags)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.
Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

This PR adds ricochet and armor penetration mechanics to mechs!

This makes it so that, if your mech is hit with a projectile that has more than 30AP (KP, sniper, AMR, melta rounds), it has a low-medium chance to penetrate straight to mech components. (chances of hitting pilots are lower than normal other bodyparts  components)
Exosuit armor has a a low chance (increased with armor) to ricochet harmlessly any and all projectile.